### PR TITLE
Review how we manage and deploy component specific assets

### DIFF
--- a/proposals/accepted/0000-review-how-we-manage-and-deploy-component-specifc-assets.md
+++ b/proposals/accepted/0000-review-how-we-manage-and-deploy-component-specifc-assets.md
@@ -1,0 +1,19 @@
+# Review how we manage and deploy component specifc assets
+Review how we build components with unique static assets such as images.
+
+**Background:**
+
+At the time of writing (May 2020) the vast majority of our components pull their images from our shared icon or logo [image sets](https://registry.origami.ft.com/components?imageset=true&active=true&maintained=true). 
+
+However [o-comments](https://github.com/Financial-Times/o-comments/pull/164) has a unique image asset that is hosted in an s3 bucket (somewhere) and served through the [Image Service](https://www.ft.com/__origami/service/image/v2/). It's the best approach we have at the moment but it's not ideal: It relies on a component author having a secure and reliable way to host their own assets; the asset could be deleted accidentally as there's no explicit connection; the asset isn't within version control for restoring and history of the component; and it reduces our ability to develop offline (although along with fonts, polyfill.io requests, and potential build service requests in demos we can't really anyway).
+
+We used to use [o-assets](https://github.com/Financial-Times/o-assets) to manage individual component assets as required [in the spec](https://origami.ft.com/spec/v1/components/#subresources), but it has a few problems:
+- For local development, assumes assets are in `bower_components` by default, but: Origami components are also published to npm now and the asset directory cannot be changed to `node_modules` because the component directory has a `@financial-times` namespace; the asset directory may or may not be included in the npm bundle by [occ](https://github.com/Financial-Times/origami-component-converter/); and
+- Requires apps in development and production to serve `bower_components/node_modules` source code so requests can be made for the assets (potentially with a url mapping behind a router by configuring o-assets variables).
+
+**Quick brain bump of requirements:**
+We need a way to include unique component assets (let's assume any static file be it images, videos, json blobs, font files) which:
+- work for the Origami Build Service
+- work for bower and npm users in development
+- allows users to self host component assets; and or
+- doesn't require projects to include an asset build step (Origami hosted assets) 


### PR DESCRIPTION
From #54.

see [rendered proposal](https://github.com/Financial-Times/origami/blob/proposals/review-how-we-manage-and-deploy-component-specifc-assets/proposals/accepted/0000-review-how-we-manage-and-deploy-component-specifc-assets.md)


## comments from issue

---

**notlee** _on 2020-05-07T16:17:32_

**Possible Solution(s). This is not fleshed out and feels very convoluted. Just wanted to get down some initial ideas and start a conversation.**

- Spec that assets must go in an `assets` directory.
- Before release, automate a commit to [set the components version](https://github.com/Financial-Times/origami/issues/48) as a JS and Sass variable.
- On tag publish the `assets` directory to an Origami S3 bucket (or other long term storage) by name and version.
- Use a simplified `o-assets`, which:
   - has a Sass and JS function to include assets
        - takes the component name
        - takes the asset path relative to the asset directory
        - outputs an absolute path to the Origami S3 bucket by default
        - _(we could go further by putting images behind the image service automatically, could take image service params as an options map)_

   - has a Sass and JS flag to pass through relative paths instead of S3 urls
   - has a Sass and JS variable to configure the asset path e.g. `./assets/[component-name]/

- By default, users of Origami components get assets served via Origami services in a similar way to how we [serve fonts currently](https://github.com/Financial-Times/o-fonts/blob/0cd269af1a8681f80ef3a7151292511b0b9ccee5/src/scss/_variables.scss#L9) but with automation (it would help use avoid [o-font-assets errors](https://github.com/Financial-Times/o-fonts/pull/112)).
- For self hosted assets, a variable can be set to output the relative paths. Popular bundlers like webpack and parcel will handle a relative asset path in bower_components/node_modules correctly (assumption alert: do they actually? What about dynamic asset names are they just not allowed?).
- For local component development with origami-build-tools, we would need to update obt to:
    - copy `./assets` of each dependency into `demos/local/assets/[component-name]`
    - inject a Sass/JS variable to update the asset path to `./assets/[component-name]`

---

---

**JakeChampion** _on 2020-10-22T16:13:29_

I like this proposed solution :-) Origami should have some system to stored versioned assets 👍 

---

