### PR TITLE
Component demos & docs proposals

### DIFF
--- a/proposals/accepted/0000-component-docs-as-static-site.md
+++ b/proposals/accepted/0000-component-docs-as-static-site.md
@@ -1,0 +1,57 @@
+# Origami component docs as a static site
+
+We remove the demos config from the manifest spec. Documentation, shown in in
+the registry, is any static site present in the `docs` directory after running
+`npm run build`.
+
+## motivation
+
+At the moment our component docs are split between the README.md (which people
+see on the github) and a series of demos defined in the `origami.json` file. The
+demo config is complex, hard to write and parse. It's both too strict, and too
+loose. It contains cruft (like `display_html`) that's built up over the years of
+use, and we can do a better job now.
+
+Neither the demos or the readme are a great way to write more holistically about
+the component, about accessibility and design decisions that went into the component.
+
+If we know docs will be built once `npm run build` is run, then we can remove
+logic around generating the docs from the registry.
+
+## explanation
+
+The spec states only this about docs:
+
+- the readme.md must link to registry/component/docs
+- component documentation, including demos of the component in many states with
+  accompanying prose, must exist as a static site in the `docs` directory after
+  `npm run build` has been issued
+- if your component supports brands, the build command should take into account
+  the `ORIGAMI_BRAND` environment variable and build accordingly
+- a live-reloading dev server must/should run when `npm start` is issued within
+  the component's repository
+
+## work required
+
+- remove the demo config from the v2 manifest spec
+- when migrating cmoponents to v2, create documentation for them
+
+## alternatives
+
+### do nothing
+
+keep our demos as they are. keep our docs spread across readme and demos.
+
+### convention over configuration
+
+A convention-over-configuration system for docs. A more strict system defining
+how docs should be formed. [See here](./0000-component-docs-convention-over-configuration.md)
+
+## notes
+
+- a previous version of this proposal suggested the docs should be built
+  in the published npm module. This is fine, but it makes it more difficult to
+  define how branding should work. Currently in the registry, branding is
+  selected via a query string. Instead of having them prebuilt i'm suggesting
+  that the component is built by the registry and we cache the result. This does
+  open us up to code execution exploits however. This probably needs more work.

--- a/proposals/accepted/0000-component-docs-convention-over-configuration.md
+++ b/proposals/accepted/0000-component-docs-convention-over-configuration.md
@@ -1,0 +1,82 @@
+# Origami component docs (convention over configuration)
+
+We remove the demos configuration from the manifest spec. Documentation is built
+the same way for every component from a strict and specified directory structure
+in a new `docs` directory.
+
+## motivation
+
+At the moment our component docs are split between the README.md (which people
+see on the github) and a series of demos defined in the `origami.json` file. The
+demo config is complex, hard to write and parse. It's both too strict, and too
+loose. It contains cruft (like `display_html`) that's built up over the years of
+use, and we can do a better job now.
+
+Neither the demos or the readme are a great way to write more holistically about
+the component, about accessibility and design decisions that went into the component.
+
+Having a single way for docs to be produced means anyone coming into any Origami
+component who has seen another, knows how to view and make demos. It also means
+less logic required to build the docs.
+
+## explanation
+
+The docs directory looks like this:
+
+```
+o-table/
+└── docs
+	├── basic-table
+	│   ├── index.html
+	│   ├── readme.md
+	│   ├── script.js
+	│   └── style.sass
+	├── monkey-table
+	│   ├── index.html
+	│   ├── readme.md
+	│   ├── script.js
+	│   └── style.sass
+	├── readme.md
+	└── sortable-table
+		├── index.html
+		├── readme.md
+		├── script.js
+		└── style.sass
+```
+
+The main readme.md file contains general documentation about the component (of
+the kind that used to be in the component's main README.md). Laced under that
+are is the content of each of the subdirectory's READMEs, with the demo they are
+documenting displayed in a codepen-like box with an o-tab for each of the
+`index.html`, `script.js`, `style.sass` and output.
+
+It's recursive, so if inside `monkey-table` you have more directories containing
+`index.html`, `script.js`, `style.sass` and `readme.md` then those will be
+weaved in under the `monkey-table` section.
+
+The navigation in the registry for that component can be generated for these
+components, and we can create a tool that generates the static site based on
+this directory structure.
+
+## work required
+
+- remove the demo configuration from the v2 manifest spec
+- add a specification for this demo structure
+- when migrating components to v2, create documentation in this directory structure
+- create a tool for building a static site from this directory structure
+
+## alternatives
+
+### do nothing
+
+keep our demos as they are. keep our docs spread across readme and demos.
+
+### static site
+
+Do not specify this format, but instead allow for any site that is built to the
+`docs` directory to be served. [See here](./0000-component-docs-as-static-site.md)
+
+## notes
+
+- each demo should possibly be an individual node module, and list the
+  dependencies in their own `package.json`

--- a/proposals/accepted/0000-demos-as-isolated-node-modules.md
+++ b/proposals/accepted/0000-demos-as-isolated-node-modules.md
@@ -168,10 +168,12 @@ demos still.
 
 ### other proposals
 
-These abandoned proposals:
+These abandoned proposals when demos and docs where conflated.
 
-https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-as-static-site.md
-https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-convention-over-configuration.md
+- [https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-as-static-site.md](component
+  docs as static site)
+- [https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-convention-over-configuration.md](component
+  docs convention over configuration)
 
 ## notes
 

--- a/proposals/accepted/0000-demos-as-isolated-node-modules.md
+++ b/proposals/accepted/0000-demos-as-isolated-node-modules.md
@@ -170,10 +170,8 @@ demos still.
 
 These abandoned proposals when demos and docs where conflated.
 
-- [https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-as-static-site.md](component
-  docs as static site)
-- [https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-convention-over-configuration.md](component
-  docs convention over configuration)
+- [component docs as static site](https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-as-static-site.md)
+- [component docs convention over configuration](https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-convention-over-configuration.md)
 
 ## notes
 

--- a/proposals/accepted/0000-demos-as-isolated-node-modules.md
+++ b/proposals/accepted/0000-demos-as-isolated-node-modules.md
@@ -1,0 +1,146 @@
+# Demos as isolated node modules
+
+We remove the demos config from the manifest spec. Demos are isolated node
+modules that list the containing component as a dependency in the
+`package.json`.
+
+Demos no longer serve as documentation, and are no longer used for utilities
+like the o-colors contrast checker. Demos are primarily for use when working on
+a component, and for testing in CI.
+
+## motivation
+
+Our demos currently serve 3 purposes:
+1. Demos -- for development and CI testing
+2. Utilities -- like the o-colors contrast checker
+3. User facing documentation -- they are displayed prominently in the registry
+
+The demos array in the origami.json is both too strict and too loose. It's
+difficult to parse, and difficult to lint. The `display_html` boolean is a way
+of indicating that a demo is not, in fact, a demo. It's grown naturally over the
+years, and we have a chance to do a better job now.
+
+If we focus demos only on being demos, and take a different approach for our
+utilities and user-facing docs, we can reduce the stuff we have to parse dramatically.
+
+## explanation
+
+We remove the origami manifest's demo configuration, and replace it with
+conventions.
+
+A demo is a directory that looks like this:
+
+```
+└── my-big-fish-demo
+	├── index.md
+	├── package.json
+	├── script.js
+	└── style.scss
+```
+
+The `index.md` is the entry point. It contains a top-level heading, a 1 line
+description and an html code block.
+
+We replace the demo properties in the origami.json as follows:
+
+| property        | purpose                               | replacement                           |
+|-----------------|---------------------------------------|---------------------------------------|
+| name            | output file name                      | n/a, path is path is on disk          |
+| title           | title for the demo in the registry    | top-level heading in index.md         |
+| description     | demo description in registry          | content between h1 and codeblock      |
+| template        | path to mustache                      | the html codeblock in index.md        |
+| sass            | path to sass                          | always style.scss                     |
+| js              | path to js                            | always script.js                      |
+| data            | data to pass to the mustache template | n/a, hardcode values in demo          |
+| brands          | supported brands                      | `origamiBrands` field in package.json |
+| documentClasses | classes to set on html root el        | a wrapper element in html codeblock   |
+| dependencies    | dependencies                          | dependencies in package.json          |
+| hidden          | hide demo in registry                 | n/a, show all demos in registry       |
+| display_html    | hide demo's html tab in registry      | n/a, utilities should be elsewhere    |
+
+We create a tool that can build and serve these demos.
+
+## work required
+
+### 1. Specification changes
+
+Remove the manifest specification's demo config, and add a `demos` section to
+the component specification explaining the conventions.
+
+### 2. Component work
+
+Rewrite the current demos to work in this style. Move utility demos out of the
+current demos directory.
+
+### 3. Tooling
+
+Build a tool that can be run in the component's root that has the following
+usage:
+
+```
+usage: odc [-h] {build,watch,serve,lint} ...
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+commands:
+  valid commands
+
+  {build,watch,serve,lint}
+	build               build demos
+	watch               build demos on every change
+	serve               start a live-reloading demo server that builds on every change
+	lint                lint the demo index.md
+```
+
+Each command takes a single optional position argument of `pattern`, and it will
+only run demos matching that pattern.
+
+#### build
+
+This builds the index.md, style.scss and script.js into
+`demos/particular-demo/public/`
+
+#### watch
+
+This performs build, and starts up a filesystem watcher that builds
+the code again on every change.
+
+#### serve
+
+This performs build and starts a local http server that serves an index of all
+the demos, and each demo is served on `localhost:port/demo-path`.
+
+It starts up a filesystem watcher that builds the code on every change, and
+reloads the user's browser on every build.
+
+#### lint
+
+This lints the demos index.md files to ensure it will work with the rest of the
+tool.
+
+## alternatives
+
+### do nothing
+
+leave our demos as they are, and start working on the new documentation
+separately. this will save time in the short term, but i think we want to rework
+demos still.
+
+### other proposals
+
+These abandoned proposals:
+
+https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-as-static-site.md
+https://github.com/Financial-Times/origami/blob/5b52d7ba831ccbfc17a7babb7b83c83bd8694d90/proposals/accepted/0000-component-docs-convention-over-configuration.md
+
+## notes
+
+- We discussed allowing demos to be anything that is built to public/index.html
+  when a demo module's `npm run build` command is issued. This is fine, but it
+  does mean we'd be running any program they had in `npm run build` in our
+  registry server which opens us up for destructive errors.
+- We discussed requiring demos to be published prebuilt. This is fine too, and
+  would allow us to do the above. But it allows for a published artifact to
+  differ from the source in a way that might be confusing? Though it would mean
+  we'd no longer be running the code on the server which might well be good.

--- a/proposals/accepted/0000-demos-as-isolated-node-modules.md
+++ b/proposals/accepted/0000-demos-as-isolated-node-modules.md
@@ -91,6 +91,7 @@ commands:
 	watch               build demos on every change
 	serve               start a live-reloading demo server that builds on every change
 	lint                lint the demo index.md
+	create              create a new demo
 ```
 
 Each command takes a single optional position argument of `pattern`, and it will
@@ -118,6 +119,43 @@ reloads the user's browser on every build.
 
 This lints the demos index.md files to ensure it will work with the rest of the
 tool.
+
+### create
+
+This takes a positional argument of `name`.
+
+Options are:
+
+| -d | --description | set the description                                         |
+| -b | --brands      | the supported brands for this demo (default: all supported) |
+
+
+It slugifies the name to use as the demo path and creates `package.json` that
+includes a dependency of `component-name@file:../..`, a name, description,
+version and `origamiBrands` array.
+
+It creates an `index.md` containing the following:
+
+~~~md
+# {{title}}
+
+{{description || "enter a description for your demo here"}}
+
+```html
+```
+~~~
+
+a `script.js` containing the following:
+
+~~~js
+import {{component-name-without-prefix}} from ("{{component-name}}")
+~~~
+
+and a `style.scss` containing the following:
+
+~~~scss
+import "{{component-name}}"
+~~~
 
 ## alternatives
 

--- a/proposals/accepted/0000-demos-as-isolated-node-modules.md
+++ b/proposals/accepted/0000-demos-as-isolated-node-modules.md
@@ -126,9 +126,10 @@ This takes a positional argument of `name`.
 
 Options are:
 
-| -d | --description | set the description                                         |
-| -b | --brands      | the supported brands for this demo (default: all supported) |
-
+| shortopt | longopt       | meaning                                                     |
+|----------|---------------|-------------------------------------------------------------|
+| -d       | --description | set the description                                         |
+| -b       | --brands      | the supported brands for this demo (default: all supported) |
 
 It slugifies the name to use as the demo path and creates `package.json` that
 includes a dependency of `component-name@file:../..`, a name, description,


### PR DESCRIPTION
**EDIT**: new proposal, you may ignore the other two for now!

here is the new proposal: https://github.com/Financial-Times/origami/blob/component-demos/proposals/accepted/0000-demos-as-isolated-node-modules.md

i will be writing a separate docs proposal next.



---


_outdated pr description:_


Here are two proposals.

1. Component docs as a static site ([rendered markdown](https://github.com/Financial-Times/origami/blob/component-demos/proposals/accepted/0000-component-docs-as-static-site.md))
2. Component docs (convention over configuration) ([rendered markdown](https://github.com/Financial-Times/origami/blob/component-demos/proposals/accepted/0000-component-docs-convention-over-configuration.md))

i'm not sure if i like either of them, now that i've typed them up. i might just be exhausted, but wouldn't it be good if we could have docs like this: https://design-system.service.gov.uk/components/ or this: https://rizzo.lonelyplanet.com?

We can't because Origami, in its current form, exists to solve a technical problem. Not a design problem. It's a component system, not a design system. 

If we had all our components in a single repository, we would replace the registry with documentation. We'd need a separate page where we list our services (unless we put them in same repo too). What if we did that? And started treating Origami as a single project?

Everyone should be committing to one open source repository that Design and Origami are Admins of but that everyone in the company has write access to

We should have holistic documentation about how everything works together. About the wider design decisions that make up Origami, about accessibility

in its present form, with everything in separate repos, every component containing its own documentation etc etc, it is solving a technical problem.

it is a component system, not a design system, it's a way of building components so they can be distributed by our services

right now i can make a component that is lime green with pink text and it just says the word "HAMBURGER" and it flashes on and off `<blink>HAMBURGER, HAMBURGER</blink>`, and i can put an origami.json in the directory, and it will appear in the registry, and i can use the build service.

that doesn't help with design, it doesn't help anyone