### PR TITLE
Expose current release number to the component's own code

### DIFF
--- a/proposals/accepted/0000-expose-current-release-number-to-the-component-s-own-code.md
+++ b/proposals/accepted/0000-expose-current-release-number-to-the-component-s-own-code.md
@@ -1,0 +1,13 @@
+# Expose current release number to the component's own code
+## What
+
+I'd like each component to expose its current version number in a new module generated dynamically during the release.
+
+## Why
+
+Being able to access the current version number from code can make debugging easier but, specially, it can be essential for some monitoring use cases in which sending the component version number along with some tracking events can prove useful.
+
+## Supporting Examples
+
+`o-ads` is already exposing it through a [`getVersion` method](https://github.com/Financial-Times/o-ads/blob/7832e1c7e9f3004485261cd52901c4313ccc22cf/src/js/utils/index.js#L453) by [creating a `version.js` file](https://github.com/Financial-Times/o-ads/blob/626e0715f03690692c18172d5d7e8e9e91a25c25/package.json#L27) which exports the version number during its bespoke release process using [release-it](https://github.com/Financial-Times/o-ads/blob/6dfd500f979b53e5e93ba09dddbf4658d8201811/.release-it.json#L2)
+


### PR DESCRIPTION
From #48.

see [rendered proposal](https://github.com/Financial-Times/origami/blob/proposals/expose-current-release-number-to-the-component-s-own-code/proposals/accepted/0000-expose-current-release-number-to-the-component-s-own-code.md)


## comments from issue

---

**notlee** _on 2020-05-07T15:42:42_

There are some trade offs in terms of workflow and reliably updating the version before tagging, but I think this would be useful 👍 particularly for npm users who do not have the guarantee of a flat dependency tree and may end up with errors caused by multiple versions of a component on a page. I'm also wondering if it might help us manage static assets in a better way

Edit: in addition we [use the `o-fonts-assets` version number in `o-fonts`](https://github.com/Financial-Times/o-fonts/blob/0cd269af1a8681f80ef3a7151292511b0b9ccee5/src/scss/_variables.scss#L9) which has caused us an error before. This could be dynamic if we set a variable automatically

---

---

**notlee** _on 2020-05-15T15:31:54_

looks like [o-tracking uses its version number too](https://github.com/Financial-Times/o-tracking/issues/223) 

---

---

**JakeChampion** _on 2020-12-04T16:21:16_

This proposal will become simpler to implement when we have origami v2 which supports only npm. It will be simpler because there would be a file in the codebase which already contains the version number (the file is `package.json`) and we can update the origami component boilerplate/template/standard-interface to have an [`prepare`](https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish) script which generates a javascript file containing the version which the component could then expose in a method. The method should be one which is in the origami component boilerplate/template/standard-interface.

Something like this:

```json5
// package.json
{
  "version": "1.3.7",
  "scripts": {
    "prepare": "--es6 --semi src/js/version.js"
  }
}
```

```js
// src/js/version.js
// this file is made automatically
export const version = '1.3.7';
```

```js
// src/js/component.js
import { version as componentVersion } from './version.js'

class Video {
  version(){
    return componentVersion;
  }
}
```

---

