### PR TITLE
Provide a way to express that a component is safe to be used with any brand.

### DIFF
--- a/proposals/accepted/0000-provide-a-way-to-express-that-a-component-is-safe-to-be-used-with-any-brand.md
+++ b/proposals/accepted/0000-provide-a-way-to-express-that-a-component-is-safe-to-be-used-with-any-brand.md
@@ -1,0 +1,11 @@
+# Provide a way to express that a component is safe to be used with any brand.
+## What
+Provide a way to express that a component is safe to be used with any brand.
+
+## Why
+
+e.g. https://registry.origami.ft.com/components/o-toggle@2.1.2 says 
+
+> o-toggle hasn't been branded yet, it only supports the master brand. 
+
+despite it not containing any of its own styles and being compatible with any brand.


### PR DESCRIPTION
From #91.

see [rendered proposal](https://github.com/Financial-Times/origami/blob/proposals/provide-a-way-to-express-that-a-component-is-safe-to-be-used-with-any-brand/proposals/accepted/0000-provide-a-way-to-express-that-a-component-is-safe-to-be-used-with-any-brand.md)


## comments from issue

---

**notlee** _on 2020-11-11T15:33:38_

Good shout, some kind of n/a option would be good in case we want to support more brands within components directly :) Maybe `all`? We'd need to update the spec, repo data, the registry, build tools and the percy action (to run tests against all brands) to handle that appropriately. In the meantime setting support for all three brands is the way to go

---

