### PR TITLE
Fix the build-tools command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
           background: true
       - run:
           name: Wait for site to be ready
-          command: sleep 20
+          command: sleep 5
       - run:
           name: Run Pa11y tests
           command: make test

--- a/_tutorials/manual-build.md
+++ b/_tutorials/manual-build.md
@@ -172,7 +172,7 @@ We want to compile our source code (which we don't have yet) into a public folde
 - `--watch` is a flag that will trigger a rebuild when we make changes to our project.
 
 Altogether, the command looks like this:
-<pre class="o-layout__main__full-span"><code class="o-syntax-highlight--bash">npx origami-build-tools build --build-folder="./public/" --sass="./src/main.scss" --js="./src/main.js" --watch</code></pre>
+<pre class="o-layout__main__full-span"><code class="o-syntax-highlight--bash">npx origami-build-tools build --build-folder="public" --sass="./src/main.scss" --js="./src/main.js" --watch</code></pre>
 
 You can leave that running in the background, and open your `index.html` in a browser to see the styling changes we'll be making in the next step.
 


### PR DESCRIPTION
The `build-folder` flag is only ignored by the watcher
when it doesn't include the `./` for some reason. I'll
investigate this separately, but for now this fixes
the tutorial.