### PR TITLE
Allow configuring the path to the manage cookies page

### DIFF
--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -113,6 +113,16 @@ const cookieMessage = new oCookieMessage(null, { theme: 'alternative' });
 ```
 
 
+### Custom Cookie Management path
+
+To use a different cookie management path, use the `manageCookiesPath` option:
+
+```js
+import oCookieMessage from '@financial-times/o-cookie-message';
+const cookieMessage = new oCookieMessage(null, { manageCookiesPath: 'preferences/manage-cookies' });
+```
+
+
 ### Firing an oDomContentLoaded event
 
 ```js

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -55,7 +55,7 @@ class CookieMessage {
 			manageCookiesPath = 'preferences/cookies';
 		}
 
-		if (typeof this.options.manageCookiesPath === "string") {
+		if (typeof this.options.manageCookiesPath === 'string') {
 			manageCookiesPath = this.options.manageCookiesPath;
 		}
 
@@ -64,7 +64,7 @@ class CookieMessage {
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
 			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
 			manageCookiesUrl: `https://cookies.${domain}/${manageCookiesPath}?redirect=${redirect}&cookieDomain=.${domain}`,
-			consentCookieName: 'FTCookieConsentGDPR'
+			consentCookieName: 'FTCookieConsentGDPR',
 		};
 	}
 

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -1,21 +1,4 @@
 class CookieMessage {
-	static getCookieInfo() {
-		let domain = 'ft.com';
-		let manageCookiesPath = 'manage-cookies';
-		if (!/\.ft\.com$/i.test(window.location.hostname)) {
-			// replace www or subdomain
-			domain = window.location.hostname.replace(/^(.*?)\./, '');
-			manageCookiesPath = 'cookies';
-		}
-		const redirect = window.location.href;
-		return {
-			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
-			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
-			manageCookiesUrl: `https://cookies.${domain}/preferences/${manageCookiesPath}?redirect=${redirect}&cookieDomain=.${domain}`,
-			consentCookieName: 'FTCookieConsentGDPR',
-		};
-	}
-
 	constructor(cookieMessageElement, options) {
 		if (cookieMessageElement === null || cookieMessageElement === undefined) {
 			cookieMessageElement = document.createElement('div');
@@ -39,7 +22,7 @@ class CookieMessage {
 
 		this.options.theme = this.options.theme ? 'alternative' : null;
 
-		this.cookieInfo = CookieMessage.getCookieInfo();
+		this.cookieInfo = this.getCookieInfo();
 
 		if (this.shouldShowCookieMessage()) {
 			this.createCookieMessage();
@@ -60,6 +43,29 @@ class CookieMessage {
 		this._eventListeners.push({
 			target: window, type: 'pageshow', listener: pageshowListener
 		});
+	}
+
+	getCookieInfo() {
+		let domain = 'ft.com';
+		let manageCookiesPath = 'preferences/manage-cookies';
+
+		if (!/\.ft\.com$/i.test(window.location.hostname)) {
+			// replace www or subdomain
+			domain = window.location.hostname.replace(/^(.*?)\./, '');
+			manageCookiesPath = 'preferences/cookies';
+		}
+
+		if (typeof this.options.manageCookiesPath === "string") {
+			manageCookiesPath = this.options.manageCookiesPath;
+		}
+
+		const redirect = window.location.href;
+		return {
+			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
+			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
+			manageCookiesUrl: `https://cookies.${domain}/${manageCookiesPath}?redirect=${redirect}&cookieDomain=.${domain}`,
+			consentCookieName: 'FTCookieConsentGDPR'
+		};
 	}
 
 	createCookieMessage() {


### PR DESCRIPTION
specialist titles used to need it to be on /preferences/cookies, but will be
updating their pages to /preferences/manage-cookies. let's let them
set it.

this code could be less algorithmic. it appears flexible, but is not. it's
tied hard to the server and routing. i feel like maybe the component
should live alongside the server lib it's associated with, rather than
in origami.