### PR TITLE
backstage: use npm 7 on ci and not npm 8

### DIFF
--- a/.github/workflows/build-websites.yml
+++ b/.github/workflows/build-websites.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         ruby-version: 2.7.4
         bundler-cache: true
+    - run: npm i -g npm@7
     - run: npm ci
     - run: bash ./scripts/build-website.bash
     - name: deploy 🚀

--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npm run regenerate
     - run: ./scripts/check-for-changes.bash

--- a/.github/workflows/percy-components-n-notification.yml
+++ b/.github/workflows/percy-components-n-notification.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-audio.yml
+++ b/.github/workflows/percy-components-o-audio.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-autocomplete.yml
+++ b/.github/workflows/percy-components-o-autocomplete.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-banner.yml
+++ b/.github/workflows/percy-components-o-banner.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-big-number.yml
+++ b/.github/workflows/percy-components-o-big-number.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-buttons.yml
+++ b/.github/workflows/percy-components-o-buttons.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-colors.yml
+++ b/.github/workflows/percy-components-o-colors.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-comments.yml
+++ b/.github/workflows/percy-components-o-comments.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-cookie-message.yml
+++ b/.github/workflows/percy-components-o-cookie-message.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-date.yml
+++ b/.github/workflows/percy-components-o-date.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-editorial-layout.yml
+++ b/.github/workflows/percy-components-o-editorial-layout.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-editorial-typography.yml
+++ b/.github/workflows/percy-components-o-editorial-typography.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-expander.yml
+++ b/.github/workflows/percy-components-o-expander.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-fonts.yml
+++ b/.github/workflows/percy-components-o-fonts.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-footer-services.yml
+++ b/.github/workflows/percy-components-o-footer-services.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-footer.yml
+++ b/.github/workflows/percy-components-o-footer.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-forms.yml
+++ b/.github/workflows/percy-components-o-forms.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-ft-affiliate-ribbon.yml
+++ b/.github/workflows/percy-components-o-ft-affiliate-ribbon.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-grid.yml
+++ b/.github/workflows/percy-components-o-grid.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-header-services.yml
+++ b/.github/workflows/percy-components-o-header-services.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-header.yml
+++ b/.github/workflows/percy-components-o-header.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-icons.yml
+++ b/.github/workflows/percy-components-o-icons.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-labels.yml
+++ b/.github/workflows/percy-components-o-labels.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-layout.yml
+++ b/.github/workflows/percy-components-o-layout.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-lazy-load.yml
+++ b/.github/workflows/percy-components-o-lazy-load.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-loading.yml
+++ b/.github/workflows/percy-components-o-loading.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-message.yml
+++ b/.github/workflows/percy-components-o-message.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-meter.yml
+++ b/.github/workflows/percy-components-o-meter.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-normalise.yml
+++ b/.github/workflows/percy-components-o-normalise.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-overlay.yml
+++ b/.github/workflows/percy-components-o-overlay.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-quote.yml
+++ b/.github/workflows/percy-components-o-quote.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-share.yml
+++ b/.github/workflows/percy-components-o-share.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-spacing.yml
+++ b/.github/workflows/percy-components-o-spacing.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-stepped-progress.yml
+++ b/.github/workflows/percy-components-o-stepped-progress.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-subs-card.yml
+++ b/.github/workflows/percy-components-o-subs-card.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-syntax-highlight.yml
+++ b/.github/workflows/percy-components-o-syntax-highlight.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-table.yml
+++ b/.github/workflows/percy-components-o-table.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-tabs.yml
+++ b/.github/workflows/percy-components-o-tabs.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-teaser-collection.yml
+++ b/.github/workflows/percy-components-o-teaser-collection.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-teaser.yml
+++ b/.github/workflows/percy-components-o-teaser.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-toggle.yml
+++ b/.github/workflows/percy-components-o-toggle.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-tooltip.yml
+++ b/.github/workflows/percy-components-o-tooltip.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-topper.yml
+++ b/.github/workflows/percy-components-o-topper.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-typography.yml
+++ b/.github/workflows/percy-components-o-typography.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-video.yml
+++ b/.github/workflows/percy-components-o-video.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-viewport.yml
+++ b/.github/workflows/percy-components-o-viewport.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/percy-components-o-visual-effects.yml
+++ b/.github/workflows/percy-components-o-visual-effects.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
+      - run: npm i -g npm@7
+        if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}
       - run: node ./scripts/publish.js '${{toJSON(steps.release.outputs)}}'

--- a/.github/workflows/test-apps-storybook-addons-guidelines.yml
+++ b/.github/workflows/test-apps-storybook-addons-guidelines.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w apps/storybook/addons/guidelines lint
     - run: npx npm run -w apps/storybook/addons/guidelines test

--- a/.github/workflows/test-apps-storybook-addons-html.yml
+++ b/.github/workflows/test-apps-storybook-addons-html.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w apps/storybook/addons/html lint
     - run: npx npm run -w apps/storybook/addons/html test

--- a/.github/workflows/test-apps-storybook-addons-markdown-tabs.yml
+++ b/.github/workflows/test-apps-storybook-addons-markdown-tabs.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w apps/storybook/addons/markdown-tabs lint
     - run: npx npm run -w apps/storybook/addons/markdown-tabs test

--- a/.github/workflows/test-apps-storybook.yml
+++ b/.github/workflows/test-apps-storybook.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w apps/storybook lint
     - run: npx npm run -w apps/storybook test

--- a/.github/workflows/test-apps-website.yml
+++ b/.github/workflows/test-apps-website.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w apps/website lint
     - run: npx npm run -w apps/website test

--- a/.github/workflows/test-components-n-notification.yml
+++ b/.github/workflows/test-components-n-notification.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/n-notification -- origami-build-tools verify
     - run: npx npm x -w components/n-notification -- origami-build-tools test || npx npm x -w components/n-notification -- origami-build-tools test

--- a/.github/workflows/test-components-o-audio.yml
+++ b/.github/workflows/test-components-o-audio.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-audio -- origami-build-tools verify
     - run: npx npm x -w components/o-audio -- origami-build-tools test || npx npm x -w components/o-audio -- origami-build-tools test

--- a/.github/workflows/test-components-o-autocomplete.yml
+++ b/.github/workflows/test-components-o-autocomplete.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-autocomplete -- origami-build-tools verify
     - run: npx npm run -w components/o-autocomplete test

--- a/.github/workflows/test-components-o-banner.yml
+++ b/.github/workflows/test-components-o-banner.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-banner -- origami-build-tools verify
     - run: npx npm x -w components/o-banner -- origami-build-tools test || npx npm x -w components/o-banner -- origami-build-tools test

--- a/.github/workflows/test-components-o-big-number.yml
+++ b/.github/workflows/test-components-o-big-number.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-big-number -- origami-build-tools verify
     - run: npx npm x -w components/o-big-number -- origami-build-tools test || npx npm x -w components/o-big-number -- origami-build-tools test

--- a/.github/workflows/test-components-o-buttons.yml
+++ b/.github/workflows/test-components-o-buttons.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-buttons -- origami-build-tools verify
     - run: npx npm x -w components/o-buttons -- origami-build-tools test || npx npm x -w components/o-buttons -- origami-build-tools test

--- a/.github/workflows/test-components-o-colors.yml
+++ b/.github/workflows/test-components-o-colors.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-colors -- origami-build-tools verify
     - run: npx npm x -w components/o-colors -- origami-build-tools test || npx npm x -w components/o-colors -- origami-build-tools test

--- a/.github/workflows/test-components-o-comments.yml
+++ b/.github/workflows/test-components-o-comments.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-comments -- origami-build-tools verify
     - run: npx npm x -w components/o-comments -- origami-build-tools test || npx npm x -w components/o-comments -- origami-build-tools test

--- a/.github/workflows/test-components-o-cookie-message.yml
+++ b/.github/workflows/test-components-o-cookie-message.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-cookie-message -- origami-build-tools verify
     - run: npx npm x -w components/o-cookie-message -- origami-build-tools test || npx npm x -w components/o-cookie-message -- origami-build-tools test

--- a/.github/workflows/test-components-o-date.yml
+++ b/.github/workflows/test-components-o-date.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-date -- origami-build-tools verify
     - run: npx npm x -w components/o-date -- origami-build-tools test || npx npm x -w components/o-date -- origami-build-tools test

--- a/.github/workflows/test-components-o-editorial-layout.yml
+++ b/.github/workflows/test-components-o-editorial-layout.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-editorial-layout -- origami-build-tools verify
     - run: npx npm x -w components/o-editorial-layout -- origami-build-tools test || npx npm x -w components/o-editorial-layout -- origami-build-tools test

--- a/.github/workflows/test-components-o-editorial-typography.yml
+++ b/.github/workflows/test-components-o-editorial-typography.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-editorial-typography -- origami-build-tools verify
     - run: npx npm x -w components/o-editorial-typography -- origami-build-tools test || npx npm x -w components/o-editorial-typography -- origami-build-tools test

--- a/.github/workflows/test-components-o-expander.yml
+++ b/.github/workflows/test-components-o-expander.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-expander -- origami-build-tools verify
     - run: npx npm x -w components/o-expander -- origami-build-tools test || npx npm x -w components/o-expander -- origami-build-tools test

--- a/.github/workflows/test-components-o-fonts.yml
+++ b/.github/workflows/test-components-o-fonts.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-fonts -- origami-build-tools verify
     - run: npx npm x -w components/o-fonts -- origami-build-tools test || npx npm x -w components/o-fonts -- origami-build-tools test

--- a/.github/workflows/test-components-o-footer-services.yml
+++ b/.github/workflows/test-components-o-footer-services.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-footer-services -- origami-build-tools verify
     - run: npx npm x -w components/o-footer-services -- origami-build-tools test || npx npm x -w components/o-footer-services -- origami-build-tools test

--- a/.github/workflows/test-components-o-footer.yml
+++ b/.github/workflows/test-components-o-footer.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-footer -- origami-build-tools verify
     - run: npx npm x -w components/o-footer -- origami-build-tools test || npx npm x -w components/o-footer -- origami-build-tools test

--- a/.github/workflows/test-components-o-forms.yml
+++ b/.github/workflows/test-components-o-forms.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-forms -- origami-build-tools verify
     - run: npx npm x -w components/o-forms -- origami-build-tools test || npx npm x -w components/o-forms -- origami-build-tools test

--- a/.github/workflows/test-components-o-ft-affiliate-ribbon.yml
+++ b/.github/workflows/test-components-o-ft-affiliate-ribbon.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-ft-affiliate-ribbon -- origami-build-tools verify
     - run: npx npm x -w components/o-ft-affiliate-ribbon -- origami-build-tools test || npx npm x -w components/o-ft-affiliate-ribbon -- origami-build-tools test

--- a/.github/workflows/test-components-o-grid.yml
+++ b/.github/workflows/test-components-o-grid.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-grid -- origami-build-tools verify
     - run: npx npm x -w components/o-grid -- origami-build-tools test || npx npm x -w components/o-grid -- origami-build-tools test

--- a/.github/workflows/test-components-o-header-services.yml
+++ b/.github/workflows/test-components-o-header-services.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-header-services -- origami-build-tools verify
     - run: npx npm x -w components/o-header-services -- origami-build-tools test || npx npm x -w components/o-header-services -- origami-build-tools test

--- a/.github/workflows/test-components-o-header.yml
+++ b/.github/workflows/test-components-o-header.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-header -- origami-build-tools verify
     - run: npx npm x -w components/o-header -- origami-build-tools test || npx npm x -w components/o-header -- origami-build-tools test

--- a/.github/workflows/test-components-o-icons.yml
+++ b/.github/workflows/test-components-o-icons.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-icons -- origami-build-tools verify
     - run: npx npm x -w components/o-icons -- origami-build-tools test || npx npm x -w components/o-icons -- origami-build-tools test

--- a/.github/workflows/test-components-o-labels.yml
+++ b/.github/workflows/test-components-o-labels.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-labels -- origami-build-tools verify
     - run: npx npm x -w components/o-labels -- origami-build-tools test || npx npm x -w components/o-labels -- origami-build-tools test

--- a/.github/workflows/test-components-o-layout.yml
+++ b/.github/workflows/test-components-o-layout.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-layout -- origami-build-tools verify
     - run: npx npm x -w components/o-layout -- origami-build-tools test || npx npm x -w components/o-layout -- origami-build-tools test

--- a/.github/workflows/test-components-o-lazy-load.yml
+++ b/.github/workflows/test-components-o-lazy-load.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-lazy-load -- origami-build-tools verify
     - run: npx npm x -w components/o-lazy-load -- origami-build-tools test || npx npm x -w components/o-lazy-load -- origami-build-tools test

--- a/.github/workflows/test-components-o-loading.yml
+++ b/.github/workflows/test-components-o-loading.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-loading -- origami-build-tools verify
     - run: npx npm x -w components/o-loading -- origami-build-tools test || npx npm x -w components/o-loading -- origami-build-tools test

--- a/.github/workflows/test-components-o-message.yml
+++ b/.github/workflows/test-components-o-message.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-message -- origami-build-tools verify
     - run: npx npm x -w components/o-message -- origami-build-tools test || npx npm x -w components/o-message -- origami-build-tools test

--- a/.github/workflows/test-components-o-meter.yml
+++ b/.github/workflows/test-components-o-meter.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-meter -- origami-build-tools verify
     - run: npx npm x -w components/o-meter -- origami-build-tools test || npx npm x -w components/o-meter -- origami-build-tools test

--- a/.github/workflows/test-components-o-normalise.yml
+++ b/.github/workflows/test-components-o-normalise.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-normalise -- origami-build-tools verify
     - run: npx npm x -w components/o-normalise -- origami-build-tools test || npx npm x -w components/o-normalise -- origami-build-tools test

--- a/.github/workflows/test-components-o-overlay.yml
+++ b/.github/workflows/test-components-o-overlay.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-overlay -- origami-build-tools verify
     - run: npx npm x -w components/o-overlay -- origami-build-tools test || npx npm x -w components/o-overlay -- origami-build-tools test

--- a/.github/workflows/test-components-o-quote.yml
+++ b/.github/workflows/test-components-o-quote.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-quote -- origami-build-tools verify
     - run: npx npm x -w components/o-quote -- origami-build-tools test || npx npm x -w components/o-quote -- origami-build-tools test

--- a/.github/workflows/test-components-o-share.yml
+++ b/.github/workflows/test-components-o-share.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-share -- origami-build-tools verify
     - run: npx npm x -w components/o-share -- origami-build-tools test || npx npm x -w components/o-share -- origami-build-tools test

--- a/.github/workflows/test-components-o-spacing.yml
+++ b/.github/workflows/test-components-o-spacing.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-spacing -- origami-build-tools verify
     - run: npx npm x -w components/o-spacing -- origami-build-tools test || npx npm x -w components/o-spacing -- origami-build-tools test

--- a/.github/workflows/test-components-o-stepped-progress.yml
+++ b/.github/workflows/test-components-o-stepped-progress.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-stepped-progress -- origami-build-tools verify
     - run: npx npm x -w components/o-stepped-progress -- origami-build-tools test || npx npm x -w components/o-stepped-progress -- origami-build-tools test

--- a/.github/workflows/test-components-o-subs-card.yml
+++ b/.github/workflows/test-components-o-subs-card.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-subs-card -- origami-build-tools verify
     - run: npx npm x -w components/o-subs-card -- origami-build-tools test || npx npm x -w components/o-subs-card -- origami-build-tools test

--- a/.github/workflows/test-components-o-syntax-highlight.yml
+++ b/.github/workflows/test-components-o-syntax-highlight.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-syntax-highlight -- origami-build-tools verify
     - run: npx npm x -w components/o-syntax-highlight -- origami-build-tools test || npx npm x -w components/o-syntax-highlight -- origami-build-tools test

--- a/.github/workflows/test-components-o-table.yml
+++ b/.github/workflows/test-components-o-table.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-table -- origami-build-tools verify
     - run: npx npm x -w components/o-table -- origami-build-tools test || npx npm x -w components/o-table -- origami-build-tools test

--- a/.github/workflows/test-components-o-tabs.yml
+++ b/.github/workflows/test-components-o-tabs.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-tabs -- origami-build-tools verify
     - run: npx npm x -w components/o-tabs -- origami-build-tools test || npx npm x -w components/o-tabs -- origami-build-tools test

--- a/.github/workflows/test-components-o-teaser-collection.yml
+++ b/.github/workflows/test-components-o-teaser-collection.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-teaser-collection -- origami-build-tools verify
     - run: npx npm x -w components/o-teaser-collection -- origami-build-tools test || npx npm x -w components/o-teaser-collection -- origami-build-tools test

--- a/.github/workflows/test-components-o-teaser.yml
+++ b/.github/workflows/test-components-o-teaser.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-teaser -- origami-build-tools verify
     - run: npx npm x -w components/o-teaser -- origami-build-tools test || npx npm x -w components/o-teaser -- origami-build-tools test

--- a/.github/workflows/test-components-o-toggle.yml
+++ b/.github/workflows/test-components-o-toggle.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-toggle -- origami-build-tools verify
     - run: npx npm x -w components/o-toggle -- origami-build-tools test || npx npm x -w components/o-toggle -- origami-build-tools test

--- a/.github/workflows/test-components-o-tooltip.yml
+++ b/.github/workflows/test-components-o-tooltip.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-tooltip -- origami-build-tools verify
     - run: npx npm x -w components/o-tooltip -- origami-build-tools test || npx npm x -w components/o-tooltip -- origami-build-tools test

--- a/.github/workflows/test-components-o-topper.yml
+++ b/.github/workflows/test-components-o-topper.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-topper -- origami-build-tools verify
     - run: npx npm x -w components/o-topper -- origami-build-tools test || npx npm x -w components/o-topper -- origami-build-tools test

--- a/.github/workflows/test-components-o-typography.yml
+++ b/.github/workflows/test-components-o-typography.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-typography -- origami-build-tools verify
     - run: npx npm x -w components/o-typography -- origami-build-tools test || npx npm x -w components/o-typography -- origami-build-tools test

--- a/.github/workflows/test-components-o-video.yml
+++ b/.github/workflows/test-components-o-video.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-video -- origami-build-tools verify
     - run: npx npm x -w components/o-video -- origami-build-tools test || npx npm x -w components/o-video -- origami-build-tools test

--- a/.github/workflows/test-components-o-viewport.yml
+++ b/.github/workflows/test-components-o-viewport.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-viewport -- origami-build-tools verify
     - run: npx npm x -w components/o-viewport -- origami-build-tools test || npx npm x -w components/o-viewport -- origami-build-tools test

--- a/.github/workflows/test-components-o-visual-effects.yml
+++ b/.github/workflows/test-components-o-visual-effects.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w components/o-visual-effects -- origami-build-tools verify
     - run: npx npm x -w components/o-visual-effects -- origami-build-tools test || npx npm x -w components/o-visual-effects -- origami-build-tools test

--- a/.github/workflows/test-libraries-o-autoinit.yml
+++ b/.github/workflows/test-libraries-o-autoinit.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w libraries/o-autoinit -- origami-build-tools verify
     - run: npx npm x -w libraries/o-autoinit -- origami-build-tools test || npx npm x -w libraries/o-autoinit -- origami-build-tools test

--- a/.github/workflows/test-libraries-o-brand.yml
+++ b/.github/workflows/test-libraries-o-brand.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w libraries/o-brand -- origami-build-tools verify
     - run: npx npm x -w libraries/o-brand -- origami-build-tools test || npx npm x -w libraries/o-brand -- origami-build-tools test

--- a/.github/workflows/test-libraries-o-errors.yml
+++ b/.github/workflows/test-libraries-o-errors.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w libraries/o-errors -- origami-build-tools verify
     - run: npx npm x -w libraries/o-errors -- origami-build-tools test || npx npm x -w libraries/o-errors -- origami-build-tools test

--- a/.github/workflows/test-libraries-o-tracking.yml
+++ b/.github/workflows/test-libraries-o-tracking.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm exec -w libraries/o-tracking -- origami-build-tools verify
     - run: npx npm x -w libraries/o-tracking -- origami-build-tools test || npx npm x -w libraries/o-tracking -- origami-build-tools test

--- a/.github/workflows/test-libraries-o-utils.yml
+++ b/.github/workflows/test-libraries-o-utils.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w libraries/o-utils lint
     - run: npx npm run -w libraries/o-utils test

--- a/.github/workflows/test-presets-eslint-config-origami-component.yml
+++ b/.github/workflows/test-presets-eslint-config-origami-component.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w presets/eslint-config-origami-component lint
     - run: npx npm run -w presets/eslint-config-origami-component test

--- a/.github/workflows/test-presets-remark-preset-lint-origami-component.yml
+++ b/.github/workflows/test-presets-remark-preset-lint-origami-component.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w presets/remark-preset-lint-origami-component lint
     - run: npx npm run -w presets/remark-preset-lint-origami-component test

--- a/.github/workflows/test-presets-stylelint-config-origami-component.yml
+++ b/.github/workflows/test-presets-stylelint-config-origami-component.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w presets/stylelint-config-origami-component lint
     - run: npx npm run -w presets/stylelint-config-origami-component test

--- a/.github/workflows/test-tools-origami-build-tools.yml
+++ b/.github/workflows/test-tools-origami-build-tools.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: npx npm run -w tools/origami-build-tools lint
     - run: npx npm run -w tools/origami-build-tools test

--- a/templates/percy-workflow.yml
+++ b/templates/percy-workflow.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         cache: 'npm'
         node-version: 16
+    - run: npm i -g npm@7
     - run: npm ci
     - run: node ./scripts/percy.js
       env:

--- a/templates/test-workflow.yml
+++ b/templates/test-workflow.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
+    - run: npm i -g npm@7
     - run: npm ci
     - run: <%& lint %>
     - run: <%& test %>


### PR DESCRIPTION
ci started using npm 8 and it is failing our builds:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'origami-build-tools@0.0.0',
npm WARN EBADENGINE   required: { node: '>= 14.16.1', npm: '^7.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.13.0', npm: '8.1.0' }
npm WARN EBADENGINE }
```