### PR TITLE
Enforce accessibility best practices by making some parameters mandatory

### DIFF
--- a/proposals/accepted/0000-enforce-accessibility-best-practices-by-making-some-parameters-mandatory.md
+++ b/proposals/accepted/0000-enforce-accessibility-best-practices-by-making-some-parameters-mandatory.md
@@ -1,0 +1,14 @@
+# Enforce accessibility best practices by making some parameters mandatory
+## What
+
+Enforce accessibility best practices by making some component parameters mandatory.
+
+## Details
+
+We often see issues raised in the DAC accessibility report that are caused by people using components and not using some of the options designed to provide extra context. A example would be the `closeButtonLabel` in [o-banner](https://github.com/Financial-Times/o-banner#options)
+
+In the past we have fixed some of these by creating a catch all default but these often fall short as they are missing the context required from the parent application.
+
+We could throw an error in a similar way to the errors thrown for not setting a theme https://github.com/Financial-Times/o-banner/blob/master/src/js/banner.js#L52
+
+As this would need to be a new breaking changing we would want to review all the options along with any other accessibility options we don't currently have but would be nice to add at the same time.


### PR DESCRIPTION
From #69.

see [rendered proposal](https://github.com/Financial-Times/origami/blob/proposals/enforce-accessibility-best-practices-by-making-some-parameters-mandatory/proposals/accepted/0000-enforce-accessibility-best-practices-by-making-some-parameters-mandatory.md)


## comments from issue

---

**JakeChampion** _on 2020-08-04T10:02:22_

Sorry for the slow reply on this!

I think this is a really good idea, thank you for raising it Glynn.

This looks like it can be rolled out on a component-by-component basis, using o-banner first as you have already pointed out it recommends setting at `buttonLabel`. With regards to o-banner, it has a default value for `buttonLabel` of "OK", I guess we would make it not have a default value and instead throw an error.



---

