### PR TITLE
[ADSDEV-899] - updated width and height to 2px to better serve users with voice activation software

### DIFF
--- a/components/o-normalise/src/scss/_mixins.scss
+++ b/components/o-normalise/src/scss/_mixins.scss
@@ -8,8 +8,8 @@
 	border: 0;
 	overflow: hidden;
 	padding: 0;
-	width: 1px;
-	height: 1px;
+	width: 2px;
+	height: 2px;
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
Originally for [this ticket](https://financialtimes.atlassian.net/browse/ADSDEV-899), there were several ways to potentially resolve this.

This is possibly the best as all as the `oNormaliseVisuallyHidden` component is already invisible by a `clip: rect(0,0,0)`, so increasing its footprint to 2px should not affect anything visually... but should help with accessibility!

Let me know if there are any questions.