### PR TITLE
feat!: Output FinancierDisplayWeb Variable Font

### DIFF
--- a/components/o-fonts/src/scss/_functions.scss
+++ b/components/o-fonts/src/scss/_functions.scss
@@ -5,16 +5,16 @@
 /// @param {String} $weight [regular] - The font weight.
 /// @param {String} $style [normal] - The font style.
 /// @return {Bool}
-/// @see oFontsDefineCustomFont To register a custom font's avalible variants.
+/// @see oFontsDefineCustomFont To register a custom font's available variants.
 @function oFontsVariantExists($family, $weight, $style) {
 	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
 	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
-	$font-properties: map-get($_o-fonts-families, $family);
+	$details: _oFontsGetFamilyDetails($family);
 	// Font is not registered.
-	@if type-of($font-properties) != 'map' {
+	@if type-of($details) != 'map' {
 		@return false;
 	}
-	$font-variants: map-get($font-properties, variants);
+	$font-variants: map-get($details, variants);
 
 	@each $variant in $font-variants {
 		// Check if this weight and style variant exists for this family
@@ -24,6 +24,66 @@
 		}
 	}
 	@return false;
+}
+
+/// Fetch details for a given font family including the variants the family
+/// supports. Alternate names for the same family are accounted for, for example
+/// the variable font family `FinancierDisplayWebVF` will return the same details
+/// as the non-variable family `FinancierDisplayWeb`.
+///
+/// @param {String} $family - a family name such as `MetricWeb`, `FinancierDisplayWeb`
+/// @return {Map|Null} - a map of details for a matching family, including supported `variants`, see $_o-fonts-families
+@function _oFontsGetFamilyDetails($family) {
+	$font: oFontsGetFontFamilyWithoutFallbacks($family);
+	@each $family-details in map-values($_o-fonts-families) {
+		$keys: map-get($family-details, 'keys');
+		@if index($keys, $font) != null {
+			@return $family-details;
+		}
+	}
+	@return null;
+}
+
+/// Get the variable font variation settings a given family supports.
+///
+/// @param {String} $family - a family name such as `FinancierDisplayWeb`
+/// @return {Map|Null} - a map of supported variable font variation settings, see $_o-fonts-families
+@function _oFontsGetVariationSettings($family) {
+	$details: _oFontsGetFamilyDetails($family);
+	@if type-of($details) != 'map' {
+		@return null;
+	}
+	$variation-settings: map-get($details, 'variation-settings');
+	@if type-of($variation-settings) != 'map' {
+		@return null;
+	}
+	@return $variation-settings;
+}
+
+/// Check if a family supports variable font weights.
+///
+/// @param {String} $family - a family name such as `FinancierDisplayWeb`
+/// @return {Boolean} - whether the family supports a variable weight
+@function _oFontsSupportsVariableWeight($family) {
+	$variation-settings: _oFontsGetVariationSettings($family);
+	@return if(
+		$variation-settings,
+		map-has-key($variation-settings, 'wght'),
+		false
+	);
+}
+
+/// Check if a family supports italics with a variable font.
+///
+/// @param {String} $family - a family name such as `FinancierDisplayWeb`
+/// @return {Boolean} - whether the family supports italics with a variable font
+@function _oFontsSupportsVariableItalic($family) {
+	$variation-settings: _oFontsGetVariationSettings($family);
+	@return if(
+		$variation-settings,
+		map-has-key($variation-settings, 'ital'),
+		false
+	);
 }
 
 /// Check if a font variant has been included
@@ -39,8 +99,14 @@
 	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
 	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
 	$variant-key: _oFontsVariantKey($family, $weight, $style);
+	$variants-included: map-get($_o-fonts-families-included, $family);
 
-	@return map-has-key($_o-fonts-families-included, $variant-key);
+	@return index($variants-included, $variant-key) != null;
+}
+
+/// Check if any font from the family has been included
+@function _oFontsFamilyIncluded($family) {
+	@return map-has-key($_o-fonts-families-included, $family);
 }
 
 /// Get a font-family stack with the appropriate fallbacks
@@ -51,12 +117,12 @@
 /// @param {String} family
 /// @return {String} - font-stack
 @function oFontsGetFontFamilyWithFallbacks($family) {
-	@if not map-has-key($_o-fonts-families, $family) {
+	$family-details: _oFontsGetFamilyDetails($family);
+	@if not $family-details {
 		@error 'Font "#{inspect($family)}" not found. "$family" must be one of #{map-keys($_o-fonts-families)}.';
 	}
 
-	$properties: map-get($_o-fonts-families, $family);
-	@return unquote(map-get($properties, font-family));
+	@return unquote(map-get($family-details, 'font-family'));
 }
 
 /// Removes a fonts fallbacks.
@@ -111,8 +177,8 @@
 ///
 /// @access private
 /// @param {String} $family - one of $_o-fonts-families
-/// @param {String} $weight [regular] - The font weight.
-/// @param {String} $style [normal] - The font style.
+/// @param {String} $weight - The font weight.
+/// @param {String} $style - The font style.
 /// @return {String} - the key
 @function _oFontsVariantKey($family, $weight, $style) {
 	@return "#{$family}-#{$weight}-#{$style}";

--- a/components/o-fonts/src/scss/_mixins.scss
+++ b/components/o-fonts/src/scss/_mixins.scss
@@ -39,12 +39,13 @@
 	$_o-fonts-families: map-merge(($font-key: (
 		'font-family': $font-family,
 		'variants': $variants,
+		'keys': ($font-key),
 		'custom': true
 	)), $_o-fonts-families) !global;
 	@content; // Output a custom Font-face declaration.
 }
 
-/// Register which fonts have been output by already for your project.
+/// Register which fonts have been output already for your project.
 /// This mixin is useful if a project calls the `oFonts` mixin is in a different
 /// entry point.
 ///
@@ -107,11 +108,9 @@
 	}
 
 	// Check the font is an Origami font, not a custom font.
-	@if map-has-key($_o-fonts-families, $family) {
-		$font-family-config: map-get($_o-fonts-families, $family);
-		@if map-get($font-family-config, 'custom') {
-			@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
-		}
+	$font-family-config: _oFontsGetFamilyDetails($family);
+	@if $font-family-config and map-get($font-family-config, 'custom') {
+		@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
 	}
 
 	// Check if the font has already been included
@@ -120,12 +119,35 @@
 
 	@if $font-is-already-included == false {
 		// Error if a font does not exist for the given variant.
-		@if not map-has-key($_o-fonts-families, $family) {
-			@error 'Font "#{inspect($family)}" not found. Must be one of #{map-keys($_o-fonts-families)}.';
+		@if not $font-family-config {
+			@error 'Font "#{inspect($family)}" not found. "$family" must be one of #{map-keys($_o-fonts-families)}.';
 		}
 
 		@if not oFontsVariantExists($family, $weight, $style) {
 			@error 'Font for "#{$family}" at weight: "#{$weight}" and style "#{$style}" does not exist.';
+		}
+
+		$font-family-included: _oFontsFamilyIncluded($family);
+		$font-family-supports-variable-weight: _oFontsSupportsVariableWeight($family);
+		$font-family-supports-variable-italic: _oFontsSupportsVariableItalic($family);
+		@if(not $font-family-included and $font-family-supports-variable-italic) {
+			@supports (font-variation-settings: 'ital' 0) {
+				@font-face {
+					src: url($o-fonts-path + '#{$family}-VF-Italic.woff2') format('woff2');
+					font-family: "#{$family}VF";
+					font-style: italic;
+
+				}
+			}
+		}
+		@if(not $font-family-included and $font-family-supports-variable-weight) {
+			@supports (font-variation-settings: 'wght' 400) {
+				@font-face {
+					src: url($o-fonts-path + '#{$family}-VF-Regular.woff2') format('woff2');
+					font-family: "#{$family}VF";
+					font-style: normal;
+				}
+			}
 		}
 
 		// Files are named as follows
@@ -165,5 +187,12 @@
 @mixin _oFontsVariantIncluded($family, $weight, $style) {
 	// Add to the list of already included families / variants
 	$variant-key: _oFontsVariantKey($family, $weight, $style);
-	$_o-fonts-families-included: map-merge($_o-fonts-families-included, ($variant-key: true)) !global;
+	$family-variants-included: map-get($_o-fonts-families-included, $family);
+	$family-variants-included: if($family-variants-included, $family-variants-included, ());
+	$family-variants-included: append($family-variants-included, $variant-key, 'comma');
+
+	$_o-fonts-families-included: map-merge(
+		$_o-fonts-families-included,
+		($family: $family-variants-included)
+	) !global;
 }

--- a/components/o-fonts/src/scss/_variables.scss
+++ b/components/o-fonts/src/scss/_variables.scss
@@ -115,11 +115,17 @@ $_o-fonts-recommended: (
 $_o-fonts-families: (
 	MetricWeb: (
 		font-family: 'MetricWeb, sans-serif',
+		keys: ('MetricWeb'),
 		variants: $_o-fonts-all-metric-variants
 	),
 	FinancierDisplayWeb: (
-		font-family: 'FinancierDisplayWeb, serif',
-		variants: $_o-fonts-all-financier-display-variants
+		font-family: 'FinancierDisplayWebVF, FinancierDisplayWeb, serif',
+		keys: ('FinancierDisplayWebVF', 'FinancierDisplayWeb'),
+		variants: $_o-fonts-all-financier-display-variants,
+		variation-settings: (
+			'wght': ('max': 800, 'min': 300),
+			'ital': true
+		),
 	),
 	FinancierTextWeb: (
 		font-family: 'FinancierTextWeb, serif',

--- a/components/o-fonts/test/scss/_mixins.test.scss
+++ b/components/o-fonts/test/scss/_mixins.test.scss
@@ -100,26 +100,30 @@
 		@include assert-equal(
 			$_o-fonts-families-included,
 			(
-				'MetricWeb-thin-normal': true,
-				'MetricWeb-light-normal': true,
-				'MetricWeb-light-italic': true,
-				'MetricWeb-regular-normal': true,
-				'MetricWeb-regular-italic': true,
-				'MetricWeb-medium-normal': true,
-				'MetricWeb-semibold-normal': true,
-				'MetricWeb-bold-normal': true,
-				'MetricWeb-bold-italic': true,
-				'MetricWeb-black-normal': true,
-				'FinancierDisplayWeb-light-normal': true,
-				'FinancierDisplayWeb-light-italic': true,
-				'FinancierDisplayWeb-regular-normal': true,
-				'FinancierDisplayWeb-regular-italic': true,
-				'FinancierDisplayWeb-medium-italic': true,
-				'FinancierDisplayWeb-medium-normal': true,
-				'FinancierDisplayWeb-semibold-normal': true,
-				'FinancierDisplayWeb-semibold-italic': true,
-				'FinancierDisplayWeb-bold-normal': true,
-				'FinancierDisplayWeb-black-normal': true
+				'MetricWeb': (
+					'MetricWeb-thin-normal',
+					'MetricWeb-light-normal',
+					'MetricWeb-light-italic',
+					'MetricWeb-regular-normal',
+					'MetricWeb-regular-italic',
+					'MetricWeb-medium-normal',
+					'MetricWeb-semibold-normal',
+					'MetricWeb-bold-normal',
+					'MetricWeb-bold-italic',
+		  'MetricWeb-black-normal'
+				),
+				'FinancierDisplayWeb': (
+  			'FinancierDisplayWeb-light-normal'
+					'FinancierDisplayWeb-light-italic',
+					'FinancierDisplayWeb-regular-normal',
+					'FinancierDisplayWeb-regular-italic',
+					'FinancierDisplayWeb-medium-italic',
+					'FinancierDisplayWeb-medium-normal',
+   				'FinancierDisplayWeb-semibold-normal',
+					'FinancierDisplayWeb-semibold-italic',
+					'FinancierDisplayWeb-bold-normal',
+					'FinancierDisplayWeb-black-normal'
+				)
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -136,10 +140,14 @@
 		@include assert-equal(
 			$_o-fonts-families-included,
 			(
-				'MetricWeb-regular-normal': true,
-				'MetricWeb-semibold-normal': true,
-				'FinancierDisplayWeb-medium-normal': true,
-				'FinancierDisplayWeb-bold-normal': true
+				'MetricWeb': (
+					'MetricWeb-regular-normal',
+					'MetricWeb-semibold-normal'
+				),
+				'FinancierDisplayWeb': (
+					'FinancierDisplayWeb-medium-normal',
+					'FinancierDisplayWeb-bold-normal'
+				)
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -161,11 +169,15 @@
 		@include assert-equal(
 			$_o-fonts-families-included,
 			(
-				'MetricWeb-regular-normal': true,
-				'MetricWeb-semibold-normal': true,
-				'FinancierDisplayWeb-medium-normal': true,
-				'FinancierDisplayWeb-bold-normal': true,
-				'FinancierDisplayWeb-regular-normal': true
+				'MetricWeb': (
+					'MetricWeb-regular-normal',
+					'MetricWeb-semibold-normal'
+				),
+				'FinancierDisplayWeb': (
+					'FinancierDisplayWeb-medium-normal',
+					'FinancierDisplayWeb-bold-normal',
+					'FinancierDisplayWeb-regular-normal'
+				)
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -195,7 +207,7 @@
 		// The custom font faces are recorded.
 		@include assert-equal(
 			$_o-fonts-families,
-			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: "thin", style: normal), (weight: "light", style: normal), (weight: "light", style: italic), (weight: "regular", style: normal), (weight: "regular", style: italic), (weight: "medium", style: normal), (weight: "semibold", style: normal), (weight: "bold", style: normal), (weight: "bold", style: italic), (weight: "black", style: normal))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: "light", style: normal), (weight: "light", style: italic), (weight: "regular", style: normal), (weight: "regular", style: italic), (weight: "medium", style: italic), (weight: "medium", style: normal), (weight: "semibold", style: normal), (weight: "semibold", style: italic), (weight: "bold", style: normal), (weight: "black", style: normal))), FinancierTextWeb: (font-family: "FinancierTextWeb, serif", variants: ((weight: "medium", style: normal), (weight: "bold", style: normal), (weight: "black", style: normal))))
+			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "keys": ("MyFont"), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", keys: ("MetricWeb"), variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWebVF, FinancierDisplayWeb, serif", keys: ("FinancierDisplayWebVF", "FinancierDisplayWeb"), variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal)), variation-settings: ('wght': ('max': 800, 'min': 300),'ital': true)))
 		);
 	}
 }


### PR DESCRIPTION
If any FinancierDisplayWeb font variant is included also output
the equivalent variable FinancierDisplayWeb font once. The variants
of FinancierDisplayWeb specifically requested may be used as
fallback fonts for older browsers, whilst the variable font may be
used to display a greater number of font variants.

`oFontsVariantExists` does not yet account for variable fonts,
therefore they are effectively not usable since `o-typography`,
which checks a font variant exists before outputting typographic
styles, will continue to only allow styles supported by
non-variable fonts. `oFontsVariantExists` should perhaps be
deprecated in favour of `oFontsVariantAllowed`, that includes a
set of variants which may be used (`FinancierDisplayWeb`
supports 500 weights, we'd rather users include a limited set for
design consistency). That's blocked until the design team decide
what variants to allow.

Depends on: https://github.com/Financial-Times/o-fonts-assets/pull/53
Relates to: https://github.com/Financial-Times/origami/pull/75