### PR TITLE
chore: Add content to fixture between h1 and h2

### DIFF
--- a/components/o-layout/test/helpers/fixtures.js
+++ b/components/o-layout/test/helpers/fixtures.js
@@ -6,6 +6,30 @@ const docs = `
 
 	<div class="o-layout__main">
 		<h1 id="this-is-a-h1">This is a heading level 1</h2>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
+		<p>This is some content.</p>
+		<p>This is more content</p>
+		<p>This is even more content</p>
 		<h2 id="this-is-a-h2">This is a heading level 2</h2>
 		<p>This is some content.</p>
 		<p>This is more content</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.0.2",
+			"version": "2.0.3",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7"
@@ -335,7 +335,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "9.0.2",
+			"version": "9.0.3",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7"


### PR DESCRIPTION
This will hopefully mean that the headless browser never selects the h2