### PR TITLE
Make our whitelabel components easier to theme for build service users

### DIFF
--- a/proposals/accepted/0000-make-our-whitelabel-components-easier-to-theme-for-build-service-users.md
+++ b/proposals/accepted/0000-make-our-whitelabel-components-easier-to-theme-for-build-service-users.md
@@ -1,0 +1,9 @@
+# Make our whitelabel components easier to theme for build service users
+## What
+Look into using CSS variables or some similar browser-based technology which allows our components CSS to be customised.
+
+## Why
+We currently don't have a way to customise the whitelabel components for user s who are consuming them via the build service.
+
+## Supporting Examples
+o-meter already does this because we decided that the fallback for IE 11 would be text based instead, which meant we could use CSS variables to customise the component.


### PR DESCRIPTION
From #58.

see [rendered proposal](https://github.com/Financial-Times/origami/blob/proposals/make-our-whitelabel-components-easier-to-theme-for-build-service-users/proposals/accepted/0000-make-our-whitelabel-components-easier-to-theme-for-build-service-users.md)


## comments from issue

---

**JakeChampion** _on 2020-06-05T13:35:03_

Do we know the browser support of our whitelabel users at all?

---

---

**notlee** _on 2020-06-05T15:20:57_

I've asked in the dev channel for specialist titles. It may be the same as customer products, or slackbot may be lying: https://financialtimes.slack.com/archives/C7D7KQEN9/p1591370332400900

---

---

**notlee** _on 2020-06-08T13:37:04_

Alex replied:
>So same as the rest of the FT.  MoneyMedia/etc. I think do opt out.  Why don’t we have our own?
>We haven’t had good enough data (fixable now)
>Our audience may not have huge overlap, but FT.com is a pretty broad brush and so we’re not really constrained technically, and tooling like Polyfill.io - like real polyfiller - helps us fill in any gaps.
>Adding Yet Another Browser Support document has overhead for questionable returns — we aren’t IP where the user profile is drastically different to the market.

As Specialist Titles support IE11 the same as ft.com (with potential exceptions, e.g. MoneyMedia) I'm not sure we have whitelabel users at the moment who would benefit from this work. 

Although a different benefit of this work could be to help internal brand users theme variants of a component via the Build Service.

---

