### PR TITLE
add proposal for renaming the team

### DIFF
--- a/proposals/accepted/0000-rename-the-team.md
+++ b/proposals/accepted/0000-rename-the-team.md
@@ -1,0 +1,34 @@
+# Rename the Origami team
+
+The name for the team is the same name as the project and this can cause confusion about when talking about either one.
+Having the same name for both could also make people think that they shouldn't contribute to an Origami codebase.
+
+## motivation
+
+We want everyone to feel they can contribute to Origami projects and we want to remove the confusion between the team and the projects when someone mentions Origami.
+
+## explanation
+
+Let's rename the team to something which shows that the team members are the stewards of the Origami project and that anyone can contribute to Origami.
+
+## work required
+
+- Come up with a name which makes it simpler to understand that someone is talking about either the Origami team or the Origami project
+- Update documentation and contact pages to use the new team name
+- Maybe create a new mailing list which uses the new team name rather than `origami.support`
+
+## alternatives
+
+Do nothing and keep the potential confusion when someone talks about Origami (the team) or Origami (the project).
+
+## supporting examples
+
+Vue and the [Vue Core team](https://vuejs.org/v2/guide/team.html)
+NodeJS and the NodeJS Technical Steering Committee?
+
+## counter examples
+
+React and the [React team](https://reactjs.org/community/team.html) -- (In conversations and in Twitter Bios they do state [React Core](https://twitter.com/acdlite))
+GOV.UK Design System and the [GOV.UK Design System team ](https://design-system.service.gov.uk/get-in-touch/)
+
+## notes


### PR DESCRIPTION
Currently name for the team is the same name as the project and this can cause confusion about when talking about Origami.

Having the same name for both could also make people think that they shouldn't contribute to an Origami codebase.