### PR TITLE
add a specific time for the demo date that prints the whole date

### DIFF
--- a/components/o-date/.prettierrc.toml
+++ b/components/o-date/.prettierrc.toml
@@ -1,0 +1,8 @@
+printWidth = 80
+trailingComma = "es5"
+semi = true
+singleQuote = true
+useTabs = true
+bracketSpacing = false
+jsxBracketSameLine = true
+arrowParens = "avoid"

--- a/components/o-date/demos/src/declarative.js
+++ b/components/o-date/demos/src/declarative.js
@@ -9,4 +9,8 @@ for (let i = 0; i < dates.length; i++) {
 	dates[i].setAttribute('datetime', today.toISOString());
 }
 
+// this one is being set to a specific time because otherwise
+// the demo changes on every build
+dates[dates.length - 1].setAttribute("datetime", "1912-04-15T05:18Z");
+
 ODate.init();

--- a/components/o-date/demos/src/declarative.js
+++ b/components/o-date/demos/src/declarative.js
@@ -1,16 +1,16 @@
 import ODate from '../../main.js';
 
 const now = new Date();
-const today = new Date();
+const sixHoursAgo = new Date();
+sixHoursAgo.setHours(now.getHours() - 6);
 const dates = document.querySelectorAll('time:not([datetime])');
-today.setHours(now.getHours() - 6);
 
 for (let i = 0; i < dates.length; i++) {
-	dates[i].setAttribute('datetime', today.toISOString());
+	// the last 2 are being set to a specific time because otherwise the demo
+	// changes on every build and upsets percy the hedgehog
+	const date =
+		i < dates.length - 2 ? sixHoursAgo.toISOString() : '1912-04-15T05:18Z';
+	dates[i].setAttribute('datetime', date);
 }
-
-// this one is being set to a specific time because otherwise
-// the demo changes on every build
-dates[dates.length - 1].setAttribute("datetime", "1912-04-15T05:18Z");
 
 ODate.init();

--- a/components/o-date/demos/src/declarative.js
+++ b/components/o-date/demos/src/declarative.js
@@ -1,16 +1,12 @@
 import ODate from '../../main.js';
 
 const now = new Date();
-const sixHoursAgo = new Date();
-sixHoursAgo.setHours(now.getHours() - 6);
+const today = new Date();
 const dates = document.querySelectorAll('time:not([datetime])');
+today.setHours(now.getHours() - 6);
 
 for (let i = 0; i < dates.length; i++) {
-	// the last 2 are being set to a specific time because otherwise the demo
-	// changes on every build and upsets percy the hedgehog
-	const date =
-		i < dates.length - 2 ? sixHoursAgo.toISOString() : '1912-04-15T05:18Z';
-	dates[i].setAttribute('datetime', date);
+	dates[i].setAttribute('datetime', today.toISOString());
 }
 
 ODate.init();

--- a/components/o-date/demos/src/declarative.mustache
+++ b/components/o-date/demos/src/declarative.mustache
@@ -10,9 +10,9 @@
 <br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-24-hours"></time> (Using the o-date-format with time-ago-limit-24-hours)
 <br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="h:mm a"></time> (Using the o-date-format with custom format string)
+<time data-o-component="o-date" class="o-date" data-o-date-format="h:mm a" datetime="1912-04-15T05:18Z"></time> (Using the o-date-format with custom format string)
 <br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="date-only">
+<time data-o-component="o-date" class="o-date" data-o-date-format="date-only" datetime="1912-04-15T05:18Z">
 	<!-- render date-only here, set on the parent "time" element -->
 	<span data-o-date-printer>
 	</span>


### PR DESCRIPTION
So that percy doesn't show a different date every time

I'll change this to a `docs: ` commit and do a force push after percy has run. This doesn't need a release.