### PR TITLE
fix!: Drop IE9 support in o-stepped-progress

### DIFF
--- a/components/o-stepped-progress/MIGRATION.md
+++ b/components/o-stepped-progress/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migration
 
+## Migrating from v3 to v4
+
+Support for IE9 has been dropped. No other changes.
+
 ## Migrating from v2 to v3
 
 Support for Bower and version 2 of the Origami Build Service have been removed.

--- a/components/o-stepped-progress/README.md
+++ b/components/o-stepped-progress/README.md
@@ -1,4 +1,5 @@
 # o-stepped-progress
+
 Track progress through a multi-step process, such as a form.
 
 - [Usage](#usage)
@@ -183,8 +184,9 @@ This table outlines all of the possible themes you can request in the [`oStepped
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-⚠ maintained | 2 | 2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+⚠ maintained | 3 | 3.2 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+╳ deprecated | 2 | 2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 ╳ deprecated | 1 | 1.0 | N/A |
 
 ## Contact

--- a/components/o-stepped-progress/src/scss/_mixins.scss
+++ b/components/o-stepped-progress/src/scss/_mixins.scss
@@ -57,16 +57,6 @@
 		position: absolute;
 		top: (div(_oSteppedProgressGet('step-size'), 2)) - (div(_oSteppedProgressGet('bar-weight'), 2));
 		background-color: _oSteppedProgressGet('default-color');
-
-		// IE hacks:
-		// The background colour is removed for IE9, because
-		// the steps are stacked vertically there. However the
-		// hack also targets IE10/11, so we have to re-add the
-		// background colour using a different hack
-		background-color: transparent\9; // stylelint-disable-line declaration-block-no-duplicate-properties
-		@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-			background-color: _oSteppedProgressGet('default-color');
-		}
 	}
 
 	.o-stepped-progress__steps {
@@ -165,16 +155,6 @@
 			right: 50%;
 			z-index: -5;
 			background-color: _oSteppedProgressGet('interacted-color');
-
-			// IE hacks:
-			// The background colour is removed for IE9, because
-			// the steps are stacked vertically there. However the
-			// hack also targets IE10/11, so we have to re-add the
-			// background colour using a different hack
-			background-color: transparent\9; // stylelint-disable-line declaration-block-no-duplicate-properties
-			@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-				background-color: _oSteppedProgressGet('interacted-color');
-			}
 		}
 	}
 


### PR DESCRIPTION
We currently have two hacks, one for IE9 and one that overrides the hack for
IE10 and IE11. We don't support IE9 so instead of doing two things we can do
none, which is the number of things I prefer to do.

I'm releasing this as a breaking change, but really I don't think it is because
I don't think we ever told anyone we support IE9 and this component was made
after we no longer supported IE9. What ya gonna do, though? call the cops?

live laugh love

stay humble

🧱