### PR TITLE
Add branding to the spec.

### DIFF
--- a/_components/branding.md
+++ b/_components/branding.md
@@ -18,7 +18,7 @@ Origami components may be branded to provide a distinct appearance within differ
 Origami maintained brands include:
 - master: FT branding for public ft.com sites and affiliates.
 - internal: Style suitable for internal products, tools, and documentation.
-- whitelabel: Base, structural styles only to build on (experimental).
+- whitelabel: Base, structural styles only to build on and customise.
 
 ## An example component
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@
 
 </head>
 <body>
-	<div class="o-layout {% if layout.o_layout_type %}o-layout--{{layout.o_layout_type}}{% else %}o-layout--docs{% endif %}" data-o-component="o-layout" data-o-layout-nav-heading-selector="h2">
+	<div class="o-layout {% if layout.o_layout_type %}o-layout--{{layout.o_layout_type}}{% else %}o-layout--docs{% endif %}" data-o-component="o-layout" data-o-layout-nav-heading-selector="{% if page.nav_heading_selector %}{{page.nav_heading_selector}}{% else %}h2{% endif %}">
 		<div class="o-layout__header">
 			{% include header.html %}
 		</div>

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -95,7 +95,7 @@ Defines the type of Origami component that the manifest belongs to. **Must** be 
 	</tr>
 </table>
 
-For components which support [brands](/docs/components/branding/), this should be an array of one or more brands: "master", "internal, "whitelabel".
+For components which support [brands](/docs/components/branding/), this **must** an array of one or more brands: "master", "internal, "whitelabel".
 
 ### keywords
 

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -10,6 +10,7 @@ redirect_from:
 # Navigation config
 nav_display: true
 nav_label: Manifest
+nav_heading_selector: h2, h3
 nav_order: 25
 ---
 
@@ -80,6 +81,21 @@ Defines the type of Origami component that the manifest belongs to. **Must** be 
 <pre><code class="o-syntax-highlight--json">{
 	"origamiVersion": 1
 }</code></pre>
+
+### brands
+
+<table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
+	<tr>
+		<th scope="row" role="rowheader">Type</th>
+		<td><code>Array</code></td>
+	</tr>
+	<tr>
+		<th scope="row" role="rowheader">Required</th>
+		<td><code>false</code></td>
+	</tr>
+</table>
+
+For components which support [brands](/docs/components/branding/), this should be an array of one or more brands: "master", "internal, "whitelabel".
 
 ### keywords
 
@@ -334,6 +350,7 @@ Each object in the list accepts the following properties:
 - `sass`: type `String`. Describes the path to the demo-specific Sass file to compile.
 - `js`: type `String`. Describes the path to the demo-specific JS file to build.
 - `data`: type `Object`. Describes to populate to the component-specific mustache template with
+- `brands`: type `Array`. For components which support [brands](/docs/components/branding/), this describes one or more brands which the demo applies to ("master", "internal, "whitelabel")
 - `documentClasses`: type `Object`. Names CSS classes to set on the component-specific `html` tag
 - `dependencies`: type `Array`. Is a list of other components that are only needed a this specific demo, which will be loaded via the <a href="https://www.ft.com/__origami/service/build" class="o-typography-link--external">Build Service</a>
 - `hidden`: type `Boolean`. Whether the demo should be hidden in the Registry
@@ -351,7 +368,8 @@ Each object in the list accepts the following properties:
 			"description": "Striped table implementation",
 			"template": "demos/src/striped-table.mustache",
 			"sass": "demos/src/striped-table.scss",
-			"documentClasses": "demo-striped-table-container"
+			"documentClasses": "demo-striped-table-container",
+			"brands": ["master", "internal"]
 		},
 		{
 			"name": "pa11y",

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -138,6 +138,48 @@ To support silent mode, components **must** include a public, silent mode variab
 
 This prevents the accidental output of styles if the component is included twice in the same product. For example, given component A and component B both include a dependency of component C.
 
+## Branding
+
+Origami components are used by products across the Financial Times Group. Some of these products or product groups require a distinct appearence or feature. To cater for these usecases Origami components **may** change their appearence by supporting one or more of the following brands:
+
+- master: FT branding for public ft.com sites and affiliates.
+- internal: Style suitable for internal products, tools, and documentation.
+- whitelabel: Base, structural styles only to build on and customise.
+
+A brand may be thought of as a theme, in that it uses Sass to change the appearence of a component. But it may also provide unique features with brand specifc Sass. For an example see our [component brand documentation](/docs/components/branding/).
+
+A project chooses a brand by [setting the brand variable](/docs/components/branding/#configure-your-projects-brand), which effects all Origami components included by that project. If no brand is chosen the master brand is used by default.
+
+### Register Supported Brands
+
+If a component supports brands, it **must** register the brands it supports under the `brands` property in its [`origami.json`](/spec/v1/manifest/) file.
+E.g. to support all three Origami brands add:
+
+```json
+"brands" : [
+    "master",
+    "internal",
+    "whitelabel"
+],
+```
+
+### Create A Brand Sass File
+
+All functions and mixins which delegate to the `o-brand` component, and brand configuration, **should** be placed in the component's `src/scss/_brand.scss` file.
+
+### Include The oBrand Component
+
+Components which support brands **must** include the [o-brand](https://registry.origami.ft.com/components/o-brand/readme) component as a dependency, which provides functions and mixins to customise a component per brand.
+
+The `o-brand` component **must not** be used directly by projects, it is intended for use within other Origami components. To provide a public interface for brand mixins like `oBrandCustomize`, create a component specifc mixin which delegates to it. E.g. For a component `o-example`:
+```scss
+@mixin oExampleCustomize($variables) {
+	@include oBrandCustomize($component: 'o-example', $variables);
+}
+```
+
+See the [o-brand README](https://registry.origami.ft.com/components/o-brand/readme) to learn how to add brand support to a component.
+
 ## Feature Flags
 
 To support a [core and enhanced experience](/docs/components/compatibility/#core--enhanced-experiences) components must render acceptably without JavaScript avalible. Styles which only apply if JavaScript is avalible **must** be applied with a feature detect such as `.o--if-js`, and to hide an element of a component when JavaScript is avalible use `o--if-no-js`. If the component provides its own JavaScript feature flag, it **must** be named `.o-componentname--js`.

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -148,7 +148,7 @@ Origami components are used by products across the Financial Times Group. Some o
 
 A brand may be thought of as a theme, in that it uses Sass to change the appearence of a component. But it may also provide unique features with brand specifc Sass. For an example see our [component brand documentation](/docs/components/branding/).
 
-A project chooses a brand by [setting the brand variable](/docs/components/branding/#configure-your-projects-brand), which effects all Origami components included by that project. If no brand is chosen the master brand is used by default.
+A project chooses a brand by [setting the brand variable](/docs/components/branding/#configure-your-projects-brand), which affects all Origami components included by that project. If no brand is chosen the master brand is used by default.
 
 ### Register Supported Brands
 

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -171,7 +171,7 @@ All functions and mixins which delegate to the `o-brand` component, and brand co
 
 Components which support brands **must** include the [o-brand](https://registry.origami.ft.com/components/o-brand/readme) component as a dependency, which provides functions and mixins to customise a component per brand.
 
-The `o-brand` component **must not** be used directly by projects, it is intended for use within other Origami components. To provide a public interface for brand mixins like `oBrandCustomize`, create a component specifc mixin which delegates to it. E.g. For a component `o-example`:
+The `o-brand` component **must not** be used directly by projects, it is intended for use within other Origami components. To provide a public interface for brand mixins like `oBrandCustomize`, create a component specific mixin which delegates to it. E.g. For a component `o-example`:
 ```scss
 @mixin oExampleCustomize($variables) {
 	@include oBrandCustomize($component: 'o-example', $variables);


### PR DESCRIPTION
- Add brand requirements to the component spec. Link to the
`o-brand` readme for specifcs on implementation.
- Add brand to the manifest spec.
- Show `h3`s in the in-page-nav for the manifest page.

Goes hand in hand with this PR: https://github.com/Financial-Times/o-brand/pull/38