### PR TITLE
chore: ignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+**/package-lock.json


### PR DESCRIPTION
We only want a root package-lock.json, it knows about all the packages