### PR TITLE
fix: only run percy workflow on main branch if a file in the component has changed

### DIFF
--- a/.github/workflows/percy-components-n-notification.yml
+++ b/.github/workflows/percy-components-n-notification.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/n-notification/package.json"
+      - "components/n-notification/package-lock.json"
+      - "components/n-notification/origami.json"
+      - "components/n-notification/main.js"
+      - "components/n-notification/main.scss"
+      - "components/n-notification/demos/**"
+      - "components/n-notification/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-audio.yml
+++ b/.github/workflows/percy-components-o-audio.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-audio/package.json"
+      - "components/o-audio/package-lock.json"
+      - "components/o-audio/origami.json"
+      - "components/o-audio/main.js"
+      - "components/o-audio/main.scss"
+      - "components/o-audio/demos/**"
+      - "components/o-audio/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-autocomplete.yml
+++ b/.github/workflows/percy-components-o-autocomplete.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-autocomplete/package.json"
+      - "components/o-autocomplete/package-lock.json"
+      - "components/o-autocomplete/origami.json"
+      - "components/o-autocomplete/main.js"
+      - "components/o-autocomplete/main.scss"
+      - "components/o-autocomplete/demos/**"
+      - "components/o-autocomplete/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-banner.yml
+++ b/.github/workflows/percy-components-o-banner.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-banner/package.json"
+      - "components/o-banner/package-lock.json"
+      - "components/o-banner/origami.json"
+      - "components/o-banner/main.js"
+      - "components/o-banner/main.scss"
+      - "components/o-banner/demos/**"
+      - "components/o-banner/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-big-number.yml
+++ b/.github/workflows/percy-components-o-big-number.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-big-number/package.json"
+      - "components/o-big-number/package-lock.json"
+      - "components/o-big-number/origami.json"
+      - "components/o-big-number/main.js"
+      - "components/o-big-number/main.scss"
+      - "components/o-big-number/demos/**"
+      - "components/o-big-number/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-buttons.yml
+++ b/.github/workflows/percy-components-o-buttons.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-buttons/package.json"
+      - "components/o-buttons/package-lock.json"
+      - "components/o-buttons/origami.json"
+      - "components/o-buttons/main.js"
+      - "components/o-buttons/main.scss"
+      - "components/o-buttons/demos/**"
+      - "components/o-buttons/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-colors.yml
+++ b/.github/workflows/percy-components-o-colors.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-colors/package.json"
+      - "components/o-colors/package-lock.json"
+      - "components/o-colors/origami.json"
+      - "components/o-colors/main.js"
+      - "components/o-colors/main.scss"
+      - "components/o-colors/demos/**"
+      - "components/o-colors/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-comments.yml
+++ b/.github/workflows/percy-components-o-comments.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-comments/package.json"
+      - "components/o-comments/package-lock.json"
+      - "components/o-comments/origami.json"
+      - "components/o-comments/main.js"
+      - "components/o-comments/main.scss"
+      - "components/o-comments/demos/**"
+      - "components/o-comments/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-cookie-message.yml
+++ b/.github/workflows/percy-components-o-cookie-message.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-cookie-message/package.json"
+      - "components/o-cookie-message/package-lock.json"
+      - "components/o-cookie-message/origami.json"
+      - "components/o-cookie-message/main.js"
+      - "components/o-cookie-message/main.scss"
+      - "components/o-cookie-message/demos/**"
+      - "components/o-cookie-message/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-date.yml
+++ b/.github/workflows/percy-components-o-date.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-date/package.json"
+      - "components/o-date/package-lock.json"
+      - "components/o-date/origami.json"
+      - "components/o-date/main.js"
+      - "components/o-date/main.scss"
+      - "components/o-date/demos/**"
+      - "components/o-date/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-editorial-layout.yml
+++ b/.github/workflows/percy-components-o-editorial-layout.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-editorial-layout/package.json"
+      - "components/o-editorial-layout/package-lock.json"
+      - "components/o-editorial-layout/origami.json"
+      - "components/o-editorial-layout/main.js"
+      - "components/o-editorial-layout/main.scss"
+      - "components/o-editorial-layout/demos/**"
+      - "components/o-editorial-layout/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-editorial-typography.yml
+++ b/.github/workflows/percy-components-o-editorial-typography.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-editorial-typography/package.json"
+      - "components/o-editorial-typography/package-lock.json"
+      - "components/o-editorial-typography/origami.json"
+      - "components/o-editorial-typography/main.js"
+      - "components/o-editorial-typography/main.scss"
+      - "components/o-editorial-typography/demos/**"
+      - "components/o-editorial-typography/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-expander.yml
+++ b/.github/workflows/percy-components-o-expander.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-expander/package.json"
+      - "components/o-expander/package-lock.json"
+      - "components/o-expander/origami.json"
+      - "components/o-expander/main.js"
+      - "components/o-expander/main.scss"
+      - "components/o-expander/demos/**"
+      - "components/o-expander/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-fonts.yml
+++ b/.github/workflows/percy-components-o-fonts.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-fonts/package.json"
+      - "components/o-fonts/package-lock.json"
+      - "components/o-fonts/origami.json"
+      - "components/o-fonts/main.js"
+      - "components/o-fonts/main.scss"
+      - "components/o-fonts/demos/**"
+      - "components/o-fonts/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-footer-services.yml
+++ b/.github/workflows/percy-components-o-footer-services.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-footer-services/package.json"
+      - "components/o-footer-services/package-lock.json"
+      - "components/o-footer-services/origami.json"
+      - "components/o-footer-services/main.js"
+      - "components/o-footer-services/main.scss"
+      - "components/o-footer-services/demos/**"
+      - "components/o-footer-services/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-footer.yml
+++ b/.github/workflows/percy-components-o-footer.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-footer/package.json"
+      - "components/o-footer/package-lock.json"
+      - "components/o-footer/origami.json"
+      - "components/o-footer/main.js"
+      - "components/o-footer/main.scss"
+      - "components/o-footer/demos/**"
+      - "components/o-footer/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-forms.yml
+++ b/.github/workflows/percy-components-o-forms.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-forms/package.json"
+      - "components/o-forms/package-lock.json"
+      - "components/o-forms/origami.json"
+      - "components/o-forms/main.js"
+      - "components/o-forms/main.scss"
+      - "components/o-forms/demos/**"
+      - "components/o-forms/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-ft-affiliate-ribbon.yml
+++ b/.github/workflows/percy-components-o-ft-affiliate-ribbon.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-ft-affiliate-ribbon/package.json"
+      - "components/o-ft-affiliate-ribbon/package-lock.json"
+      - "components/o-ft-affiliate-ribbon/origami.json"
+      - "components/o-ft-affiliate-ribbon/main.js"
+      - "components/o-ft-affiliate-ribbon/main.scss"
+      - "components/o-ft-affiliate-ribbon/demos/**"
+      - "components/o-ft-affiliate-ribbon/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-grid.yml
+++ b/.github/workflows/percy-components-o-grid.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-grid/package.json"
+      - "components/o-grid/package-lock.json"
+      - "components/o-grid/origami.json"
+      - "components/o-grid/main.js"
+      - "components/o-grid/main.scss"
+      - "components/o-grid/demos/**"
+      - "components/o-grid/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-header-services.yml
+++ b/.github/workflows/percy-components-o-header-services.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-header-services/package.json"
+      - "components/o-header-services/package-lock.json"
+      - "components/o-header-services/origami.json"
+      - "components/o-header-services/main.js"
+      - "components/o-header-services/main.scss"
+      - "components/o-header-services/demos/**"
+      - "components/o-header-services/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-header.yml
+++ b/.github/workflows/percy-components-o-header.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-header/package.json"
+      - "components/o-header/package-lock.json"
+      - "components/o-header/origami.json"
+      - "components/o-header/main.js"
+      - "components/o-header/main.scss"
+      - "components/o-header/demos/**"
+      - "components/o-header/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-icons.yml
+++ b/.github/workflows/percy-components-o-icons.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-icons/package.json"
+      - "components/o-icons/package-lock.json"
+      - "components/o-icons/origami.json"
+      - "components/o-icons/main.js"
+      - "components/o-icons/main.scss"
+      - "components/o-icons/demos/**"
+      - "components/o-icons/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-labels.yml
+++ b/.github/workflows/percy-components-o-labels.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-labels/package.json"
+      - "components/o-labels/package-lock.json"
+      - "components/o-labels/origami.json"
+      - "components/o-labels/main.js"
+      - "components/o-labels/main.scss"
+      - "components/o-labels/demos/**"
+      - "components/o-labels/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-layout.yml
+++ b/.github/workflows/percy-components-o-layout.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-layout/package.json"
+      - "components/o-layout/package-lock.json"
+      - "components/o-layout/origami.json"
+      - "components/o-layout/main.js"
+      - "components/o-layout/main.scss"
+      - "components/o-layout/demos/**"
+      - "components/o-layout/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-lazy-load.yml
+++ b/.github/workflows/percy-components-o-lazy-load.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-lazy-load/package.json"
+      - "components/o-lazy-load/package-lock.json"
+      - "components/o-lazy-load/origami.json"
+      - "components/o-lazy-load/main.js"
+      - "components/o-lazy-load/main.scss"
+      - "components/o-lazy-load/demos/**"
+      - "components/o-lazy-load/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-loading.yml
+++ b/.github/workflows/percy-components-o-loading.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-loading/package.json"
+      - "components/o-loading/package-lock.json"
+      - "components/o-loading/origami.json"
+      - "components/o-loading/main.js"
+      - "components/o-loading/main.scss"
+      - "components/o-loading/demos/**"
+      - "components/o-loading/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-message.yml
+++ b/.github/workflows/percy-components-o-message.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-message/package.json"
+      - "components/o-message/package-lock.json"
+      - "components/o-message/origami.json"
+      - "components/o-message/main.js"
+      - "components/o-message/main.scss"
+      - "components/o-message/demos/**"
+      - "components/o-message/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-meter.yml
+++ b/.github/workflows/percy-components-o-meter.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-meter/package.json"
+      - "components/o-meter/package-lock.json"
+      - "components/o-meter/origami.json"
+      - "components/o-meter/main.js"
+      - "components/o-meter/main.scss"
+      - "components/o-meter/demos/**"
+      - "components/o-meter/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-normalise.yml
+++ b/.github/workflows/percy-components-o-normalise.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-normalise/package.json"
+      - "components/o-normalise/package-lock.json"
+      - "components/o-normalise/origami.json"
+      - "components/o-normalise/main.js"
+      - "components/o-normalise/main.scss"
+      - "components/o-normalise/demos/**"
+      - "components/o-normalise/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-overlay.yml
+++ b/.github/workflows/percy-components-o-overlay.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-overlay/package.json"
+      - "components/o-overlay/package-lock.json"
+      - "components/o-overlay/origami.json"
+      - "components/o-overlay/main.js"
+      - "components/o-overlay/main.scss"
+      - "components/o-overlay/demos/**"
+      - "components/o-overlay/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-quote.yml
+++ b/.github/workflows/percy-components-o-quote.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-quote/package.json"
+      - "components/o-quote/package-lock.json"
+      - "components/o-quote/origami.json"
+      - "components/o-quote/main.js"
+      - "components/o-quote/main.scss"
+      - "components/o-quote/demos/**"
+      - "components/o-quote/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-share.yml
+++ b/.github/workflows/percy-components-o-share.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-share/package.json"
+      - "components/o-share/package-lock.json"
+      - "components/o-share/origami.json"
+      - "components/o-share/main.js"
+      - "components/o-share/main.scss"
+      - "components/o-share/demos/**"
+      - "components/o-share/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-spacing.yml
+++ b/.github/workflows/percy-components-o-spacing.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-spacing/package.json"
+      - "components/o-spacing/package-lock.json"
+      - "components/o-spacing/origami.json"
+      - "components/o-spacing/main.js"
+      - "components/o-spacing/main.scss"
+      - "components/o-spacing/demos/**"
+      - "components/o-spacing/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-stepped-progress.yml
+++ b/.github/workflows/percy-components-o-stepped-progress.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-stepped-progress/package.json"
+      - "components/o-stepped-progress/package-lock.json"
+      - "components/o-stepped-progress/origami.json"
+      - "components/o-stepped-progress/main.js"
+      - "components/o-stepped-progress/main.scss"
+      - "components/o-stepped-progress/demos/**"
+      - "components/o-stepped-progress/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-subs-card.yml
+++ b/.github/workflows/percy-components-o-subs-card.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-subs-card/package.json"
+      - "components/o-subs-card/package-lock.json"
+      - "components/o-subs-card/origami.json"
+      - "components/o-subs-card/main.js"
+      - "components/o-subs-card/main.scss"
+      - "components/o-subs-card/demos/**"
+      - "components/o-subs-card/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-syntax-highlight.yml
+++ b/.github/workflows/percy-components-o-syntax-highlight.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-syntax-highlight/package.json"
+      - "components/o-syntax-highlight/package-lock.json"
+      - "components/o-syntax-highlight/origami.json"
+      - "components/o-syntax-highlight/main.js"
+      - "components/o-syntax-highlight/main.scss"
+      - "components/o-syntax-highlight/demos/**"
+      - "components/o-syntax-highlight/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-table.yml
+++ b/.github/workflows/percy-components-o-table.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-table/package.json"
+      - "components/o-table/package-lock.json"
+      - "components/o-table/origami.json"
+      - "components/o-table/main.js"
+      - "components/o-table/main.scss"
+      - "components/o-table/demos/**"
+      - "components/o-table/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-tabs.yml
+++ b/.github/workflows/percy-components-o-tabs.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-tabs/package.json"
+      - "components/o-tabs/package-lock.json"
+      - "components/o-tabs/origami.json"
+      - "components/o-tabs/main.js"
+      - "components/o-tabs/main.scss"
+      - "components/o-tabs/demos/**"
+      - "components/o-tabs/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-teaser-collection.yml
+++ b/.github/workflows/percy-components-o-teaser-collection.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-teaser-collection/package.json"
+      - "components/o-teaser-collection/package-lock.json"
+      - "components/o-teaser-collection/origami.json"
+      - "components/o-teaser-collection/main.js"
+      - "components/o-teaser-collection/main.scss"
+      - "components/o-teaser-collection/demos/**"
+      - "components/o-teaser-collection/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-teaser.yml
+++ b/.github/workflows/percy-components-o-teaser.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-teaser/package.json"
+      - "components/o-teaser/package-lock.json"
+      - "components/o-teaser/origami.json"
+      - "components/o-teaser/main.js"
+      - "components/o-teaser/main.scss"
+      - "components/o-teaser/demos/**"
+      - "components/o-teaser/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-toggle.yml
+++ b/.github/workflows/percy-components-o-toggle.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-toggle/package.json"
+      - "components/o-toggle/package-lock.json"
+      - "components/o-toggle/origami.json"
+      - "components/o-toggle/main.js"
+      - "components/o-toggle/main.scss"
+      - "components/o-toggle/demos/**"
+      - "components/o-toggle/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-tooltip.yml
+++ b/.github/workflows/percy-components-o-tooltip.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-tooltip/package.json"
+      - "components/o-tooltip/package-lock.json"
+      - "components/o-tooltip/origami.json"
+      - "components/o-tooltip/main.js"
+      - "components/o-tooltip/main.scss"
+      - "components/o-tooltip/demos/**"
+      - "components/o-tooltip/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-topper.yml
+++ b/.github/workflows/percy-components-o-topper.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-topper/package.json"
+      - "components/o-topper/package-lock.json"
+      - "components/o-topper/origami.json"
+      - "components/o-topper/main.js"
+      - "components/o-topper/main.scss"
+      - "components/o-topper/demos/**"
+      - "components/o-topper/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-typography.yml
+++ b/.github/workflows/percy-components-o-typography.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-typography/package.json"
+      - "components/o-typography/package-lock.json"
+      - "components/o-typography/origami.json"
+      - "components/o-typography/main.js"
+      - "components/o-typography/main.scss"
+      - "components/o-typography/demos/**"
+      - "components/o-typography/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-video.yml
+++ b/.github/workflows/percy-components-o-video.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-video/package.json"
+      - "components/o-video/package-lock.json"
+      - "components/o-video/origami.json"
+      - "components/o-video/main.js"
+      - "components/o-video/main.scss"
+      - "components/o-video/demos/**"
+      - "components/o-video/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-viewport.yml
+++ b/.github/workflows/percy-components-o-viewport.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-viewport/package.json"
+      - "components/o-viewport/package-lock.json"
+      - "components/o-viewport/origami.json"
+      - "components/o-viewport/main.js"
+      - "components/o-viewport/main.scss"
+      - "components/o-viewport/demos/**"
+      - "components/o-viewport/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/percy-components-o-visual-effects.yml
+++ b/.github/workflows/percy-components-o-visual-effects.yml
@@ -11,6 +11,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "components/o-visual-effects/package.json"
+      - "components/o-visual-effects/package-lock.json"
+      - "components/o-visual-effects/origami.json"
+      - "components/o-visual-effects/main.js"
+      - "components/o-visual-effects/main.scss"
+      - "components/o-visual-effects/demos/**"
+      - "components/o-visual-effects/src/**"
 
 jobs:
   percy:

--- a/.github/workflows/test-components-n-notification.yml
+++ b/.github/workflows/test-components-n-notification.yml
@@ -1,7 +1,7 @@
 name: test components/n-notification
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/n-notification
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-audio.yml
+++ b/.github/workflows/test-components-o-audio.yml
@@ -1,7 +1,7 @@
 name: test components/o-audio
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-audio
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-autocomplete.yml
+++ b/.github/workflows/test-components-o-autocomplete.yml
@@ -1,7 +1,7 @@
 name: test components/o-autocomplete
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-autocomplete
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-banner.yml
+++ b/.github/workflows/test-components-o-banner.yml
@@ -1,7 +1,7 @@
 name: test components/o-banner
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-banner
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-big-number.yml
+++ b/.github/workflows/test-components-o-big-number.yml
@@ -1,7 +1,7 @@
 name: test components/o-big-number
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-big-number
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-buttons.yml
+++ b/.github/workflows/test-components-o-buttons.yml
@@ -1,7 +1,7 @@
 name: test components/o-buttons
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-buttons
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-colors.yml
+++ b/.github/workflows/test-components-o-colors.yml
@@ -1,7 +1,7 @@
 name: test components/o-colors
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-colors
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-comments.yml
+++ b/.github/workflows/test-components-o-comments.yml
@@ -1,7 +1,7 @@
 name: test components/o-comments
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-comments
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-cookie-message.yml
+++ b/.github/workflows/test-components-o-cookie-message.yml
@@ -1,7 +1,7 @@
 name: test components/o-cookie-message
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-cookie-message
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-date.yml
+++ b/.github/workflows/test-components-o-date.yml
@@ -1,7 +1,7 @@
 name: test components/o-date
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-date
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-editorial-layout.yml
+++ b/.github/workflows/test-components-o-editorial-layout.yml
@@ -1,7 +1,7 @@
 name: test components/o-editorial-layout
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-editorial-layout
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-editorial-typography.yml
+++ b/.github/workflows/test-components-o-editorial-typography.yml
@@ -1,7 +1,7 @@
 name: test components/o-editorial-typography
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-editorial-typography
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-expander.yml
+++ b/.github/workflows/test-components-o-expander.yml
@@ -1,7 +1,7 @@
 name: test components/o-expander
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-expander
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-fonts.yml
+++ b/.github/workflows/test-components-o-fonts.yml
@@ -1,7 +1,7 @@
 name: test components/o-fonts
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-fonts
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-footer-services.yml
+++ b/.github/workflows/test-components-o-footer-services.yml
@@ -1,7 +1,7 @@
 name: test components/o-footer-services
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-footer-services
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-footer.yml
+++ b/.github/workflows/test-components-o-footer.yml
@@ -1,7 +1,7 @@
 name: test components/o-footer
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-footer
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-forms.yml
+++ b/.github/workflows/test-components-o-forms.yml
@@ -1,7 +1,7 @@
 name: test components/o-forms
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-forms
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-ft-affiliate-ribbon.yml
+++ b/.github/workflows/test-components-o-ft-affiliate-ribbon.yml
@@ -1,7 +1,7 @@
 name: test components/o-ft-affiliate-ribbon
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-ft-affiliate-ribbon
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-grid.yml
+++ b/.github/workflows/test-components-o-grid.yml
@@ -1,7 +1,7 @@
 name: test components/o-grid
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-grid
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-header-services.yml
+++ b/.github/workflows/test-components-o-header-services.yml
@@ -1,7 +1,7 @@
 name: test components/o-header-services
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-header-services
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-header.yml
+++ b/.github/workflows/test-components-o-header.yml
@@ -1,7 +1,7 @@
 name: test components/o-header
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-header
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-icons.yml
+++ b/.github/workflows/test-components-o-icons.yml
@@ -1,7 +1,7 @@
 name: test components/o-icons
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-icons
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-labels.yml
+++ b/.github/workflows/test-components-o-labels.yml
@@ -1,7 +1,7 @@
 name: test components/o-labels
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-labels
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-layout.yml
+++ b/.github/workflows/test-components-o-layout.yml
@@ -1,7 +1,7 @@
 name: test components/o-layout
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-layout
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-lazy-load.yml
+++ b/.github/workflows/test-components-o-lazy-load.yml
@@ -1,7 +1,7 @@
 name: test components/o-lazy-load
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-lazy-load
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-loading.yml
+++ b/.github/workflows/test-components-o-loading.yml
@@ -1,7 +1,7 @@
 name: test components/o-loading
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-loading
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-message.yml
+++ b/.github/workflows/test-components-o-message.yml
@@ -1,7 +1,7 @@
 name: test components/o-message
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-message
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-meter.yml
+++ b/.github/workflows/test-components-o-meter.yml
@@ -1,7 +1,7 @@
 name: test components/o-meter
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-meter
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-normalise.yml
+++ b/.github/workflows/test-components-o-normalise.yml
@@ -1,7 +1,7 @@
 name: test components/o-normalise
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-normalise
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-overlay.yml
+++ b/.github/workflows/test-components-o-overlay.yml
@@ -1,7 +1,7 @@
 name: test components/o-overlay
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-overlay
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-quote.yml
+++ b/.github/workflows/test-components-o-quote.yml
@@ -1,7 +1,7 @@
 name: test components/o-quote
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-quote
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-share.yml
+++ b/.github/workflows/test-components-o-share.yml
@@ -1,7 +1,7 @@
 name: test components/o-share
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-share
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-spacing.yml
+++ b/.github/workflows/test-components-o-spacing.yml
@@ -1,7 +1,7 @@
 name: test components/o-spacing
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-spacing
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-stepped-progress.yml
+++ b/.github/workflows/test-components-o-stepped-progress.yml
@@ -1,7 +1,7 @@
 name: test components/o-stepped-progress
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-stepped-progress
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-subs-card.yml
+++ b/.github/workflows/test-components-o-subs-card.yml
@@ -1,7 +1,7 @@
 name: test components/o-subs-card
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-subs-card
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-syntax-highlight.yml
+++ b/.github/workflows/test-components-o-syntax-highlight.yml
@@ -1,7 +1,7 @@
 name: test components/o-syntax-highlight
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-syntax-highlight
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-table.yml
+++ b/.github/workflows/test-components-o-table.yml
@@ -1,7 +1,7 @@
 name: test components/o-table
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-table
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-tabs.yml
+++ b/.github/workflows/test-components-o-tabs.yml
@@ -1,7 +1,7 @@
 name: test components/o-tabs
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-tabs
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-teaser-collection.yml
+++ b/.github/workflows/test-components-o-teaser-collection.yml
@@ -1,7 +1,7 @@
 name: test components/o-teaser-collection
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-teaser-collection
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-teaser.yml
+++ b/.github/workflows/test-components-o-teaser.yml
@@ -1,7 +1,7 @@
 name: test components/o-teaser
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-teaser
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-toggle.yml
+++ b/.github/workflows/test-components-o-toggle.yml
@@ -1,7 +1,7 @@
 name: test components/o-toggle
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-toggle
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-tooltip.yml
+++ b/.github/workflows/test-components-o-tooltip.yml
@@ -1,7 +1,7 @@
 name: test components/o-tooltip
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-tooltip
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-topper.yml
+++ b/.github/workflows/test-components-o-topper.yml
@@ -1,7 +1,7 @@
 name: test components/o-topper
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-topper
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-typography.yml
+++ b/.github/workflows/test-components-o-typography.yml
@@ -1,7 +1,7 @@
 name: test components/o-typography
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-typography
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-video.yml
+++ b/.github/workflows/test-components-o-video.yml
@@ -1,7 +1,7 @@
 name: test components/o-video
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-video
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-viewport.yml
+++ b/.github/workflows/test-components-o-viewport.yml
@@ -1,7 +1,7 @@
 name: test components/o-viewport
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-viewport
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-components-o-visual-effects.yml
+++ b/.github/workflows/test-components-o-visual-effects.yml
@@ -1,7 +1,7 @@
 name: test components/o-visual-effects
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-components/o-visual-effects
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-libraries-o-autoinit.yml
+++ b/.github/workflows/test-libraries-o-autoinit.yml
@@ -1,7 +1,7 @@
 name: test libraries/o-autoinit
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-libraries/o-autoinit
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-libraries-o-brand.yml
+++ b/.github/workflows/test-libraries-o-brand.yml
@@ -1,7 +1,7 @@
 name: test libraries/o-brand
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-libraries/o-brand
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-libraries-o-errors.yml
+++ b/.github/workflows/test-libraries-o-errors.yml
@@ -1,7 +1,7 @@
 name: test libraries/o-errors
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-libraries/o-errors
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-libraries-o-tracking.yml
+++ b/.github/workflows/test-libraries-o-tracking.yml
@@ -1,7 +1,7 @@
 name: test libraries/o-tracking
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-libraries/o-tracking
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-libraries-o-utils.yml
+++ b/.github/workflows/test-libraries-o-utils.yml
@@ -1,7 +1,7 @@
 name: test libraries/o-utils
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-libraries/o-utils
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-presets-eslint-config-origami-component.yml
+++ b/.github/workflows/test-presets-eslint-config-origami-component.yml
@@ -1,7 +1,7 @@
 name: test presets/eslint-config-origami-component
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-presets/eslint-config-origami-component
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-presets-remark-preset-lint-origami-component.yml
+++ b/.github/workflows/test-presets-remark-preset-lint-origami-component.yml
@@ -1,7 +1,7 @@
 name: test presets/remark-preset-lint-origami-component
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-presets/remark-preset-lint-origami-component
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-presets-stylelint-config-origami-component.yml
+++ b/.github/workflows/test-presets-stylelint-config-origami-component.yml
@@ -1,7 +1,7 @@
 name: test presets/stylelint-config-origami-component
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-presets/stylelint-config-origami-component
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/test-tools-origami-build-tools.yml
+++ b/.github/workflows/test-tools-origami-build-tools.yml
@@ -1,7 +1,7 @@
 name: test tools/origami-build-tools
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-tools/origami-build-tools
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/templates/percy-workflow.yml
+++ b/templates/percy-workflow.yml
@@ -12,6 +12,14 @@ on:
       - synchronize
   push:
     branches: main
+    paths:
+      - "<%& workspace %>/package.json"
+      - "<%& workspace %>/package-lock.json"
+      - "<%& workspace %>/origami.json"
+      - "<%& workspace %>/main.js"
+      - "<%& workspace %>/main.scss"
+      - "<%& workspace %>/demos/**"
+      - "<%& workspace %>/src/**"
 
 jobs:
   percy:

--- a/templates/test-workflow.yml
+++ b/templates/test-workflow.yml
@@ -2,7 +2,7 @@
 name: test <%& workspace %>
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow}}-<%& workspace %>
- cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
This will stop percy from running on all components for commits on the main branch