### PR TITLE
backstage: rewrite the o-layout test to be less flakey

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ git lfs install
 
 ### Tips
 
-- If you need to install a new dependency for a component, install it to that
-  component's workspace by running `npm --workspace
-  components/<component-name-here> install <new-dependency>` from the root
 - To run `obt` for a specific component try `npm exec -w components/o-name obt
   dev` from the root
 - If you're working on the storybook configuration and it starts acting weird

--- a/components/o-layout/test/layout.test.js
+++ b/components/o-layout/test/layout.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
-import { assert } from '@open-wc/testing';
+import { setViewport } from '@web/test-runner-commands';
+import { assert, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon/pkg/sinon-esm.js';
 import Layout from '../src/js/layout.js';
 import { docs, docsWithSubHeading, query } from './helpers/fixtures.js';
@@ -47,23 +48,28 @@ describe('Layout', () => {
 			assert.strictEqual(layout.navHeadings.length, 2, `Expected to find two navigation headings but found ${layout.navHeadings.length}.`);
 		});
 
-		it('constructs a nested navigation when a h3 (or lower) follows a h2', (done) => {
+		it('constructs a nested navigation when a h3 (or lower) follows a h2', async () => {
+			await setViewport({ width: 1080, height: 1280 });
 			document.body.innerHTML = docsWithSubHeading;
 			documentationLayoutElement = document.querySelector('.o-layout--docs');
 			new Layout(documentationLayoutElement, {
 				navHeadingSelector: 'h1, h2, h3, h4, h5, h6'
 			});
-			setTimeout(() => {
-				try {
-					assert.dom.equal(
-						documentationLayoutElement.querySelector('.o-layout__sidebar'),
-						`<div class="o-layout__sidebar"><nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2" aria-current="false">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1" aria-current="false">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-1b" aria-current="false">Sub heading 1b</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2" aria-current="false">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2" aria-current="false">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a" aria-current="false">Sub heading a</a></li></ol></li></ol></nav></div>`
-					);
-					done();
-				} catch (error) {
-					done(error);
+			await waitUntil(
+				() => {
+					let link = documentationLayoutElement.querySelector('[href="#this-is-a-h1"]');
+					if (link) {
+						return link.getAttribute('aria-current') === 'location';
+					}
+				},
+				'the correct link never became listed as the current location', {
+					timeout: 2000
 				}
-			}, 200);
+			);
+			assert.dom.equal(
+				documentationLayoutElement.querySelector('.o-layout__sidebar'),
+				`<div class="o-layout__sidebar"><nav class="o-layout__navigation"><ol class="o-layout__unstyled-element"><li class="o-layout__unstyled-element o-layout__navigation-title"><a class="o-layout__unstyled-element" href="#this-is-a-h1" aria-current="location">This is a heading level 1</a></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-h2" aria-current="false">This is a heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-1" aria-current="false">Sub heading 1</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-1b" aria-current="false">Sub heading 1b</a></li><li><a class="o-layout__unstyled-element" href="#sub-heading-2" aria-current="false">Sub heading 2</a></li></ol></li><li class="o-layout__unstyled-element "><a class="o-layout__unstyled-element" href="#this-is-a-second-h2" aria-current="false">This is a second heading level 2</a><ol><li><a class="o-layout__unstyled-element" href="#sub-heading-a" aria-current="false">Sub heading a</a></li></ol></li></ol></nav></div>`
+			);
 		});
 
 		it('does not construct the navigation by default for the query layout', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,7 +6975,7 @@
     },
     "components/o-subs-card": {
       "name": "@financial-times/o-subs-card",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "engines": {
         "npm": "^7"
@@ -7610,6 +7610,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+      "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+      "peer": true,
+      "dependencies": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -10215,6 +10233,21 @@
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
       "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ==",
       "dev": true
+    },
+    "node_modules/@lwc/eslint-plugin-lwc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.1.1.tgz",
+      "integrity": "sha512-e+66ZydcQ0HFs/hIsq2JXMWVDDG2BoYWCG2ZBs/Y23bLFAE+iPFOmli5cHS9QqVOYzx9HlOTkt0h/XweNoQ5xg==",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "@babel/eslint-parser": "^7",
+        "eslint": "^7 || ^8"
+      }
     },
     "node_modules/@mdn/browser-compat-data": {
       "version": "4.0.9",
@@ -23935,6 +23968,14 @@
         }
       }
     },
+    "node_modules/debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -24203,6 +24244,27 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dependencies": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      }
+    },
+    "node_modules/deglob/node_modules/ignore": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/del": {
@@ -34304,13 +34366,11 @@
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "2.8.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34355,13 +34415,11 @@
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "2.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34377,7 +34435,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34389,7 +34446,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34399,7 +34455,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "2.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34415,7 +34470,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34431,7 +34485,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34446,7 +34499,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34457,7 +34509,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "1.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34470,19 +34521,16 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34491,7 +34539,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34500,7 +34547,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "1.8.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34512,7 +34558,6 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "1.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34521,13 +34566,11 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34539,7 +34582,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34553,7 +34595,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34566,7 +34607,6 @@
     },
     "node_modules/npm/node_modules/ajv": {
       "version": "6.12.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34582,7 +34622,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34591,7 +34630,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34606,31 +34644,26 @@
     },
     "node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "1.1.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34643,13 +34676,11 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/asn1": {
       "version": "0.2.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34658,7 +34689,6 @@
     },
     "node_modules/npm/node_modules/assert-plus": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34667,13 +34697,11 @@
     },
     "node_modules/npm/node_modules/asynckit": {
       "version": "0.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aws-sign2": {
       "version": "0.7.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -34682,19 +34710,16 @@
     },
     "node_modules/npm/node_modules/aws4": {
       "version": "1.11.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -34703,7 +34728,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "2.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34720,7 +34744,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34729,7 +34752,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34739,13 +34761,11 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "15.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34774,13 +34794,11 @@
     },
     "node_modules/npm/node_modules/caseless": {
       "version": "0.12.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34796,7 +34814,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -34805,7 +34822,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -34817,7 +34833,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34826,7 +34841,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34839,7 +34853,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34855,7 +34868,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34864,7 +34876,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34873,7 +34884,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
       "version": "4.2.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34887,7 +34897,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34899,7 +34908,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34908,7 +34916,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "4.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34920,7 +34927,6 @@
     },
     "node_modules/npm/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34929,7 +34935,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34941,13 +34946,11 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -34956,16 +34959,15 @@
     },
     "node_modules/npm/node_modules/colors": {
       "version": "1.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34975,7 +34977,6 @@
     },
     "node_modules/npm/node_modules/combined-stream": {
       "version": "1.0.8",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -34987,31 +34988,26 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/dashdash": {
       "version": "1.14.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35023,7 +35019,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35040,13 +35035,11 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35055,7 +35048,6 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35064,7 +35056,6 @@
     },
     "node_modules/npm/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35073,13 +35064,11 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35088,7 +35077,6 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35098,7 +35086,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -35107,7 +35094,6 @@
     },
     "node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35117,22 +35103,20 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35141,13 +35125,11 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/extend": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -35156,31 +35138,26 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -35189,7 +35166,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35201,19 +35177,16 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35233,7 +35206,6 @@
     },
     "node_modules/npm/node_modules/getpass": {
       "version": "0.1.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35242,7 +35214,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "7.1.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35262,13 +35233,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.8",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/har-schema": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -35277,7 +35246,6 @@
     },
     "node_modules/npm/node_modules/har-validator": {
       "version": "5.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35290,7 +35258,6 @@
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35302,7 +35269,6 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35311,13 +35277,11 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "4.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35329,13 +35293,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "4.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35349,7 +35311,6 @@
     },
     "node_modules/npm/node_modules/http-signature": {
       "version": "1.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35364,7 +35325,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35377,7 +35337,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35386,9 +35345,9 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -35398,7 +35357,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "3.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35407,7 +35365,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35416,7 +35373,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35425,13 +35381,11 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35441,13 +35395,11 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -35456,7 +35408,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "2.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35475,13 +35426,11 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "1.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35490,7 +35439,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -35502,7 +35450,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35514,7 +35461,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35523,54 +35469,45 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-typedarray": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/isstream": {
       "version": "0.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-schema": {
       "version": "0.2.3",
-      "extraneous": true,
       "inBundle": true
     },
     "node_modules/npm/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -35579,7 +35516,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -35588,7 +35524,6 @@
       "engines": [
         "node >= 0.2.0"
       ],
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -35597,7 +35532,6 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35609,19 +35543,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "4.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35636,7 +35567,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "2.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35655,7 +35585,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35677,7 +35606,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35686,7 +35614,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "6.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35699,7 +35626,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "2.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35712,7 +35638,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35726,7 +35651,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "4.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35742,7 +35666,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35754,7 +35677,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "2.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35767,7 +35689,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "1.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35780,7 +35701,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35792,7 +35712,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "9.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35819,7 +35738,6 @@
     },
     "node_modules/npm/node_modules/mime-db": {
       "version": "1.49.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35828,7 +35746,6 @@
     },
     "node_modules/npm/node_modules/mime-types": {
       "version": "2.1.32",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35840,7 +35757,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35852,7 +35768,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "3.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35864,7 +35779,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35876,7 +35790,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "1.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35893,7 +35806,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35905,7 +35817,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35915,7 +35826,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35927,7 +35837,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35939,7 +35848,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -35952,7 +35860,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -35964,7 +35871,6 @@
     },
     "node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -35978,19 +35884,16 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35999,7 +35902,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "7.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36023,13 +35925,11 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36045,7 +35945,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36057,7 +35956,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36069,7 +35967,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36083,7 +35980,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36098,7 +35994,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -36113,7 +36008,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "2.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36125,7 +36019,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36134,7 +36027,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -36146,13 +36038,11 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "8.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36166,7 +36056,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "2.2.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36184,7 +36073,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "6.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36196,7 +36084,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "5.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36208,7 +36095,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "11.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36225,13 +36111,11 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "5.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36243,7 +36127,6 @@
     },
     "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36256,7 +36139,6 @@
     },
     "node_modules/npm/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36265,7 +36147,6 @@
     },
     "node_modules/npm/node_modules/oauth-sign": {
       "version": "0.9.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -36274,7 +36155,6 @@
     },
     "node_modules/npm/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36283,7 +36163,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36292,7 +36171,6 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -36301,7 +36179,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36316,7 +36193,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "11.3.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36349,7 +36225,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36360,7 +36235,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36369,19 +36243,16 @@
     },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -36390,7 +36261,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -36399,13 +36269,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36418,7 +36286,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36427,13 +36294,11 @@
     },
     "node_modules/npm/node_modules/psl": {
       "version": "1.8.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/punycode": {
       "version": "2.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36442,7 +36307,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "extraneous": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -36450,7 +36314,6 @@
     },
     "node_modules/npm/node_modules/qs": {
       "version": "6.5.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -36459,7 +36322,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36471,13 +36333,11 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "4.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36492,7 +36352,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36505,7 +36364,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36519,7 +36377,6 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36531,7 +36388,6 @@
     },
     "node_modules/npm/node_modules/request": {
       "version": "2.88.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -36562,7 +36418,6 @@
     },
     "node_modules/npm/node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36576,7 +36431,6 @@
     },
     "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -36589,7 +36443,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36598,7 +36451,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36613,7 +36465,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -36633,13 +36484,11 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36654,19 +36503,16 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36676,7 +36522,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36690,7 +36535,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36704,7 +36548,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -36714,13 +36557,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36730,13 +36571,11 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.10",
-      "extraneous": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sshpk": {
       "version": "1.16.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36761,7 +36600,6 @@
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "8.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36773,7 +36611,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36782,7 +36619,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "2.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36795,7 +36631,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36804,7 +36639,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36816,13 +36650,11 @@
     },
     "node_modules/npm/node_modules/stringify-package": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36834,7 +36666,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36846,7 +36677,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36863,25 +36693,21 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -36893,13 +36719,11 @@
     },
     "node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "Unlicense"
     },
     "node_modules/npm/node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36908,7 +36732,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36917,7 +36740,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36926,7 +36748,6 @@
     },
     "node_modules/npm/node_modules/uri-js": {
       "version": "4.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -36935,13 +36756,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/uuid": {
       "version": "3.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -36950,7 +36769,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -36960,7 +36778,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -36972,7 +36789,6 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36983,13 +36799,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -36998,7 +36812,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "2.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -37013,7 +36826,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -37022,13 +36834,11 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -37040,7 +36850,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -37496,6 +37305,10 @@
     },
     "node_modules/origami-storybook-addon-markdown-tabs": {
       "resolved": "apps/storybook/addons/markdown-tabs",
+      "link": true
+    },
+    "node_modules/origami-tools-helpers": {
+      "resolved": "tools/origami-tools-helpers",
       "link": true
     },
     "node_modules/os-browserify": {
@@ -38366,6 +38179,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dependencies": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pkg-dir": {
@@ -46789,6 +46615,11 @@
       "resolved": "https://registry.npmjs.org/unionize/-/unionize-2.2.0.tgz",
       "integrity": "sha512-lHXiL6LPVuRYBGCLOdUd4GMHoAGqM0HtYHAZcA6pUEiwN1nk+LEYlh8bud7saeL0bkFntJzCPEPVVJeFm3Cqsg=="
     },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -47582,6 +47413,14 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verify-origami-json": {
+      "resolved": "tools/verify-origami-json",
+      "link": true
+    },
+    "node_modules/verify-package-json": {
+      "resolved": "tools/verify-package-json",
+      "link": true
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -49191,6 +49030,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
+        "@lwc/eslint-plugin-lwc": "^1.1.1",
         "eslint-plugin-import": "^2.22.0"
       },
       "devDependencies": {
@@ -50304,30 +50144,11 @@
       "version": "1.30.1",
       "license": "MIT"
     },
-    "tools/origami-build-tools/node_modules/debug-log": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "tools/origami-build-tools/node_modules/default-uid": {
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "tools/origami-build-tools/node_modules/deglob": {
-      "version": "4.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
       }
     },
     "tools/origami-build-tools/node_modules/denodeify": {
@@ -51653,18 +51474,6 @@
         "which": "bin/which"
       }
     },
-    "tools/origami-build-tools/node_modules/pkg-config": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "tools/origami-build-tools/node_modules/pkginfo": {
       "version": "0.3.1",
       "dev": true,
@@ -51995,10 +51804,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "tools/origami-build-tools/node_modules/uniq": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "tools/origami-build-tools/node_modules/universalify": {
       "version": "2.0.0",
       "license": "MIT",
@@ -52181,6 +51986,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "tools/origami-tools-helpers": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "deglob": "^4.0.1"
+      },
+      "bin": {
+        "origami-tools-helpers": "index.js"
       }
     },
     "tools/sass-compilation": {
@@ -52607,6 +52422,73 @@
       "bin": {
         "validate-component-demo-html": "index.js"
       }
+    },
+    "tools/verify-origami-json": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "is-ci": "^3.0.1"
+      },
+      "bin": {
+        "verify-origami-json": "index.js"
+      }
+    },
+    "tools/verify-origami-json/node_modules/ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+    },
+    "tools/verify-origami-json/node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "tools/verify-package-json": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "is-ci": "^3.0.1",
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "verify-package-json": "index.js"
+      }
+    },
+    "tools/verify-package-json/node_modules/ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+    },
+    "tools/verify-package-json/node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "tools/verify-package-json/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     }
   },
   "dependencies": {
@@ -52683,6 +52565,17 @@
         "json5": "^2.1.2",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+      "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+      "peer": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
@@ -54842,6 +54735,14 @@
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
       "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ==",
       "dev": true
+    },
+    "@lwc/eslint-plugin-lwc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.1.1.tgz",
+      "integrity": "sha512-e+66ZydcQ0HFs/hIsq2JXMWVDDG2BoYWCG2ZBs/Y23bLFAE+iPFOmli5cHS9QqVOYzx9HlOTkt0h/XweNoQ5xg==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "@mdn/browser-compat-data": {
       "version": "4.0.9",
@@ -65689,6 +65590,11 @@
         "ms": "2.1.2"
       }
     },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -65896,6 +65802,26 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
         }
       }
     },
@@ -66888,6 +66814,7 @@
     "eslint-config-origami-component": {
       "version": "file:presets/eslint-config-origami-component",
       "requires": {
+        "@lwc/eslint-plugin-lwc": "^1.1.1",
         "eslint-plugin-import": "^2.22.0",
         "mocha": "^8.0.1",
         "proclaim": "^3.4.2"
@@ -73642,13 +73569,11 @@
       "dependencies": {
         "@gar/promisify": {
           "version": "1.1.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "@npmcli/arborist": {
           "version": "2.8.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/map-workspaces": "^1.0.2",
@@ -73685,13 +73610,11 @@
         },
         "@npmcli/ci-detect": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "@npmcli/config": {
           "version": "2.3.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ini": "^2.0.0",
             "mkdirp-infer-owner": "^2.0.0",
@@ -73703,7 +73626,6 @@
         "@npmcli/disparity-colors": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ansi-styles": "^4.3.0"
           }
@@ -73711,7 +73633,6 @@
         "@npmcli/fs": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@gar/promisify": "^1.0.1",
             "semver": "^7.3.5"
@@ -73720,7 +73641,6 @@
         "@npmcli/git": {
           "version": "2.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/promise-spawn": "^1.3.2",
             "lru-cache": "^6.0.0",
@@ -73735,7 +73655,6 @@
         "@npmcli/installed-package-contents": {
           "version": "1.0.7",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
@@ -73744,7 +73663,6 @@
         "@npmcli/map-workspaces": {
           "version": "1.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
             "glob": "^7.1.6",
@@ -73755,7 +73673,6 @@
         "@npmcli/metavuln-calculator": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "cacache": "^15.0.5",
             "pacote": "^11.1.11",
@@ -73765,7 +73682,6 @@
         "@npmcli/move-file": {
           "version": "1.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "mkdirp": "^1.0.4",
             "rimraf": "^3.0.2"
@@ -73773,18 +73689,15 @@
         },
         "@npmcli/name-from-folder": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "@npmcli/node-gyp": {
           "version": "1.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "@npmcli/package-json": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1"
           }
@@ -73792,7 +73705,6 @@
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "infer-owner": "^1.0.4"
           }
@@ -73800,7 +73712,6 @@
         "@npmcli/run-script": {
           "version": "1.8.6",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
@@ -73810,18 +73721,15 @@
         },
         "@tootallnate/once": {
           "version": "1.1.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "agent-base": {
           "version": "6.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "debug": "4"
           }
@@ -73829,7 +73737,6 @@
         "agentkeepalive": {
           "version": "4.1.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "debug": "^4.1.0",
             "depd": "^1.1.2",
@@ -73839,7 +73746,6 @@
         "aggregate-error": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
@@ -73848,7 +73754,6 @@
         "ajv": {
           "version": "6.12.6",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -73858,41 +73763,34 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "ansi-styles": {
           "version": "4.3.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.6",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^3.6.0"
@@ -73900,46 +73798,38 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "asn1": {
           "version": "0.2.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "aws4": {
           "version": "1.11.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
@@ -73947,7 +73837,6 @@
         "bin-links": {
           "version": "2.2.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "cmd-shim": "^4.0.1",
             "mkdirp": "^1.0.3",
@@ -73959,13 +73848,11 @@
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -73973,13 +73860,11 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "cacache": {
           "version": "15.3.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/fs": "^1.0.0",
             "@npmcli/move-file": "^1.0.1",
@@ -74003,13 +73888,11 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "chalk": {
           "version": "4.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -74017,26 +73900,22 @@
         },
         "chownr": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "cidr-regex": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ip-regex": "^4.1.0"
           }
         },
         "clean-stack": {
           "version": "2.2.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "cli-columns": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
@@ -74045,7 +73924,6 @@
         "cli-table3": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -74054,18 +73932,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "3.0.0",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "string-width": {
               "version": "4.2.2",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -74075,7 +73950,6 @@
             "strip-ansi": {
               "version": "6.0.0",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "ansi-regex": "^5.0.0"
               }
@@ -74084,49 +73958,42 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "cmd-shim": {
           "version": "4.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "mkdirp-infer-owner": "^2.0.0"
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "color-convert": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "color-support": {
           "version": "1.1.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true
+          "optional": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
@@ -74135,35 +74002,29 @@
         "combined-stream": {
           "version": "1.0.8",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -74171,50 +74032,42 @@
         "debug": {
           "version": "4.3.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "depd": {
           "version": "1.1.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -74222,13 +74075,11 @@
         },
         "diff": {
           "version": "5.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -74236,79 +74087,66 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "encoding": {
           "version": "0.1.13",
           "bundled": true,
-          "extraneous": true,
+          "optional": true,
           "requires": {
             "iconv-lite": "^0.6.2"
           }
         },
         "env-paths": {
           "version": "2.2.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "err-code": {
           "version": "2.0.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "2.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "gauge": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.2",
@@ -74324,7 +74162,6 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -74332,7 +74169,6 @@
         "glob": {
           "version": "7.1.7",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -74344,18 +74180,15 @@
         },
         "graceful-fs": {
           "version": "4.2.8",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "har-validator": {
           "version": "5.1.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
@@ -74364,38 +74197,32 @@
         "has": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "4.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "hosted-git-info": {
           "version": "4.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "http-cache-semantics": {
           "version": "4.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "http-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@tootallnate/once": "1",
             "agent-base": "6",
@@ -74405,7 +74232,6 @@
         "http-signature": {
           "version": "1.2.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -74415,7 +74241,6 @@
         "https-proxy-agent": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
@@ -74424,7 +74249,6 @@
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ms": "^2.0.0"
           }
@@ -74432,7 +74256,7 @@
         "iconv-lite": {
           "version": "0.6.3",
           "bundled": true,
-          "extraneous": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -74440,30 +74264,25 @@
         "ignore-walk": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -74471,18 +74290,15 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "ini": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "init-package-json": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "glob": "^7.1.1",
             "npm-package-arg": "^8.1.2",
@@ -74496,18 +74312,15 @@
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "ip-regex": {
           "version": "4.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "is-cidr": {
           "version": "4.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "cidr-regex": "^3.1.1"
           }
@@ -74515,75 +74328,61 @@
         "is-core-module": {
           "version": "2.6.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "has": "^1.0.3"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -74593,18 +74392,15 @@
         },
         "just-diff": {
           "version": "3.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "just-diff-apply": {
           "version": "3.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "libnpmaccess": {
           "version": "4.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
@@ -74615,7 +74411,6 @@
         "libnpmdiff": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/disparity-colors": "^1.0.1",
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -74630,7 +74425,6 @@
         "libnpmexec": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/arborist": "^2.3.0",
             "@npmcli/ci-detect": "^1.3.0",
@@ -74648,7 +74442,6 @@
         "libnpmfund": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/arborist": "^2.5.0"
           }
@@ -74656,7 +74449,6 @@
         "libnpmhook": {
           "version": "6.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^11.0.0"
@@ -74665,7 +74457,6 @@
         "libnpmorg": {
           "version": "2.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^11.0.0"
@@ -74674,7 +74465,6 @@
         "libnpmpack": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/run-script": "^1.8.3",
             "npm-package-arg": "^8.1.0",
@@ -74684,7 +74474,6 @@
         "libnpmpublish": {
           "version": "4.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "normalize-package-data": "^3.0.2",
             "npm-package-arg": "^8.1.2",
@@ -74696,7 +74485,6 @@
         "libnpmsearch": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "npm-registry-fetch": "^11.0.0"
           }
@@ -74704,7 +74492,6 @@
         "libnpmteam": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^11.0.0"
@@ -74713,7 +74500,6 @@
         "libnpmversion": {
           "version": "1.2.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/git": "^2.0.7",
             "@npmcli/run-script": "^1.8.4",
@@ -74725,7 +74511,6 @@
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -74733,7 +74518,6 @@
         "make-fetch-happen": {
           "version": "9.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "agentkeepalive": "^4.1.3",
             "cacache": "^15.2.0",
@@ -74755,13 +74539,11 @@
         },
         "mime-db": {
           "version": "1.49.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.32",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "mime-db": "1.49.0"
           }
@@ -74769,7 +74551,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -74777,7 +74558,6 @@
         "minipass": {
           "version": "3.1.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -74785,7 +74565,6 @@
         "minipass-collect": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -74793,7 +74572,6 @@
         "minipass-fetch": {
           "version": "1.4.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "encoding": "^0.1.12",
             "minipass": "^3.1.0",
@@ -74804,7 +74582,6 @@
         "minipass-flush": {
           "version": "1.0.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -74812,7 +74589,6 @@
         "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "jsonparse": "^1.3.1",
             "minipass": "^3.0.0"
@@ -74821,7 +74597,6 @@
         "minipass-pipeline": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -74829,7 +74604,6 @@
         "minipass-sized": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -74837,7 +74611,6 @@
         "minizlib": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
@@ -74845,13 +74618,11 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "mkdirp-infer-owner": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "chownr": "^2.0.0",
             "infer-owner": "^1.0.4",
@@ -74860,23 +74631,19 @@
         },
         "ms": {
           "version": "2.1.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "negotiator": {
           "version": "0.6.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "node-gyp": {
           "version": "7.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -74892,13 +74659,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -74913,7 +74678,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -74921,7 +74685,6 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -74932,7 +74695,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -74944,7 +74706,6 @@
         "nopt": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "abbrev": "1"
           }
@@ -74952,7 +74713,6 @@
         "normalize-package-data": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
             "is-core-module": "^2.5.0",
@@ -74963,7 +74723,6 @@
         "npm-audit-report": {
           "version": "2.1.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "chalk": "^4.0.0"
           }
@@ -74971,7 +74730,6 @@
         "npm-bundled": {
           "version": "1.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -74979,20 +74737,17 @@
         "npm-install-checks": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "semver": "^7.1.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "8.1.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
             "semver": "^7.3.4",
@@ -75002,7 +74757,6 @@
         "npm-packlist": {
           "version": "2.2.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "glob": "^7.1.6",
             "ignore-walk": "^3.0.3",
@@ -75013,7 +74767,6 @@
         "npm-pick-manifest": {
           "version": "6.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
             "npm-normalize-package-bin": "^1.0.1",
@@ -75024,7 +74777,6 @@
         "npm-profile": {
           "version": "5.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "npm-registry-fetch": "^11.0.0"
           }
@@ -75032,7 +74784,6 @@
         "npm-registry-fetch": {
           "version": "11.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "make-fetch-happen": "^9.0.1",
             "minipass": "^3.1.3",
@@ -75044,13 +74795,11 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "npmlog": {
           "version": "5.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "are-we-there-yet": "^2.0.0",
             "console-control-strings": "^1.1.0",
@@ -75061,7 +74810,6 @@
             "are-we-there-yet": {
               "version": "2.0.0",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
@@ -75071,36 +74819,30 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "p-map": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aggregate-error": "^3.0.0"
           }
@@ -75108,7 +74850,6 @@
         "pacote": {
           "version": "11.3.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
@@ -75134,7 +74875,6 @@
         "parse-conflict-json": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
             "just-diff": "^3.0.1",
@@ -75143,38 +74883,31 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "proc-log": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "promise-call-limit": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "promise-retry": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "err-code": "^2.0.2",
             "retry": "^0.12.0"
@@ -75183,48 +74916,40 @@
         "promzard": {
           "version": "0.3.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "read": "1"
           }
         },
         "psl": {
           "version": "1.8.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "read": {
           "version": "1.0.7",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "read-package-json": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "glob": "^7.1.1",
             "json-parse-even-better-errors": "^2.3.0",
@@ -75235,7 +74960,6 @@
         "read-package-json-fast": {
           "version": "2.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
             "npm-normalize-package-bin": "^1.0.1"
@@ -75244,7 +74968,6 @@
         "readable-stream": {
           "version": "3.6.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -75254,7 +74977,6 @@
         "readdir-scoped-modules": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -75265,7 +74987,6 @@
         "request": {
           "version": "2.88.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -75292,7 +75013,6 @@
             "form-data": {
               "version": "2.3.3",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -75302,7 +75022,6 @@
             "tough-cookie": {
               "version": "2.5.0",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -75312,54 +75031,45 @@
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "rimraf": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "semver": {
           "version": "7.3.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "smart-buffer": {
           "version": "4.2.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "socks": {
           "version": "2.6.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ip": "^1.1.5",
             "smart-buffer": "^4.1.0"
@@ -75368,7 +75078,6 @@
         "socks-proxy-agent": {
           "version": "6.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "agent-base": "^6.0.2",
             "debug": "^4.3.1",
@@ -75378,7 +75087,6 @@
         "spdx-correct": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -75386,13 +75094,11 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -75400,13 +75106,11 @@
         },
         "spdx-license-ids": {
           "version": "3.0.10",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "sshpk": {
           "version": "1.16.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -75422,7 +75126,6 @@
         "ssri": {
           "version": "8.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "minipass": "^3.1.1"
           }
@@ -75430,7 +75133,6 @@
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -75438,7 +75140,6 @@
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -75446,13 +75147,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
-              "extraneous": true
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
-              "extraneous": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -75461,13 +75160,11 @@
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -75475,7 +75172,6 @@
         "supports-color": {
           "version": "7.2.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -75483,7 +75179,6 @@
         "tar": {
           "version": "6.1.11",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -75495,36 +75190,30 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "treeverse": {
           "version": "1.0.4",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
@@ -75532,7 +75221,6 @@
         "unique-filename": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "unique-slug": "^2.0.0"
           }
@@ -75540,7 +75228,6 @@
         "unique-slug": {
           "version": "2.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
@@ -75548,25 +75235,21 @@
         "uri-js": {
           "version": "4.4.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "punycode": "^2.1.0"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "uuid": {
           "version": "3.4.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -75575,7 +75258,6 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "builtins": "^1.0.3"
           }
@@ -75583,7 +75265,6 @@
         "verror": {
           "version": "1.10.0",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -75592,13 +75273,11 @@
         },
         "walk-up-path": {
           "version": "1.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "defaults": "^1.0.3"
           }
@@ -75606,7 +75285,6 @@
         "which": {
           "version": "2.0.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -75614,20 +75292,17 @@
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "write-file-atomic": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -75637,8 +75312,7 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         }
       }
     },
@@ -76326,22 +76000,8 @@
         "date-fns": {
           "version": "1.30.1"
         },
-        "debug-log": {
-          "version": "1.0.1"
-        },
         "default-uid": {
           "version": "1.0.0"
-        },
-        "deglob": {
-          "version": "4.0.1",
-          "requires": {
-            "find-root": "^1.0.0",
-            "glob": "^7.0.5",
-            "ignore": "^5.0.0",
-            "pkg-config": "^1.1.0",
-            "run-parallel": "^1.1.2",
-            "uniq": "^1.0.1"
-          }
         },
         "denodeify": {
           "version": "1.2.1",
@@ -77149,14 +76809,6 @@
             }
           }
         },
-        "pkg-config": {
-          "version": "1.1.1",
-          "requires": {
-            "debug-log": "^1.0.0",
-            "find-root": "^1.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
         "pkginfo": {
           "version": "0.3.1",
           "dev": true
@@ -77348,9 +77000,6 @@
         },
         "type-fest": {
           "version": "0.20.2"
-        },
-        "uniq": {
-          "version": "1.0.1"
         },
         "universalify": {
           "version": "2.0.0"
@@ -81956,6 +81605,12 @@
         }
       }
     },
+    "origami-tools-helpers": {
+      "version": "file:tools/origami-tools-helpers",
+      "requires": {
+        "deglob": "^4.0.1"
+      }
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -82632,6 +82287,16 @@
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "requires": {
         "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -89702,6 +89367,11 @@
       "resolved": "https://registry.npmjs.org/unionize/-/unionize-2.2.0.tgz",
       "integrity": "sha512-lHXiL6LPVuRYBGCLOdUd4GMHoAGqM0HtYHAZcA6pUEiwN1nk+LEYlh8bud7saeL0bkFntJzCPEPVVJeFm3Cqsg=="
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -90314,6 +89984,57 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verify-origami-json": {
+      "version": "file:tools/verify-origami-json",
+      "requires": {
+        "is-ci": "^3.0.1"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+        },
+        "is-ci": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+          "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+          "requires": {
+            "ci-info": "^3.2.0"
+          }
+        }
+      }
+    },
+    "verify-package-json": {
+      "version": "file:tools/verify-package-json",
+      "requires": {
+        "is-ci": "^3.0.1",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+        },
+        "is-ci": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+          "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+          "requires": {
+            "ci-info": "^3.2.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "verror": {
       "version": "1.10.0",

--- a/presets/eslint-config-origami-component/config.js
+++ b/presets/eslint-config-origami-component/config.js
@@ -2,18 +2,17 @@
 
 module.exports = {
 	parserOptions: {
-		ecmaVersion: 7,
 		sourceType: "module",
 		ecmaFeatures: {
 			jsx: true,
 		},
 	},
 	env: {
-		es6: true,
+		es2021: true,
 		browser: true,
 		node: true,
 	},
-	plugins: ["import"],
+	plugins: ["import", "@lwc/eslint-plugin-lwc"],
 	rules: {
 		"import/extensions": ["warn", "ignorePackages"],
 		"no-unused-vars": "error",
@@ -121,6 +120,7 @@ module.exports = {
 		curly: "error",
 		radix: "error",
 		yoda: "error",
+		"@lwc/lwc/no-async-await": "error",
 	},
 	globals: {
 		require: false,
@@ -128,4 +128,12 @@ module.exports = {
 		exports: false,
 		requireText: false,
 	},
+   "overrides": [
+      {
+        "files": ["test/**/*.js"],
+        "rules": {
+          "@lwc/lwc/no-async-await": "off"
+        }
+      }
+    ]
 }

--- a/presets/eslint-config-origami-component/package.json
+++ b/presets/eslint-config-origami-component/package.json
@@ -10,6 +10,7 @@
     "proclaim": "^3.4.2"
   },
   "dependencies": {
+    "@lwc/eslint-plugin-lwc": "^1.1.1",
     "eslint-plugin-import": "^2.22.0"
   }
 }


### PR DESCRIPTION
The changes applied at to increase the viewport to one we know will work and to use `waitUntil` (https://open-wc.org/docs/testing/helpers/#waituntil) to periodically poll the dom until the aria-current attribute has been updated

This should resolve https://github.com/Financial-Times/origami/issues/329