### PR TITLE
fix: remove the files attribute so we publish the correct files

### DIFF
--- a/libraries/sass-mq/package.json
+++ b/libraries/sass-mq/package.json
@@ -21,13 +21,7 @@
     "sassdoc.sh",
     "scripts"
   ],
-  "files": [
-    "_mq.scss",
-    "LICENSE.md",
-    "README.md",
-    "sass/index.scss"
-  ],
-  "main": "_mq.scss",
+  "main": "index.scss",
   "scripts": {
     "test": "true | sh ./scripts/test.sh 2>&1 | cat",
     "lint": "exit 0",
@@ -51,7 +45,7 @@
   "homepage": "https://sass-mq.github.io/sass-mq/",
   "eyeglass": {
     "needs": ">= 0.8.2",
-    "sassDir": "./_mq.scss",
+    "sassDir": "./index.scss",
     "exports": false
   },
   "peerDependencies": {


### PR DESCRIPTION
This library was not publishing the index.scss file. This pr makes it so all files not in the package.json.ignore are published, including index.scss