### PR TITLE
Add a design section to the home page

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -36,22 +36,25 @@ nav_order: 1
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Get Started</h2>
-			<p>To jump straight in and include Origami components in your project, see our <a href="/docs/tutorials/">tutorials page</a>.</p>
-			<p>If you would like to learn about Origami components in more detail see our <a href="/docs/components/">component documentation</a>.</p>
-			<p>For an overview of all the tools and services we offer see our <a href="/docs/">documentation page</a>.</p>
+			<h2>Designers</h2>
+			<p>
+				You can browse <a href="https://registry.origami.ft.com/components">live demos of our components in the registry</a>.
+			</p>
+			<p>
+				The UX and Design team maintain a Sketch UI kit to help you
+				design and prototype quickly in line with the FT brand:
+			</p>
+			<ul>
+				<li><a href="https://sketch.cloud/s/4kg5D">Add the library to Sketch</a></li>
+				<li><a href="https://sketch.cloud/s/152ww">Download the UI grid and breakpoints</a></li>
+			</ul>
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Contribute</h2>
-			<p>
-				We're happy to accept contributions and suggestions. We use GitHub issues and maintain a specification to
-				help engineers contribute.
-			</p>
-			<ul>
-				<li><a href="https://github.com/Financial-Times/origami-proposals#readme">Propose a new component</a></li>
-				<li><a href="/spec/">Read the Origami specification</a></li>
-			</ul>
+			<h2>Developers</h2>
+			<p>To jump straight in and include Origami components in your project, see our <a href="/docs/tutorials/">tutorials page</a>.</p>
+			<p>If you would like to learn about Origami components in more detail see our <a href="/docs/components/">component documentation</a>.</p>
+			<p>For an overview of all the tools and services we offer see our <a href="/docs/">documentation page</a>.</p>
 		</div>
 
 		<div class="o-layout-item">
@@ -61,6 +64,7 @@ nav_order: 1
 				if you have questions or feedback for the Origami team &#x1F603;
 			</p>
 			<ul>
+				<li><a href="https://github.com/Financial-Times/origami-proposals#readme">Propose a new component</a></li>
 				<li><a href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}" class="o-typography-link--external" target="_blank">Find us on Slack in #{{site.data.contact.slack}}</a></li>
 				<li><a href="mailto:{{site.data.contact.email}}" class="o-typography-link--external">Email us</a></li>
 			</ul>


### PR DESCRIPTION
This now links out to design resources, and I've condensed the developer
content and moves some into contact.