### PR TITLE
docs: add accordion as a keyword for o-expander

### DIFF
--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.1",
   "description": "Content-aware helper for expanding and collapsing content or lists.",
   "keywords": [
+    "accordion",
     "expand",
     "content",
     "more",


### PR DESCRIPTION
We've had Origami users look for an accordion component when on the Origami Registry and fail to find a component.
When we show them o-expander they say that is what they are after, which is why I've added accordion as a keyword