### PR TITLE
add a small amount of documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Welcome to Origami!
 
+This is the repository for the Origami components, libraries and apps that make
+up the Origami Component System.
+
+## Projects in this repository
+
+This repository houses many projects of different kinds. Most of them have
+READMEs of their own where you can learn more about them.
+
+### apps/website
+
+The [Origami website](./apps/website), served at <https://origami.ft.com>.
+
+### apps/storybook
+
+[Origami's storybook](./apps/storybook), served at <https://origami.ft.com/storybook>.
+
+### components and libraries
+
+Components and libraries that implement the FT's design system for the web.
+
+### presets
+
+Presets for development tools that make it easier to build consistent
+components.
+
+### scripts
+
+Scripts for maintenance of the repository itself
+
+### tools
+
+Tools used to build and test Origami components
+
 ## Proposals
 
 If you'd like to make a proposal for a new component or anything else, go ahead and [open an issue](https://github.com/Financial-Times/origami/issues/new)


### PR DESCRIPTION
I think we should also add a readme to all of the top-level directories
so we can give people a little more info when they browse in.

for instance: document the scripts in scripts/readme.md