### PR TITLE
Proposals in the repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contributing Guide
 
 There are several ways to contribute to this proposal process:
@@ -35,12 +34,17 @@ Anybody can propose a new component or pattern for inclusion in Origami. This ca
 
   3. ### Raise an Issue
 
-     If your idea is not already proposed in the backlog, please [raise an issue] on this repository and follow the provided template. The more detail you include the better. We prefer you to open an issue yourself, but if you don't have a GitHub account then you can also [email a proposal to the team](mailto:origami.support@ft.com?subject=Component%20Proposal). If you're doing this then please [follow the issue template][issue template].
+     If your idea is not already proposed in the backlog, please [create a new proposal PR](#creating-a-proposal-pr). Alternatively, you can [raise a component or proposal issue] on this repository and follow the provided template. The more detail you include the better. If you don't have a GitHub account then you can also [email a proposal to the team](mailto:origami.support@ft.com?subject=Proposal).
 
   4. ### Request Feedback
 
-     Once you've got a proposal, request feedback from the Origami team and feel free to share it to relevant stakeholders in the business – they may have something to add, and more evidence is always good. You can contact the Origami team via [email](mailto:origami.support@ft.com?subject=Component%20Proposal) or [Slack], alternatively assign the Origami Core GitHub team to the issue.
+     Once you've got a proposal, request feedback from the Origami team and feel free to share it to relevant stakeholders in the business – they may have something to add, and more evidence is always good. You can contact the Origami team via [email](mailto:origami.support@ft.com?subject=Proposal) or [Slack], alternatively assign the Origami Core GitHub team to the issue.
 
+### Creating a proposal PR
+
+1. Copy `proposals/0000-template.md` to `proposals/0000-my-new-proposal-title.md`
+2. Edit your new file, filling in the sections of the template appropriately
+3. File a pull request and add the `proposal` label, as well as the `component` or `pattern` label if applicable.
 
 ## Review a Proposal
 
@@ -66,5 +70,5 @@ This section is for members of the Origami team, and acts as a guide for reviewi
 [issue template]: https://github.com/Financial-Times/origami/blob/master/.github/ISSUE_TEMPLATE.md
 [origami registry]: https://registry.origami.ft.com/
 [proposal backlog]: https://github.com/Financial-Times/origami/projects/1
-[raise an issue]: https://github.com/Financial-Times/origami/issues/new
+[raise a component or proposal issue]: https://github.com/Financial-Times/origami-proposals/issues/new
 [slack]: https://financialtimes.slack.com/messages/origami-support

--- a/proposals/accepted/0000-template.md
+++ b/proposals/accepted/0000-template.md
@@ -1,0 +1,40 @@
+# put your proposal title here
+
+> Provide a brief one line summary of your proposal.
+
+## motivation
+
+> Explain why you think Origami should accept the proposal.
+>
+> e.g. When proposing a new component:
+> - What evidence do you have that it's needed by multiple teams across the FT?
+> - What evidence do you have that it meets the needs of the users of those teams?
+>
+> This section is required
+
+## explanation
+
+> Provide a detailed explanation of your proposal
+> This section is required
+
+## work required
+
+> Add here steps required to make your proposal a reality
+> Provide links to the code that would need to change if relevant
+> This section isn't required to open a proposal, but is required before a proposal can be accepted
+
+## alternatives
+
+> Provide some alternatives to your proposal and their benefits and drawbacks
+> This section is required
+
+## supporting examples
+
+> Include links to prior art, examples, research, or code to support your proposal, if any is available.
+> If this is a component proposal, it's also useful to have links to designs if there are any.
+> This section is required
+
+## notes
+
+> Add notes about unresolved questions or other things that don't fit well into the sections above
+> This section is optional

--- a/proposals/accepted/0060-proposals-in-repo.md
+++ b/proposals/accepted/0060-proposals-in-repo.md
@@ -1,0 +1,47 @@
+# Proposals in the repo
+
+> Let's keep our proposals in the `origami` repository!
+
+## motivation
+
+Our proposal process currently uses issues.
+
+These are great! Except, there is no distinction in path between an accepted proposal and a rejected proposal. Either way, the issue gets closed.
+
+We also don't have a good history of the changes that were made, and we don't have good documentation on what happened after the proposal was accepted.
+
+## explanation
+
+Instead of writing proposals up as an issue, let's write them up as a pull request adding a markdown file to a directory called "proposals/accepted" so we can have a satisfying way of saying "Yes" or "No" to a proposal.
+
+We can also move proposals to a `proposals/complete` folder when they are done, adding a note about how the proposal was implemented. Which will be great for documenting what happened after the proposal was accepted.
+
+### benefits
+
+* Easier to see on what we've accepted and are working on!
+* Documentation on what what we've done and how we did it.
+* Use your own text editor to make the proposal!
+
+### drawbacks
+
+* Maybe it's less easy to create a proposal from outside the team (have to clone the repo, or copy-and-paste template)
+
+## work required
+
+1. Update the [contribution guide](https://github.com/Financial-Times/origami/blob/master/.github/CONTRIBUTING.md)
+2. Create a [proposal template](./0000-template.md)
+3. _optional:_ convert old proposals to files in the repo
+
+## alternatives
+
+### nothing
+
+Keep what we have
+
+### action
+
+We could keep the issue mechanism around and have an action to automatically create the file in the repo of an accepted issue. we could comment `@origamiserviceuser this is accepted` or something
+
+## supporting examples
+
+There is a similar process in the `rfcs` repos of [the npm project](https://github.com/npm/rfcs) and [rustlang](https://github.com/rust-lang/rfcs/#what-the-process-is)


### PR DESCRIPTION
rendered proposal: https://github.com/Financial-Times/origami/blob/13fd5401cc527df9e8a2e35ed5730163cd798ed8/proposals/accepted/0060-proposals-in-repo.md

i've made it 0060 as that was the previous issue's id #60, and that way we can migrate old issues to this format like this