### PR TITLE
fix: explicitly state package should be published publically

### DIFF
--- a/tools/origami-bower-safe-version-supervisor/package.json
+++ b/tools/origami-bower-safe-version-supervisor/package.json
@@ -19,7 +19,7 @@
     "semver-extra": "^3.0.0"
   },
   "private": false,
-	"publishConfig": {
+  "publishConfig": {
     "access": "public"
   }
 }

--- a/tools/origami-bower-safe-version-supervisor/package.json
+++ b/tools/origami-bower-safe-version-supervisor/package.json
@@ -21,5 +21,5 @@
   "private": false,
 	"publishConfig": {
     "access": "public"
-  },
+  }
 }

--- a/tools/origami-bower-safe-version-supervisor/package.json
+++ b/tools/origami-bower-safe-version-supervisor/package.json
@@ -18,5 +18,8 @@
     "semver-bounded": "^2.0.3",
     "semver-extra": "^3.0.0"
   },
-  "private": false
+  "private": false,
+	"publishConfig": {
+    "access": "public"
+  },
 }


### PR DESCRIPTION
This is required the first time a namespaced package is published - the default access for namespace packages is private.

If this is not set in package.json or the npm CLI then this error is shown during publishing:
>npm ERR! code E402
>npm ERR! 402 Payment Required - PUT registry.npmjs.org/@financial-times%2forigami-bower-safe-version-supervisor - You must sign up for private packages