### PR TITLE
fix remark-lint-origami-component readme-has-name check

### DIFF
--- a/presets/remark-preset-lint-origami-component/rules/readme-has-name.js
+++ b/presets/remark-preset-lint-origami-component/rules/readme-has-name.js
@@ -9,10 +9,10 @@ function readmeHasName(tree, file) {
 		return
 	}
 
-	let packageJsonPath = join("package.json")
+	let packageJsonPath = join(file.path, "..", "package.json")
 
 	if (!existsSync(packageJsonPath)) {
-		file.message(`${process.cwd()}/package.json not found.`)
+		file.message(`${packageJsonPath} not found.`)
 		return
 	}
 

--- a/scripts/component/lint.bash
+++ b/scripts/component/lint.bash
@@ -8,15 +8,15 @@ verify-origami-json
 verify-package-json
 
 if test -f ".eslintrc.cjs"; then
-    args=(-c ".eslintrc.cjs" --no-error-on-unmatched-pattern)
-    if test -f ".eslintignore"; then
-        args+=(--ignore-path ".eslintignore")
-    fi
-    npx eslint ${args[*]} "**/*.js"
+	 args=(-c ".eslintrc.cjs" --no-error-on-unmatched-pattern)
+	 if test -f ".eslintignore"; then
+		  args+=(--ignore-path ".eslintignore")
+	 fi
+	 npx eslint ${args[*]} "**/*.js"
 fi
 
 if test -f ".stylelintrc.cjs"; then
-    npx stylelint --allow-empty-input --config=".stylelintrc.cjs" "**/*.scss" 
+	 npx stylelint --allow-empty-input --config=".stylelintrc.cjs" "**/*.scss"
 fi
 
 # we need to cd back to root and run remark-cli from there


### PR DESCRIPTION
grab the readme-relative package.json rather than the cwd-relative one