### PR TITLE
Make spec changes to reflect living components

### DIFF
--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -126,9 +126,11 @@ Expects keywords related to the component to help discover it in the registry. T
 	</tr>
 	<tr>
 		<th scope="row" role="rowheader">Required</th>
-		<td><code>true</code></td>
+		<td><code>true*</code></td>
 	</tr>
 </table>
+
+*Applies to `{ "origamiType": "module" }` only.
 
 Describes the organisational category the component belongs to. **Must** be one of:
 - `components`

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -111,7 +111,7 @@ For components which support [brands](/docs/components/branding/), this **must**
 	</tr>
 </table>
 
-Expects keywords related to the component to help discover it in the registry. These **should** be stored as an array.
+Expects keywords related to the component to help discover it in the registry. These **should** be stored as an array. These **may** be stored as a comma-separated string.
 
 <pre><code class="o-syntax-highlight--json">{
 	"keywords": ["table", "rows", "columns"]

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -43,18 +43,19 @@ nav_order: 25
 <table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
 	<tr>
 		<th scope="row" role="rowheader">Type</th>
-		<td><code>String</code></td>
+		<td><code>String</code> or <code>null</null></td>
 	</tr>
 	<tr>
 		<th scope="row" role="rowheader">Required</th>
-		<td><code>true</code></td>
+		<td><code>true/code></td>
 	</tr>
 </table>
 
 Defines the type of Origami component that the manifest belongs to. **Must** be set to one of:
-- `module`
-- `imageset`
-- `service`
+- `"module"`: A front-end component that follows [the component specification](/spec/v1/components/)
+- `"imageset"`: A set of images that have an alias on the Origami Image Service
+- `"service"`: An HTTP service that follows [the service specification](/spec/v1/services/)
+- `null`: An Origami component that does not fit any of the named categories
 
 <aside>
 	The <code>type</code> of <code>"module"</code> is a hangover from when client-side Origami components were named "modules". It's likely to change in a later version of the spec.


### PR DESCRIPTION
* Allow the value `null` for `origamiType`
* Make `origamiCategory` only apply to `origamiType: module`
* Add a **may** for the common use of keywords as a string