### PR TITLE
checkout with lfs when building websites

### DIFF
--- a/.github/workflows/build-websites.yml
+++ b/.github/workflows/build-websites.yml
@@ -6,10 +6,12 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: use node javascript
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
the website's images are stored in LFS to prevent repo slowness