### PR TITLE
chore: explicitly configure the npmjs used when publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           cache: 'npm'
           node-version: 16
+          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
I read https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages and I think this might need to be set in order for the .npmrc file to then be able to run npm publish