### PR TITLE
Make percy snapshot from the demos/local folder which is where the demos live

### DIFF
--- a/scripts/percy.js
+++ b/scripts/percy.js
@@ -67,6 +67,6 @@ try {
 
 async function generatePercySnapshots() {
 	let npxPath = await io.which("npx", true)
-	let outputDir = `${workspace}/demos/percy/`
+	let outputDir = `${workspace}/demos/local/`
 	await $`"${npxPath}" percy snapshot ${outputDir}`
 }


### PR DESCRIPTION
Previously Percy would move all the demos from `demos/local` to `demos/percy` and rename the demos to include the brand in their filename.

In a [previous patch](https://github.com/Financial-Times/origami/pull/450), we stopped doing the moving and renaming of demos but we did not update the percy command to run from `demos/local`