### PR TITLE
Add `checkout` step to autocommit task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ commands:
 
   autocommit:
     steps:
+      - checkout
       - run:
           name: Fetch component changes
           command: make fetch-component-data


### PR DESCRIPTION
i think? this will mean the makefile is there when the task runs, so that failing step should work now?