### PR TITLE
Move all demo dependencies into devdependencies from origami.json

### DIFF
--- a/components/n-notification/demos/src/main.scss
+++ b/components/n-notification/demos/src/main.scss
@@ -1,5 +1,12 @@
 $n-notification-is-silent: false;
 @import "../../main";
+@import "@financial-times/o-buttons/main";
+@import "@financial-times/o-normalise/main";
+@import '@financial-times/o-fonts/main';
+
+@include oButtons();
+@include oNormalise();
+@include oFonts();
 
 body {
 	display: grid;

--- a/components/n-notification/origami.json
+++ b/components/n-notification/origami.json
@@ -10,11 +10,6 @@
 	},
 	"supportStatus": "experimental",
 	"demosDefaults": {
-		"dependencies": [
-			"o-fonts@^4.0.0",
-			"o-buttons@^6.0.0",
-			"o-normalise@^2.0.0"
-		],
 		"sass": "demos/src/main.scss",
 		"js": "demos/src/main.js"
 	},

--- a/components/n-notification/package.json
+++ b/components/n-notification/package.json
@@ -23,9 +23,9 @@
     "@financial-times/o-typography": "^7.0.3"
   },
   "devDependencies": {
-    "@financial-times/o-fonts": "^4.0.0",
-    "@financial-times/o-buttons": "^6.0.0",
-    "@financial-times/o-normalise": "^2.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "scripts": {
     "build": "bash ../../scripts/component/build.bash",

--- a/components/n-notification/package.json
+++ b/components/n-notification/package.json
@@ -22,6 +22,11 @@
     "@financial-times/o-colors": "^6.1.1",
     "@financial-times/o-typography": "^7.0.3"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts": "^4.0.0",
+    "@financial-times/o-buttons": "^6.0.0",
+    "@financial-times/o-normalise": "^2.0.0"
+  },
   "scripts": {
     "build": "bash ../../scripts/component/build.bash",
     "test": "bash ../../scripts/component/test.bash",

--- a/components/o-audio/origami.json
+++ b/components/o-audio/origami.json
@@ -12,8 +12,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": ""
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-autocomplete/demos/src/dynamic-complex/dynamic-complex.js
+++ b/components/o-autocomplete/demos/src/dynamic-complex/dynamic-complex.js
@@ -1,6 +1,7 @@
 import Autocomplete from '../../../main.js';
 import {data} from './data.js';
-
+import oForms from '@financial-times/o-forms';
+oForms.init();
 /**
  * @typedef {object} CustomOption
  * @property {string} Continent_Code - 2 letter continent code

--- a/components/o-autocomplete/demos/src/dynamic-delayed/dynamic-delayed.js
+++ b/components/o-autocomplete/demos/src/dynamic-delayed/dynamic-delayed.js
@@ -1,5 +1,7 @@
 import '../../../main.js';
-
+import {debounce} from '@financial-times/o-utils';
+import oForms from '@financial-times/o-forms';
+oForms.init();
 /**
  * @typedef {Function} PopulateOptions
  * @property {Array<string>} options - The options which match the rext which was typed into the autocomplete by the user
@@ -292,7 +294,7 @@ function customSuggestions(query, populateOptions) {
 	}, 1000);
 }
 
-window.customSuggestions = window.Origami['o-utils'].debounce(customSuggestions, 100);
+window.customSuggestions = debounce(customSuggestions, 100);
 
 document.addEventListener('DOMContentLoaded', function() {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));

--- a/components/o-autocomplete/demos/src/dynamic/dynamic.js
+++ b/components/o-autocomplete/demos/src/dynamic/dynamic.js
@@ -1,5 +1,6 @@
 import '../../../main.js';
-
+import oForms from '@financial-times/o-forms';
+oForms.init();
 /**
  * @typedef {Function} PopulateOptions
  * @property {Array<string>} options - The options which match the rext which was typed into the autocomplete by the user

--- a/components/o-autocomplete/demos/src/shared.scss
+++ b/components/o-autocomplete/demos/src/shared.scss
@@ -1,5 +1,9 @@
 @import '../../main';
+@import "@financial-times/o-normalise/main";
+@import "@financial-times/o-forms/main";
 
+@include oNormalise();
+@include oForms();
 
 body {
 	box-sizing: border-box;

--- a/components/o-autocomplete/demos/src/static/static.js
+++ b/components/o-autocomplete/demos/src/static/static.js
@@ -1,5 +1,6 @@
 import '../../../main.js';
-
+import oForms from '@financial-times/o-forms';
 document.addEventListener('DOMContentLoaded', function() {
+	oForms.init();
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });

--- a/components/o-autocomplete/origami.json
+++ b/components/o-autocomplete/origami.json
@@ -21,12 +21,7 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/shared.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-forms@^9.0.0",
-			"o-normalise@^3.0.0",
-			"o-utils@^2.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-autocomplete/package.json
+++ b/components/o-autocomplete/package.json
@@ -39,6 +39,11 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-forms":"^9.0.0",
+    "@financial-times/o-normalise":"^3.0.0",
+    "@financial-times/o-utils":"^2.0.0"
+  },
   "dependencies": {
     "@financial-times/accessible-autocomplete": "^2.1.2"
   },

--- a/components/o-autocomplete/package.json
+++ b/components/o-autocomplete/package.json
@@ -34,15 +34,15 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.1",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-forms":"^9.0.0",
-    "@financial-times/o-normalise":"^3.0.0",
-    "@financial-times/o-utils":"^2.0.0"
+    "@financial-times/o-forms": "^9.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-utils": "^2.1.0"
   },
   "dependencies": {
     "@financial-times/accessible-autocomplete": "^2.1.2"

--- a/components/o-banner/demos/src/demo.scss
+++ b/components/o-banner/demos/src/demo.scss
@@ -1,7 +1,10 @@
 
 @import '../../main';
-
 @include oBanner();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	@include oTypographySans();

--- a/components/o-banner/origami.json
+++ b/components/o-banner/origami.json
@@ -14,11 +14,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5",
-			"o-normalise@^3"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-banner/package.json
+++ b/components/o-banner/package.json
@@ -31,6 +31,10 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5",
+    "@financial-times/o-normalise":"^3"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-banner/package.json
+++ b/components/o-banner/package.json
@@ -32,8 +32,8 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5",
-    "@financial-times/o-normalise":"^3"
+    "@financial-times/o-fonts": "^5",
+    "@financial-times/o-normalise": "^3"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-big-number/demos/src/demo.scss
+++ b/components/o-big-number/demos/src/demo.scss
@@ -1,3 +1,6 @@
 @import "../../main";
-
 @include oBigNumber();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();

--- a/components/o-big-number/origami.json
+++ b/components/o-big-number/origami.json
@@ -9,8 +9,7 @@
 	},
 	"supportStatus": "maintained",
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss",
-		"dependencies": ["o-fonts@^5.0.0", "o-normalise@^3.0.0"]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-big-number/package.json
+++ b/components/o-big-number/package.json
@@ -21,6 +21,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-big-number/package.json
+++ b/components/o-big-number/package.json
@@ -22,8 +22,8 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-buttons/demos/src/demo.scss
+++ b/components/o-buttons/demos/src/demo.scss
@@ -1,4 +1,8 @@
 @import "../../main";
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 html {
 	background-color: oColorsByUsecase('page', 'background');

--- a/components/o-buttons/origami.json
+++ b/components/o-buttons/origami.json
@@ -13,11 +13,7 @@
 	},
 	"supportStatus": "active",
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-buttons/package.json
+++ b/components/o-buttons/package.json
@@ -22,12 +22,12 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-buttons/package.json
+++ b/components/o-buttons/package.json
@@ -25,6 +25,10 @@
     "@financial-times/o-normalise": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-colors/demos/src/color-mixer/color-mixer.js
+++ b/components/o-colors/demos/src/color-mixer/color-mixer.js
@@ -1,3 +1,4 @@
+import "@financial-times/o-autoinit";
 import { getContrastRatio } from '../shared/contrast-ratio.js';
 import { getHexValues, mixHexes } from '../shared/colors-mix.js';
 

--- a/components/o-colors/demos/src/color-mixer/color-mixer.scss
+++ b/components/o-colors/demos/src/color-mixer/color-mixer.scss
@@ -1,7 +1,12 @@
 // Import colors module
 @import '../../../main';
 @include oColors();
-
+@import '@financial-times/o-forms/main';
+@include oForms();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-syntax-highlight/main';
+@include oSyntaxHighlight();
 :root {
 	--color: #000000;
 	--background: #ffffff;

--- a/components/o-colors/demos/src/contrast-checker/contrast-checker.js
+++ b/components/o-colors/demos/src/contrast-checker/contrast-checker.js
@@ -1,9 +1,14 @@
+import "@financial-times/o-autoinit";
 import { getContrastRatio, getWCAGRating } from '../shared/contrast-ratio.js';
 import { getHexValues, mixHexes, expandHexValues } from '../shared/colors-mix.js';
 import Tabs from "@financial-times/o-tabs";
+import Forms from "@financial-times/o-forms";
+import Overlay from "@financial-times/o-overlay";
 
 document.addEventListener('DOMContentLoaded', () => {
 	Tabs.init();
+	Forms.init();
+	Overlay.init();
 	const form = document.forms[0];
 	const foreground = form['foreground'];
 	const background = form['background'];
@@ -14,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	showContrastRatio(foreground, background);
 
 	document.querySelector('.trigger-input').addEventListener('click', () => {
-		Origami['o-overlay'].getOverlays()['mixer-overlay'].open(); //eslint-disable-line no-undef
+		Overlay.getOverlays()['mixer-overlay'].open(); //eslint-disable-line no-undef
 	});
 });
 

--- a/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
+++ b/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
@@ -1,9 +1,16 @@
 // Import colors module
 @import '../../../main';
+@include oColors();
 @import '@financial-times/o-tabs/main';
 @include oTabs();
-@include oColors();
-
+@import '@financial-times/o-forms/main';
+@include oForms();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
+@import '@financial-times/o-overlay/main';
+@include oOverlay();
 @mixin swatchStyle() {
 	appearance: none;
 	border: 1px solid lightgrey;

--- a/components/o-colors/demos/src/demo.js
+++ b/components/o-colors/demos/src/demo.js
@@ -1,3 +1,5 @@
+import "@financial-times/o-autoinit";
+
 const oCopyClass = 'o-copy-true';
 
 function oColorsDemoPalette() {

--- a/components/o-colors/demos/src/demo.scss
+++ b/components/o-colors/demos/src/demo.scss
@@ -1,6 +1,11 @@
 // Import colors module
 @import '../../main';
 @include oColors();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+
 
 body {
 	box-sizing: border-box;

--- a/components/o-colors/origami.json
+++ b/components/o-colors/origami.json
@@ -15,12 +15,7 @@
 	"supportStatus": "active",
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0",
-			"o-autoinit@^3.0.0"
-		]
+		"js": "demos/src/demo.js"
 	},
 	"demos": [
 		{
@@ -32,15 +27,6 @@
 			"template": "demos/src/contrast-checker/index.mustache",
 			"description": "",
 			"display_html": false,
-			"dependencies": [
-				"o-buttons@^7.0.0",
-				"o-fonts@^5.0.0",
-				"o-forms@^9.0.0",
-				"o-normalise@^3.0.0",
-				"o-overlay@^4.0.0",
-				"o-syntax-highlight@^4.0.0",
-				"o-autoinit@^3.0.0"
-			],
 			"brands": [
 				"core"
 			]
@@ -54,14 +40,6 @@
 			"template": "demos/src/color-mixer/index.mustache",
 			"display_html": false,
 			"description": "",
-			"dependencies": [
-				"o-fonts@^5.0.0",
-				"o-forms@^9.0.0",
-				"o-normalise@^3.0.0",
-				"o-overlay@^4.0.0",
-				"o-syntax-highlight@^4.0.0",
-				"o-autoinit@^3.0.0"
-			],
 			"brands": [
 				"core"
 			]
@@ -141,15 +119,6 @@
 			"sass": "demos/src/contrast-checker/contrast-checker.scss",
 			"template": "demos/src/contrast-checker/index.mustache",
 			"display_html": false,
-			"dependencies": [
-				"o-buttons@^7.0.0",
-				"o-fonts@^5.0.0",
-				"o-forms@^9.0.0",
-				"o-normalise@^3.0.0",
-				"o-overlay@^4.0.0",
-				"o-syntax-highlight@^4.0.0",
-				"o-autoinit@^3.0.0"
-			],
 			"description": "",
 			"brands": [
 				"internal"
@@ -163,14 +132,6 @@
 			"sass": "demos/src/color-mixer/color-mixer.scss",
 			"template": "demos/src/color-mixer/index.mustache",
 			"display_html": false,
-			"dependencies": [
-				"o-fonts@^5.0.0",
-				"o-forms@^9.0.0",
-				"o-normalise@^3.0.0",
-				"o-overlay@^4.0.0",
-				"o-syntax-highlight@^4.0.0",
-				"o-autoinit@^3.0.0"
-			],
 			"description": "",
 			"brands": [
 				"internal"

--- a/components/o-colors/package.json
+++ b/components/o-colors/package.json
@@ -30,7 +30,14 @@
     "@financial-times/math": "^1.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-tabs": "^6.2.0"
+    "@financial-times/o-tabs": "^6.2.0",
+    "@financial-times/o-buttons":"^7.0.0",
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-forms":"^9.0.0",
+    "@financial-times/o-normalise":"^3.0.0",
+    "@financial-times/o-overlay":"^4.0.0",
+    "@financial-times/o-syntax-highlight":"^4.0.0",
+    "@financial-times/o-autoinit":"^3.0.0"
   },
   "scripts": {
     "start": "npx serve ./demos/local",

--- a/components/o-colors/package.json
+++ b/components/o-colors/package.json
@@ -31,13 +31,13 @@
   },
   "devDependencies": {
     "@financial-times/o-tabs": "^6.2.0",
-    "@financial-times/o-buttons":"^7.0.0",
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-forms":"^9.0.0",
-    "@financial-times/o-normalise":"^3.0.0",
-    "@financial-times/o-overlay":"^4.0.0",
-    "@financial-times/o-syntax-highlight":"^4.0.0",
-    "@financial-times/o-autoinit":"^3.0.0"
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-forms": "^9.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-overlay": "^4.2.1",
+    "@financial-times/o-syntax-highlight": "^4.2.0",
+    "@financial-times/o-autoinit": "^3.1.0"
   },
   "scripts": {
     "start": "npx serve ./demos/local",

--- a/components/o-colors/package.json
+++ b/components/o-colors/package.json
@@ -26,18 +26,18 @@
     "npm": "^7 || ^8"
   },
   "peerDependencies": {
-    "@financial-times/o-brand": "^4.0.1",
-    "@financial-times/math": "^1.0.0"
+    "@financial-times/math": "^1.0.0",
+    "@financial-times/o-brand": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-tabs": "^6.2.0",
+    "@financial-times/o-autoinit": "^3.1.0",
     "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-fonts": "^5.2.0",
     "@financial-times/o-forms": "^9.2.0",
     "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-overlay": "^4.2.1",
     "@financial-times/o-syntax-highlight": "^4.2.0",
-    "@financial-times/o-autoinit": "^3.1.0"
+    "@financial-times/o-tabs": "^6.2.0"
   },
   "scripts": {
     "start": "npx serve ./demos/local",

--- a/components/o-comments/demos/src/demo.js
+++ b/components/o-comments/demos/src/demo.js
@@ -1,3 +1,7 @@
 import Comments from '../../main.js';
+import Forms from '@financial-times/o-forms';
+import Overlay from '@financial-times/o-overlay';
 
 Comments.init();
+Forms.init();
+Overlay.init();

--- a/components/o-comments/demos/src/stream.scss
+++ b/components/o-comments/demos/src/stream.scss
@@ -1,2 +1,6 @@
 @import '../../main';
 @include oComments;
+@import '@financial-times/o-forms/main';
+@include oForms();
+@import '@financial-times/o-overlay/main';
+@include oOverlay();

--- a/components/o-comments/origami.json
+++ b/components/o-comments/origami.json
@@ -21,11 +21,7 @@
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
 		"data": "demos/src/data/data.json",
-		"documentClasses": "",
-		"dependencies": [
-			"o-forms@^9.0.0",
-			"o-overlay@^4.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -31,6 +31,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-forms":"^9.0.0",
+			"@financial-times/o-overlay":"^4.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -25,15 +25,15 @@
     "@financial-times/o-buttons": "^7.0.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-editorial-typography": "^2.0.1",
-    "@financial-times/o-forms": "^9.0.0",
+    "@financial-times/o-forms": "^9.2.0",
     "@financial-times/o-normalise": "^3.0.0",
-    "@financial-times/o-overlay": "^4.0.0",
+    "@financial-times/o-overlay": "^4.2.1",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-forms":"^9.0.0",
-			"@financial-times/o-overlay":"^4.0.0"
+    "@financial-times/o-forms": "^9.2.0",
+			"@financial-times/o-overlay": "^4.2.1"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@financial-times/o-forms": "^9.2.0",
-			"@financial-times/o-overlay": "^4.2.1"
+    "@financial-times/o-overlay": "^4.2.1"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-cookie-message/demos/src/demo.scss
+++ b/components/o-cookie-message/demos/src/demo.scss
@@ -1,5 +1,9 @@
 @import '../../main';
 @include oCookieMessage();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	font-family: MetricWeb;

--- a/components/o-cookie-message/origami.json
+++ b/components/o-cookie-message/origami.json
@@ -19,10 +19,6 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		],
 		"js": "demos/src/demo.js"
 	},
 	"demos": [

--- a/components/o-cookie-message/package.json
+++ b/components/o-cookie-message/package.json
@@ -36,6 +36,10 @@
     "@financial-times/o-viewport": "^5.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-cookie-message/package.json
+++ b/components/o-cookie-message/package.json
@@ -37,8 +37,8 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-editorial-layout/demos/src/demo.scss
+++ b/components/o-editorial-layout/demos/src/demo.scss
@@ -1,2 +1,8 @@
 @import '../../main';
 @include oEditorialLayout();
+@import '@financial-times/o-grid/main';
+@include oGrid();
+@import '@financial-times/o-colors/main';
+@include oColors();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();

--- a/components/o-editorial-layout/origami.json
+++ b/components/o-editorial-layout/origami.json
@@ -17,12 +17,7 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "o-grid-container o-colors-page-background",
-		"dependencies": [
-			"o-grid@^6.0.0",
-			"o-normalise@^3.0.0",
-			"o-colors@^6.0.0"
-		]
+		"documentClasses": "o-grid-container o-colors-page-background"
 	},
 	"demos": [
 		{

--- a/components/o-editorial-layout/package.json
+++ b/components/o-editorial-layout/package.json
@@ -24,9 +24,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-grid":"^6.0.0",
-    "@financial-times/o-normalise":"^3.0.0",
-    "@financial-times/o-colors":"^6.0.0"
+    "@financial-times/o-grid": "^6.1.1",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-colors": "^6.4.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-editorial-layout/package.json
+++ b/components/o-editorial-layout/package.json
@@ -24,9 +24,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
+    "@financial-times/o-colors": "^6.4.0",
     "@financial-times/o-grid": "^6.1.1",
-    "@financial-times/o-normalise": "^3.2.0",
-    "@financial-times/o-colors": "^6.4.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-editorial-layout/package.json
+++ b/components/o-editorial-layout/package.json
@@ -23,6 +23,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-grid":"^6.0.0",
+    "@financial-times/o-normalise":"^3.0.0",
+    "@financial-times/o-colors":"^6.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-editorial-typography/demos/src/demo.scss
+++ b/components/o-editorial-typography/demos/src/demo.scss
@@ -1,6 +1,8 @@
 @import '../../main';
 
 @include oEditorialTypography();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	background: oColorsByUsecase('page', 'background');

--- a/components/o-editorial-typography/main.scss
+++ b/components/o-editorial-typography/main.scss
@@ -1,6 +1,7 @@
 @import '@financial-times/o-typography/main';
 @import '@financial-times/o-spacing/main';
 @import '@financial-times/o-fonts/main';
+@import '@financial-times/o-colors/main';
 
 @import 'src/scss/variables';
 @import 'src/scss/functions';

--- a/components/o-editorial-typography/origami.json
+++ b/components/o-editorial-typography/origami.json
@@ -17,10 +17,7 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-editorial-typography/package.json
+++ b/components/o-editorial-typography/package.json
@@ -22,6 +22,9 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-editorial-typography/package.json
+++ b/components/o-editorial-typography/package.json
@@ -23,7 +23,7 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-expander/demos/src/demo.scss
+++ b/components/o-expander/demos/src/demo.scss
@@ -1,6 +1,8 @@
 @import "./../../main";
 
 @include oExpander();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 .o-expander--initialized[data-o-expander-shrink-to="height"] .o-expander__content {
 	max-height: 72px;

--- a/components/o-expander/origami.json
+++ b/components/o-expander/origami.json
@@ -21,10 +21,7 @@
 	},
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -29,6 +29,9 @@
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-viewport": "^5.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -30,7 +30,7 @@
     "@financial-times/o-viewport": "^5.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-footer-services/demos/src/demo.scss
+++ b/components/o-footer-services/demos/src/demo.scss
@@ -1,4 +1,8 @@
 @import '../../main';
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 .demo {
 	margin-top: 40px;

--- a/components/o-footer-services/origami.json
+++ b/components/o-footer-services/origami.json
@@ -15,11 +15,7 @@
 	"browserFeatures": {},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-footer-services/package.json
+++ b/components/o-footer-services/package.json
@@ -24,6 +24,10 @@
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-footer-services/package.json
+++ b/components/o-footer-services/package.json
@@ -25,8 +25,8 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-footer-services/package.json
+++ b/components/o-footer-services/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-footer/demos/src/demo.scss
+++ b/components/o-footer/demos/src/demo.scss
@@ -1,6 +1,10 @@
 @import '../../main';
 
 @include oFooter();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	background: oColorsByUsecase('page', 'background');

--- a/components/o-footer/origami.json
+++ b/components/o-footer/origami.json
@@ -21,11 +21,7 @@
 	},
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -29,15 +29,15 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-toggle": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -35,6 +35,10 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-forms/demos/src/demo.scss
+++ b/components/o-forms/demos/src/demo.scss
@@ -1,5 +1,10 @@
 @import "./../../main";
-
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 body {
 	background: oColorsByUsecase(page, background);
 }

--- a/components/o-forms/origami.json
+++ b/components/o-forms/origami.json
@@ -24,12 +24,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "demo",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-buttons@^7.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": "demo"
 	},
 	"demos": [
 		{

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -38,9 +38,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
+    "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-buttons": "^7.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -28,19 +28,19 @@
   "peerDependencies": {
     "@financial-times/math": "^1.0.0",
     "@financial-times/o-brand": "^4.1.0",
-    "@financial-times/o-buttons": "^7.0.0",
+    "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-buttons":"^7.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-buttons": "^7.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -37,6 +37,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-buttons":"^7.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-header-services/demos/src/main.scss
+++ b/components/o-header-services/demos/src/main.scss
@@ -1,5 +1,9 @@
 @import '../../main';
 @include oHeaderServices();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	font-family: arial;

--- a/components/o-header-services/origami.json
+++ b/components/o-header-services/origami.json
@@ -22,10 +22,6 @@
 		]
 	},
 	"demosDefaults": {
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		],
 		"sass": "demos/src/main.scss",
 		"template": "demos/src/header.mustache",
 		"js": "demos/src/main.js"

--- a/components/o-header-services/package.json
+++ b/components/o-header-services/package.json
@@ -34,6 +34,10 @@
     "@financial-times/o-utils": "^2.0.0",
     "@financial-times/o-visual-effects": "^4.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-header-services/package.json
+++ b/components/o-header-services/package.json
@@ -28,15 +28,15 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-utils": "^2.0.0",
     "@financial-times/o-visual-effects": "^4.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-header/demos/src/main.scss
+++ b/components/o-header/demos/src/main.scss
@@ -1,7 +1,12 @@
 @import '../../main';
 
 @include oHeader();
-
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-grid/main';
+@include oGrid();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 body {
 	background-color: oColorsByUsecase('page', 'background');
 }

--- a/components/o-header/origami.json
+++ b/components/o-header/origami.json
@@ -25,12 +25,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/main.scss",
 		"js": "demos/src/main.js",
-		"documentClasses": "core",
-		"dependencies": [
-			"o-grid@^6.0.0",
-			"o-normalise@^3.0.0",
-			"o-fonts@^5.0.0"
-		]
+		"documentClasses": "core"
 	},
 	"demos": [
 		{

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -26,18 +26,18 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-buttons": "^7.0.0",
     "@financial-times/o-colors": "^6.0.1",
-    "@financial-times/o-grid": "^6.0.0",
+    "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.1",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-toggle": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-utils": "^2.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-grid":"^6.0.0",
-			"@financial-times/o-normalise":"^3.0.0",
-			"@financial-times/o-fonts":"^5.0.0"
+    "@financial-times/o-grid": "^6.1.1",
+			"@financial-times/o-normalise": "^3.2.0",
+			"@financial-times/o-fonts": "^5.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -34,6 +34,11 @@
     "@financial-times/o-utils": "^2.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-grid":"^6.0.0",
+			"@financial-times/o-normalise":"^3.0.0",
+			"@financial-times/o-fonts":"^5.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -35,9 +35,9 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
+    "@financial-times/o-fonts": "^5.2.0",
     "@financial-times/o-grid": "^6.1.1",
-			"@financial-times/o-normalise": "^3.2.0",
-			"@financial-times/o-fonts": "^5.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-labels/demos/src/demo.scss
+++ b/components/o-labels/demos/src/demo.scss
@@ -1,6 +1,10 @@
 @import "../../main";
 
 @include oLabels();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	padding: 1rem;

--- a/components/o-labels/origami.json
+++ b/components/o-labels/origami.json
@@ -17,11 +17,7 @@
 		"optional": []
 	},
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-labels/package.json
+++ b/components/o-labels/package.json
@@ -26,6 +26,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-labels/package.json
+++ b/components/o-labels/package.json
@@ -27,8 +27,8 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-layout/demos/src/demo.js
+++ b/components/o-layout/demos/src/demo.js
@@ -1,5 +1,15 @@
 import './../../main.js';
+import Table from "@financial-times/o-table";
+import SyntaxHighlight from "@financial-times/o-syntax-highlight";
+import Tabs from "@financial-times/o-tabs";
+import HeaderServices from "@financial-times/o-header-services";
+import Forms from "@financial-times/o-forms";
 
 document.addEventListener('DOMContentLoaded', () => {
+	Table.init();
+	SyntaxHighlight.init();
+	Tabs.init();
+	HeaderServices.init();
+	Forms.init();
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });

--- a/components/o-layout/demos/src/demo.scss
+++ b/components/o-layout/demos/src/demo.scss
@@ -1,7 +1,23 @@
 @import '../../main';
+@import "@financial-times/o-table/main";
+@import "@financial-times/o-syntax-highlight/main";
+@import "@financial-times/o-tabs/main";
+@import "@financial-times/o-header-services/main";
+@import "@financial-times/o-footer-services/main";
+@import "@financial-times/o-buttons/main";
+@import "@financial-times/o-forms/main";
+@import "@financial-times/o-normalise/main";
+
+@include oTable();
+@include oSyntaxHighlight();
+@include oTabs();
+@include oHeaderServices();
+@include oFooterServices();
+@include oButtons();
+@include oForms();
+@include oNormalise();
 
 @include oLayout();
-
 .demo-button:not(:last-of-type) {
 	margin-right: 0.5rem;
 }

--- a/components/o-layout/origami.json
+++ b/components/o-layout/origami.json
@@ -23,17 +23,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": [
-			"o-table@^9.0.0",
-			"o-syntax-highlight@^4.0.0",
-			"o-tabs@^6.0.0",
-			"o-header-services@^5.0.0",
-			"o-footer-services@^4.0.0",
-			"o-buttons@^7.0.0",
-			"o-forms@^9.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -33,6 +33,16 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-table":"^9.0.0",
+    "@financial-times/o-syntax-highlight":"^4.0.0",
+    "@financial-times/o-tabs":"^6.0.0",
+    "@financial-times/o-header-services":"^5.0.0",
+    "@financial-times/o-footer-services":"^4.0.0",
+    "@financial-times/o-buttons":"^7.0.0",
+    "@financial-times/o-forms":"^9.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -27,21 +27,21 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-fonts": "^5.0.0",
     "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-quote": "^5.0.1",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-table":"^9.0.0",
-    "@financial-times/o-syntax-highlight":"^4.0.0",
-    "@financial-times/o-tabs":"^6.0.0",
-    "@financial-times/o-header-services":"^5.0.0",
-    "@financial-times/o-footer-services":"^4.0.0",
-    "@financial-times/o-buttons":"^7.0.0",
-    "@financial-times/o-forms":"^9.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-table": "^9.2.0",
+    "@financial-times/o-syntax-highlight": "^4.2.0",
+    "@financial-times/o-tabs": "^6.2.0",
+    "@financial-times/o-header-services": "^5.2.0",
+    "@financial-times/o-footer-services": "^4.2.0",
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-forms": "^9.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -34,14 +34,14 @@
     "@financial-times/o-visual-effects": "^4.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-table": "^9.2.0",
-    "@financial-times/o-syntax-highlight": "^4.2.0",
-    "@financial-times/o-tabs": "^6.2.0",
-    "@financial-times/o-header-services": "^5.2.0",
-    "@financial-times/o-footer-services": "^4.2.0",
     "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-footer-services": "^4.2.0",
     "@financial-times/o-forms": "^9.2.0",
-    "@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-header-services": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-syntax-highlight": "^4.2.0",
+    "@financial-times/o-table": "^9.2.0",
+    "@financial-times/o-tabs": "^6.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-message/demos/src/demo.scss
+++ b/components/o-message/demos/src/demo.scss
@@ -1,5 +1,9 @@
 @import '../../main';
 @include oMessage();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	background: oColorsByUsecase('page', 'background');

--- a/components/o-message/origami.json
+++ b/components/o-message/origami.json
@@ -17,11 +17,7 @@
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
 		"template": "demos/src/message-template.mustache",
-		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5",
-			"o-normalise@^3"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-message/package.json
+++ b/components/o-message/package.json
@@ -33,6 +33,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5",
+    "@financial-times/o-normalise":"^3"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-message/package.json
+++ b/components/o-message/package.json
@@ -34,8 +34,8 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5",
-    "@financial-times/o-normalise":"^3"
+    "@financial-times/o-fonts": "^5",
+    "@financial-times/o-normalise": "^3"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-meter/demos/src/demo.scss
+++ b/components/o-meter/demos/src/demo.scss
@@ -1,2 +1,8 @@
 @import '../../main';
 @include oMeter;
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-typography/main';
+@include oTypography();

--- a/components/o-meter/origami.json
+++ b/components/o-meter/origami.json
@@ -12,11 +12,6 @@
 	],
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0",
-			"o-typography@^7.0.0"
-		],
 		"documentClasses": "o-typography-wrapper"
 	},
 	"demos": [

--- a/components/o-meter/package.json
+++ b/components/o-meter/package.json
@@ -28,6 +28,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0",
+    "@financial-times/o-typography":"^7.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-meter/package.json
+++ b/components/o-meter/package.json
@@ -29,9 +29,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0",
-    "@financial-times/o-typography":"^7.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-typography": "^7.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-normalise/demos/src/demo.scss
+++ b/components/o-normalise/demos/src/demo.scss
@@ -1,6 +1,10 @@
 @import '../../main';
 
 @include oNormalise();
+@import '@financial-times/o-colors/main';
+@include oColors();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
 
 body {
 	background: var(--o-colors-paper);

--- a/components/o-normalise/origami.json
+++ b/components/o-normalise/origami.json
@@ -15,11 +15,7 @@
 	"browserFeatures": {},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-colors@^6.0.3",
-			"o-buttons@^7.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-normalise/package.json
+++ b/components/o-normalise/package.json
@@ -27,8 +27,8 @@
     "@financial-times/sass-mq": "^5.0.2"
   },
   "devDependencies": {
-    "@financial-times/o-colors": "^6.4.0",
-    "@financial-times/o-buttons": "^7.2.0"
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-colors": "^6.4.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-normalise/package.json
+++ b/components/o-normalise/package.json
@@ -27,8 +27,8 @@
     "@financial-times/sass-mq": "^5.0.2"
   },
   "devDependencies": {
-    "@financial-times/o-colors":"^6.0.3",
-    "@financial-times/o-buttons":"^7.0.0"
+    "@financial-times/o-colors": "^6.4.0",
+    "@financial-times/o-buttons": "^7.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-normalise/package.json
+++ b/components/o-normalise/package.json
@@ -26,6 +26,10 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/sass-mq": "^5.0.2"
   },
+  "devDependencies": {
+    "@financial-times/o-colors":"^6.0.3",
+    "@financial-times/o-buttons":"^7.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-overlay/demos/src/demo.scss
+++ b/components/o-overlay/demos/src/demo.scss
@@ -1,5 +1,11 @@
 @import "../../main";
 @include oOverlay();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	@include oTypographySans();

--- a/components/o-overlay/demos/src/sliding-notification.scss
+++ b/components/o-overlay/demos/src/sliding-notification.scss
@@ -1,6 +1,11 @@
 @import "../../main";
 @include oOverlay();
-
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 body {
 	padding: oSpacingByName('s3');
 	min-height: 500px;

--- a/components/o-overlay/origami.json
+++ b/components/o-overlay/origami.json
@@ -23,12 +23,7 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-buttons@^7.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"js": "demos/src/demo.js"
 	},
 	"demos": [
 		{

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -39,6 +39,11 @@
     "@financial-times/o-viewport": "^5.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-buttons":"^7.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -40,9 +40,9 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
+    "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-buttons": "^7.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -33,16 +33,16 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-buttons":"^7.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-buttons": "^7.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-quote/demos/src/demo.scss
+++ b/components/o-quote/demos/src/demo.scss
@@ -1,4 +1,8 @@
 @import "./../../main";
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	padding: 1.5rem;

--- a/components/o-quote/origami.json
+++ b/components/o-quote/origami.json
@@ -13,12 +13,7 @@
 	],
 	"supportStatus": "active",
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-editorial-typography@^2.0.0",
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-quote/package.json
+++ b/components/o-quote/package.json
@@ -31,8 +31,8 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-quote/package.json
+++ b/components/o-quote/package.json
@@ -30,6 +30,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-share/demos/src/demo.scss
+++ b/components/o-share/demos/src/demo.scss
@@ -1,5 +1,9 @@
 @import '../../main';
 @include oShare();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 .demo {
 	background-color: oColorsByUsecase('page', 'background');

--- a/components/o-share/origami.json
+++ b/components/o-share/origami.json
@@ -25,10 +25,6 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		],
 		"documentClasses": "demo"
 	},
 	"demos": [

--- a/components/o-share/package.json
+++ b/components/o-share/package.json
@@ -32,13 +32,13 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-share/package.json
+++ b/components/o-share/package.json
@@ -36,6 +36,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-spacing/demos/src/demo.scss
+++ b/components/o-spacing/demos/src/demo.scss
@@ -1,6 +1,12 @@
 @import '../../main';
 
 @include oSpacing();
+@import '@financial-times/o-colors/main';
+@include oColors();
+@import '@financial-times/o-typography/main';
+@include oTypography();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	font-family: if(oBrandIs('whitelabel'), Arial, MetricWeb); // todo use o-typography when it has a new major with sans default

--- a/components/o-spacing/origami.json
+++ b/components/o-spacing/origami.json
@@ -15,12 +15,7 @@
 	],
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "o-typography-wrapper",
-		"dependencies": [
-			"o-normalise@^3.0.0",
-			"o-typography@^7.0.1",
-			"o-colors@^6.0.3"
-		]
+		"documentClasses": "o-typography-wrapper"
 	},
 	"demos": [
 		{

--- a/components/o-spacing/package.json
+++ b/components/o-spacing/package.json
@@ -16,6 +16,11 @@
   "peerDependencies": {
     "@financial-times/math": "^1.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-normalise":"^3.0.0",
+			"@financial-times/o-typography":"^7.0.1",
+			"@financial-times/o-colors":"^6.0.3"
+  },
   "scripts": {
     "start": "npx serve ./demos/local",
     "build": "bash ../../scripts/component/build.bash",

--- a/components/o-spacing/package.json
+++ b/components/o-spacing/package.json
@@ -17,9 +17,9 @@
     "@financial-times/math": "^1.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-normalise":"^3.0.0",
-			"@financial-times/o-typography":"^7.0.1",
-			"@financial-times/o-colors":"^6.0.3"
+    "@financial-times/o-normalise": "^3.2.0",
+			"@financial-times/o-typography": "^7.2.0",
+			"@financial-times/o-colors": "^6.4.0"
   },
   "scripts": {
     "start": "npx serve ./demos/local",

--- a/components/o-spacing/package.json
+++ b/components/o-spacing/package.json
@@ -17,9 +17,9 @@
     "@financial-times/math": "^1.0.0"
   },
   "devDependencies": {
+    "@financial-times/o-colors": "^6.4.0",
     "@financial-times/o-normalise": "^3.2.0",
-			"@financial-times/o-typography": "^7.2.0",
-			"@financial-times/o-colors": "^6.4.0"
+    "@financial-times/o-typography": "^7.2.0"
   },
   "scripts": {
     "start": "npx serve ./demos/local",

--- a/components/o-stepped-progress/demos/src/demo.scss
+++ b/components/o-stepped-progress/demos/src/demo.scss
@@ -1,5 +1,11 @@
 @import '../../main';
 @include oSteppedProgress();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-icons/main';
+@include oIcons();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	background: oColorsByUsecase('page', 'background');

--- a/components/o-stepped-progress/origami.json
+++ b/components/o-stepped-progress/origami.json
@@ -15,12 +15,7 @@
 	"browserFeatures": {},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-icons@^7.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"js": "demos/src/demo.js"
 	},
 	"demos": [
 		{

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -25,15 +25,15 @@
   "peerDependencies": {
     "@financial-times/math": "^1.0.0",
     "@financial-times/o-colors": "^6.0.1",
-    "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-icons": "^7.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-icons":"^7.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-icons": "^7.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -30,6 +30,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-icons":"^7.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-icons": "^7.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-icons": "^7.2.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-subs-card/demos/src/demo.scss
+++ b/components/o-subs-card/demos/src/demo.scss
@@ -1,5 +1,13 @@
 $o-subs-card-is-silent: false;
 @import '../../main';
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-grid/main';
+@include oGrid();
+@import '@financial-times/o-colors/main';
+@include oColors();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 
 body {

--- a/components/o-subs-card/origami.json
+++ b/components/o-subs-card/origami.json
@@ -14,13 +14,7 @@
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-grid@^6.0.0",
-			"o-colors@^6.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-subs-card/package.json
+++ b/components/o-subs-card/package.json
@@ -33,6 +33,12 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-grid":"^6.0.0",
+			"@financial-times/o-colors":"^6.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-subs-card/package.json
+++ b/components/o-subs-card/package.json
@@ -34,10 +34,10 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
+    "@financial-times/o-colors": "^6.4.0",
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-grid": "^6.1.1",
-			"@financial-times/o-colors": "^6.4.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-grid": "^6.1.1",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-subs-card/package.json
+++ b/components/o-subs-card/package.json
@@ -28,16 +28,16 @@
     "@financial-times/o-buttons": "^7.0.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-expander": "^6.0.0",
-    "@financial-times/o-grid": "^6.0.0",
+    "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-normalise": "^3.1.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-grid":"^6.0.0",
-			"@financial-times/o-colors":"^6.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-grid": "^6.1.1",
+			"@financial-times/o-colors": "^6.4.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-table/demos/src/demo.js
+++ b/components/o-table/demos/src/demo.js
@@ -1,5 +1,8 @@
 import './../../main.js';
-
+import Typography from "@financial-times/o-typography";
+import Forms from "@financial-times/o-forms";
 document.addEventListener("DOMContentLoaded", function() {
+	Forms.init();
+	Typography.init();
 	document.dispatchEvent(new CustomEvent("o.DOMContentLoaded"));
 });

--- a/components/o-table/demos/src/demo.scss
+++ b/components/o-table/demos/src/demo.scss
@@ -1,6 +1,16 @@
 @import "./../../main";
 @include oTable();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
 
+@import "@financial-times/o-normalise/main";
+@include oNormalise();
+@import "@financial-times/o-typography/main";
+@include oTypography();
+@import "@financial-times/o-forms/main";
+@include oForms();
+@import "@financial-times/o-buttons/main";
+@include oButtons();
 html {
 	background: oColorsByUsecase('page', 'background');
 }

--- a/components/o-table/origami.json
+++ b/components/o-table/origami.json
@@ -20,14 +20,7 @@
 	},
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5",
-			"o-normalise@^3",
-			"o-typography@^7",
-			"o-forms@^9",
-			"o-buttons@^7"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-table/package.json
+++ b/components/o-table/package.json
@@ -39,11 +39,11 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5",
-    "@financial-times/o-normalise":"^3",
-    "@financial-times/o-typography":"^7",
-    "@financial-times/o-forms":"^9",
-    "@financial-times/o-buttons":"^7"
+    "@financial-times/o-buttons": "^7",
+    "@financial-times/o-fonts": "^5",
+    "@financial-times/o-forms": "^9",
+    "@financial-times/o-normalise": "^3",
+    "@financial-times/o-typography": "^7"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-table/package.json
+++ b/components/o-table/package.json
@@ -38,6 +38,13 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5",
+    "@financial-times/o-normalise":"^3",
+    "@financial-times/o-typography":"^7",
+    "@financial-times/o-forms":"^9",
+    "@financial-times/o-buttons":"^7"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-tabs/demos/src/demo.scss
+++ b/components/o-tabs/demos/src/demo.scss
@@ -2,6 +2,10 @@
 @import "../../main";
 
 @include oTabs();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	margin: 1rem;

--- a/components/o-tabs/origami.json
+++ b/components/o-tabs/origami.json
@@ -26,11 +26,7 @@
 	},
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5",
-			"o-normalise@^3"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-tabs/package.json
+++ b/components/o-tabs/package.json
@@ -25,6 +25,10 @@
     "@financial-times/o-buttons": "^7.0.0",
     "@financial-times/o-colors": "^6.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5",
+    "@financial-times/o-normalise":"^3"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-tabs/package.json
+++ b/components/o-tabs/package.json
@@ -26,8 +26,8 @@
     "@financial-times/o-colors": "^6.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5",
-    "@financial-times/o-normalise":"^3"
+    "@financial-times/o-fonts": "^5",
+    "@financial-times/o-normalise": "^3"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-teaser-collection/demos/src/demo.scss
+++ b/components/o-teaser-collection/demos/src/demo.scss
@@ -1,6 +1,12 @@
 @import '../../main';
 
 @include oTeaserCollection();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-grid/main';
+@include oGrid();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	background-color: oColorsByUsecase('page', 'background');

--- a/components/o-teaser-collection/origami.json
+++ b/components/o-teaser-collection/origami.json
@@ -13,12 +13,7 @@
 	"browserFeatures": {},
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"documentClasses": "",
-		"dependencies": [
-			"o-normalise@^3.0.0",
-			"o-grid@^6.0.0",
-			"o-fonts@^5.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-teaser-collection/package.json
+++ b/components/o-teaser-collection/package.json
@@ -25,15 +25,15 @@
   },
   "peerDependencies": {
     "@financial-times/o-colors": "^6.0.1",
-    "@financial-times/o-grid": "^6.0.0",
+    "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-normalise":"^3.0.0",
-			"@financial-times/o-grid":"^6.0.0",
-			"@financial-times/o-fonts":"^5.0.0"
+    "@financial-times/o-normalise": "^3.2.0",
+			"@financial-times/o-grid": "^6.1.1",
+			"@financial-times/o-fonts": "^5.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-teaser-collection/package.json
+++ b/components/o-teaser-collection/package.json
@@ -31,9 +31,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-normalise": "^3.2.0",
-			"@financial-times/o-grid": "^6.1.1",
-			"@financial-times/o-fonts": "^5.2.0"
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-grid": "^6.1.1",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-teaser-collection/package.json
+++ b/components/o-teaser-collection/package.json
@@ -30,6 +30,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-normalise":"^3.0.0",
+			"@financial-times/o-grid":"^6.0.0",
+			"@financial-times/o-fonts":"^5.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-teaser/origami.json
+++ b/components/o-teaser/origami.json
@@ -14,11 +14,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": [
-			"o-date@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -30,6 +30,10 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-date":"^5.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@financial-times/o-date": "^5.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -26,13 +26,13 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.1",
     "@financial-times/o-labels": "^6.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-date":"^5.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-date": "^5.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-toggle/demos/src/demo.scss
+++ b/components/o-toggle/demos/src/demo.scss
@@ -1,6 +1,14 @@
 @import "./../../main";
 
 @include oToggle();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
+@import '@financial-times/o-spacing/main';
+@include oSpacing();
 
 body {
 	margin: var(--o-spacing-s4, 1rem);

--- a/components/o-toggle/origami.json
+++ b/components/o-toggle/origami.json
@@ -14,13 +14,7 @@
 	"supportStatus": "active",
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-spacing@^3.0.0",
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0",
-			"o-buttons@^7.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-toggle/package.json
+++ b/components/o-toggle/package.json
@@ -21,6 +21,12 @@
     "test": "bash ../../scripts/component/test.bash",
     "lint": "bash ../../scripts/component/lint.bash"
   },
+  "devDependencies": {
+    "@financial-times/o-spacing":"^3.0.0",
+			"@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-normalise":"^3.0.0",
+			"@financial-times/o-buttons":"^7.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-toggle/package.json
+++ b/components/o-toggle/package.json
@@ -22,10 +22,10 @@
     "lint": "bash ../../scripts/component/lint.bash"
   },
   "devDependencies": {
-    "@financial-times/o-spacing":"^3.0.0",
-			"@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-normalise":"^3.0.0",
-			"@financial-times/o-buttons":"^7.0.0"
+    "@financial-times/o-spacing": "^3.2.0",
+			"@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-normalise": "^3.2.0",
+			"@financial-times/o-buttons": "^7.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-toggle/package.json
+++ b/components/o-toggle/package.json
@@ -22,10 +22,10 @@
     "lint": "bash ../../scripts/component/lint.bash"
   },
   "devDependencies": {
-    "@financial-times/o-spacing": "^3.2.0",
-			"@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-normalise": "^3.2.0",
-			"@financial-times/o-buttons": "^7.2.0"
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-spacing": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-tooltip/demos/src/demo.scss
+++ b/components/o-tooltip/demos/src/demo.scss
@@ -1,6 +1,14 @@
 @import '../../main';
 
 @include oTooltip();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-colors/main';
+@include oColors();
+@import '@financial-times/o-buttons/main';
+@include oButtons();
 
 body {
 	@include oTypographySans();

--- a/components/o-tooltip/origami.json
+++ b/components/o-tooltip/origami.json
@@ -16,13 +16,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": [
-			"o-fonts@^5",
-			"o-colors@^6",
-			"o-buttons@^7",
-			"o-normalise@^3"
-		]
+		"documentClasses": ""
 	},
 	"demos": [
 		{

--- a/components/o-tooltip/package.json
+++ b/components/o-tooltip/package.json
@@ -37,10 +37,10 @@
     "@financial-times/o-visual-effects": "^4.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5",
-			"@financial-times/o-colors":"^6",
-			"@financial-times/o-buttons":"^7",
-			"@financial-times/o-normalise":"^3"
+    "@financial-times/o-buttons": "^7",
+    "@financial-times/o-colors": "^6",
+    "@financial-times/o-fonts": "^5",
+    "@financial-times/o-normalise": "^3"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-tooltip/package.json
+++ b/components/o-tooltip/package.json
@@ -36,6 +36,12 @@
     "@financial-times/o-viewport": "^5.0.0",
     "@financial-times/o-visual-effects": "^4.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5",
+			"@financial-times/o-colors":"^6",
+			"@financial-times/o-buttons":"^7",
+			"@financial-times/o-normalise":"^3"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-topper/demos/src/demo.scss
+++ b/components/o-topper/demos/src/demo.scss
@@ -1,6 +1,12 @@
 @import '../../main';
 
 @include oTopper();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+@import '@financial-times/o-typography/main';
+@include oTypography();
 
 body {
 	background: oColorsByUsecase('page', 'background');

--- a/components/o-topper/origami.json
+++ b/components/o-topper/origami.json
@@ -15,12 +15,7 @@
 		"optional": []
 	},
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-typography@^7.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -30,9 +30,9 @@
     "@financial-times/o-typography": "^7.0.1"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-			"@financial-times/o-typography":"^7.0.0",
-			"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+			"@financial-times/o-typography": "^7.2.0",
+			"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -29,6 +29,11 @@
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+			"@financial-times/o-typography":"^7.0.0",
+			"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",
-			"@financial-times/o-typography": "^7.2.0",
-			"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-typography": "^7.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-typography/demos/src/demo.scss
+++ b/components/o-typography/demos/src/demo.scss
@@ -1,6 +1,11 @@
 @import '../../main';
 
 @include oTypography();
+@import '@financial-times/o-grid/main';
+@include oGrid();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
+
 
 body {
 	background-color: oColorsByUsecase('page', 'background');

--- a/components/o-typography/origami.json
+++ b/components/o-typography/origami.json
@@ -20,10 +20,6 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-grid@^6.0.0",
-			"o-normalise@^3.0.0"
-		],
 		"documentClasses": "o-grid-container o-typography--loading-display o-typography--loading-sans o-typography--loading-sans-bold o-typography--loading-display-bold"
 	},
 	"demos": [

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -42,6 +42,10 @@
     "@financial-times/o-normalise": "^3.0.0",
     "@financial-times/o-spacing": "^3.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-grid":"^6.0.0",
+    "@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -37,14 +37,14 @@
     "@financial-times/math": "^1.0.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-fonts": "^5.0.0",
-    "@financial-times/o-grid": "^6.0.0",
+    "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-spacing": "^3.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-grid":"^6.0.0",
-    "@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-grid": "^6.1.1",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-video/demos/src/main.scss
+++ b/components/o-video/demos/src/main.scss
@@ -1,6 +1,10 @@
 @import "../../main";
 
 @include oVideo();
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+@import '@financial-times/o-normalise/main';
+@include oNormalise();
 
 body {
 	font-family: MetricWeb, sans-serif;

--- a/components/o-video/origami.json
+++ b/components/o-video/origami.json
@@ -20,11 +20,7 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/main.scss",
-		"js": "demos/src/demo.js",
-		"dependencies": [
-			"o-fonts@^5.0.0",
-			"o-normalise@^3.0.0"
-		]
+		"js": "demos/src/demo.js"
 	},
 	"demos": [
 		{

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -25,13 +25,13 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.0.0",
+    "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0"
   },
   "devDependencies": {
-    "@financial-times/o-fonts":"^5.0.0",
-		"@financial-times/o-normalise":"^3.0.0"
+    "@financial-times/o-fonts": "^5.2.0",
+		"@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",
-		"@financial-times/o-normalise": "^3.2.0"
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -29,6 +29,10 @@
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0"
   },
+  "devDependencies": {
+    "@financial-times/o-fonts":"^5.0.0",
+		"@financial-times/o-normalise":"^3.0.0"
+  },
   "engines": {
     "npm": "^7 || ^8"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,11 @@
     "components/n-notification": {
       "name": "@financial-times/n-notification",
       "version": "8.2.0",
+      "devDependencies": {
+        "@financial-times/o-buttons": "^6.0.0",
+        "@financial-times/o-fonts": "^4.0.0",
+        "@financial-times/o-normalise": "^2.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -259,6 +264,103 @@
         "@financial-times/o-colors": "^6.1.1",
         "@financial-times/o-typography": "^7.0.3"
       }
+    },
+    "components/n-notification/node_modules/@financial-times/o-brand": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-3.3.0.tgz",
+      "integrity": "sha512-2suZLjeP5WUZ8Rsl/l1+b8E7tKXXLLZTYMEOeYCMsOGzcelioDQfx/cr5U5hZJzd5Njr7dkVDtFLNHeLWnjEhA==",
+      "dev": true
+    },
+    "components/n-notification/node_modules/@financial-times/o-buttons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-6.2.0.tgz",
+      "integrity": "sha512-B44LPK3eMmd4WcQB+EFzdnKw/42Jc+8I1Lx22ZcGbLrEw6TUAgDm0eSkiG/rdWep/gegBnWaF+wxJamnY1GU5A==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-brand": "^3.2.5",
+        "@financial-times/o-colors": "^5.0.0",
+        "@financial-times/o-icons": "^6.0.0",
+        "@financial-times/o-normalise": "^2.0.0",
+        "@financial-times/o-typography": "^6.0.0"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-buttons/node_modules/@financial-times/o-colors": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-5.4.1.tgz",
+      "integrity": "sha512-kNLemhGYJHbyUfxd/sV895bK1QkQu2RgtUFV+xpgpspx6hkWoGuRwVGOCgQVMcXCWpucXzBFRo+e4yoQ8KbHbQ==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-brand": "^3.2.5",
+        "mathsass": "^0.10.1"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-buttons/node_modules/@financial-times/o-typography": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-6.4.6.tgz",
+      "integrity": "sha512-VEmA3klKT5Uqx8LpudUP/cwlJr/6W7sValwCualXtFPYVZgYVnB2jxypciGt//DC4PE5zQna+ZYSBDFBVSh2+g==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-colors": "^5.0.0",
+        "@financial-times/o-fonts": "^4.5.0",
+        "@financial-times/o-grid": "^5.0.0",
+        "@financial-times/o-icons": "^6.0.0",
+        "@financial-times/o-normalise": "^2.0.0",
+        "@financial-times/o-spacing": "^2.0.0",
+        "fontfaceobserver": "^2.0.9"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-fonts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-4.5.0.tgz",
+      "integrity": "sha512-eXlgtgdLRsHb89Yy1pANApbFDkQEHUXzVVW3DdZPNOk6F4kenuCwCumQKyNf2JGdjswfdNRjfTjhzEr37kXfzw==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-brand": "^3.2.5"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-grid": {
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-5.2.12.tgz",
+      "integrity": "sha512-j1oz7ClBvhAvlQoIj62rH0b5g3LAJcSDnWTPBV9/IYKY+xq0pewFOQ+SvK7fn4dzl7UUEVXSjy2iav8zo2OFTg==",
+      "dev": true,
+      "dependencies": {
+        "sass-mq": "^5.0.0"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-6.3.0.tgz",
+      "integrity": "sha512-As9sPICDOhTnWx71K/Pi/3Vdr0tMrPcm0UFfjNm+re2/7khNzCyVQUJ3qFonjvfFgUs31kRYxdvaYccW7nSSdg==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/fticons": "^1.23.1",
+        "@financial-times/o-assets": "^3.4.1"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-normalise": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-2.0.8.tgz",
+      "integrity": "sha512-ahHhDav4BGlatzbzkFH9W/zK0Xt1RSAfLW1F6jw1othcWMaSiIIIrE6nInrpL1NxLxExfaMm80zyJAWqKlxFCA==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-colors": "^5.0.0"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-normalise/node_modules/@financial-times/o-colors": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-5.4.1.tgz",
+      "integrity": "sha512-kNLemhGYJHbyUfxd/sV895bK1QkQu2RgtUFV+xpgpspx6hkWoGuRwVGOCgQVMcXCWpucXzBFRo+e4yoQ8KbHbQ==",
+      "dev": true,
+      "dependencies": {
+        "@financial-times/o-brand": "^3.2.5",
+        "mathsass": "^0.10.1"
+      }
+    },
+    "components/n-notification/node_modules/@financial-times/o-spacing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-2.1.0.tgz",
+      "integrity": "sha512-XbrKZAA79vPHLkab4OgA8CzBEf3tma6tT49c3lRM/W2zxZ4P2wpZU3lpt9wTnKANb7gdP//QBXIsyFcazRaxpA==",
+      "dev": true
     },
     "components/o-audio": {
       "name": "@financial-times/o-audio",
@@ -281,6 +383,11 @@
       "dependencies": {
         "@financial-times/accessible-autocomplete": "^2.1.2"
       },
+      "devDependencies": {
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-utils": "^2.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -301,6 +408,10 @@
       "name": "@financial-times/o-banner",
       "version": "4.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -319,6 +430,10 @@
       "name": "@financial-times/o-big-number",
       "version": "3.1.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -332,6 +447,10 @@
       "name": "@financial-times/o-buttons",
       "version": "7.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -348,6 +467,13 @@
       "version": "6.4.0",
       "license": "MIT",
       "devDependencies": {
+        "@financial-times/o-autoinit": "^3.0.0",
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-overlay": "^4.0.0",
+        "@financial-times/o-syntax-highlight": "^4.0.0",
         "@financial-times/o-tabs": "^6.2.0"
       },
       "engines": {
@@ -362,6 +488,10 @@
       "name": "@financial-times/o-comments",
       "version": "8.3.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-overlay": "^4.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -382,6 +512,10 @@
       "license": "MIT",
       "dependencies": {
         "superstore-sync": "^2.1.1"
+      },
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
       },
       "engines": {
         "npm": "^7 || ^8"
@@ -410,6 +544,11 @@
       "name": "@financial-times/o-editorial-layout",
       "version": "2.3.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-colors": "^6.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -425,6 +564,9 @@
       "name": "@financial-times/o-editorial-typography",
       "version": "2.3.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -439,6 +581,9 @@
       "name": "@financial-times/o-expander",
       "version": "6.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -462,6 +607,10 @@
       "name": "@financial-times/o-footer",
       "version": "9.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -483,6 +632,10 @@
       "name": "@financial-times/o-footer-services",
       "version": "4.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -497,6 +650,11 @@
       "name": "@financial-times/o-forms",
       "version": "9.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -542,6 +700,11 @@
       "name": "@financial-times/o-header",
       "version": "9.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -563,6 +726,10 @@
       "name": "@financial-times/o-header-services",
       "version": "5.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -595,6 +762,10 @@
       "name": "@financial-times/o-labels",
       "version": "6.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -610,6 +781,16 @@
       "name": "@financial-times/o-layout",
       "version": "5.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-footer-services": "^4.0.0",
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-header-services": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-syntax-highlight": "^4.0.0",
+        "@financial-times/o-table": "^9.0.0",
+        "@financial-times/o-tabs": "^6.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -652,6 +833,10 @@
       "name": "@financial-times/o-message",
       "version": "5.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -670,6 +855,11 @@
       "name": "@financial-times/o-meter",
       "version": "3.1.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -683,6 +873,10 @@
       "name": "@financial-times/o-normalise",
       "version": "3.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-colors": "^6.0.3"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -698,6 +892,11 @@
       "dependencies": {
         "focusable": "^2.3.0",
         "ftdomdelegate": "^4.0.0"
+      },
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
       },
       "engines": {
         "npm": "^7 || ^8"
@@ -717,6 +916,10 @@
       "name": "@financial-times/o-quote",
       "version": "5.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -735,6 +938,10 @@
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
       },
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -752,6 +959,11 @@
       "name": "@financial-times/o-spacing",
       "version": "3.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-colors": "^6.0.3",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.1"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -763,6 +975,11 @@
       "name": "@financial-times/o-stepped-progress",
       "version": "4.0.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -779,6 +996,12 @@
       "name": "@financial-times/o-subs-card",
       "version": "6.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-colors": "^6.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -814,6 +1037,13 @@
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
       },
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7",
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-forms": "^9",
+        "@financial-times/o-normalise": "^3",
+        "@financial-times/o-typography": "^7"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -833,6 +1063,10 @@
       "name": "@financial-times/o-tabs",
       "version": "6.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -846,6 +1080,10 @@
       "name": "@financial-times/o-teaser",
       "version": "6.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-date": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -863,6 +1101,11 @@
       "name": "@financial-times/o-teaser-collection",
       "version": "4.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -878,6 +1121,12 @@
       "name": "@financial-times/o-toggle",
       "version": "3.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-spacing": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       }
@@ -888,6 +1137,12 @@
       "license": "MIT",
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
+      },
+      "devDependencies": {
+        "@financial-times/o-buttons": "^7",
+        "@financial-times/o-colors": "^6",
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
       },
       "engines": {
         "npm": "^7 || ^8"
@@ -906,6 +1161,11 @@
       "name": "@financial-times/o-topper",
       "version": "5.2.1",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -926,6 +1186,10 @@
       "dependencies": {
         "fontfaceobserver": "^2.0.9"
       },
+      "devDependencies": {
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -943,6 +1207,10 @@
       "name": "@financial-times/o-video",
       "version": "7.2.0",
       "license": "MIT",
+      "devDependencies": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -3291,8 +3559,7 @@
     },
     "node_modules/@financial-times/fticons": {
       "version": "1.23.1",
-      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
-      "peer": true
+      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA=="
     },
     "node_modules/@financial-times/karma-proclaim": {
       "version": "1.1.2",
@@ -3318,6 +3585,12 @@
     "node_modules/@financial-times/n-notification": {
       "resolved": "components/n-notification",
       "link": true
+    },
+    "node_modules/@financial-times/o-assets": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-assets/-/o-assets-3.4.9.tgz",
+      "integrity": "sha512-Axv68ie1dwHGBknjqIiMNt2+eIbO7+SIKQXH7qOtnbWDGHU0DBGdjoHXpXTTUkE9DTEVr718ObLR2++jMGJcfQ==",
+      "dev": true
     },
     "node_modules/@financial-times/o-audio": {
       "resolved": "components/o-audio",
@@ -26717,7 +26990,6 @@
     "node_modules/mathsass": {
       "version": "0.10.1",
       "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
-      "peer": true,
       "engines": {
         "node": ">=0.8.0",
         "npm": ">=1.2.10"
@@ -39139,6 +39411,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/sass-mq": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
+      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA==",
+      "dev": true
+    },
     "node_modules/sass-true": {
       "version": "5.0.0",
       "integrity": "sha512-Q2HONu8QJcx8Lsdn8RqSHRGGB0aPlqCpXMDONtuXedaNIecz6QD3NCwkZiR4mprr5ZDiFcZwYT6fHDbyBXmDLQ==",
@@ -49640,8 +49918,7 @@
     },
     "@financial-times/fticons": {
       "version": "1.23.1",
-      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
-      "peer": true
+      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA=="
     },
     "@financial-times/karma-proclaim": {
       "version": "1.1.2",
@@ -49701,7 +49978,120 @@
     },
     "@financial-times/n-notification": {
       "version": "file:components/n-notification",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-buttons": "^6.0.0",
+        "@financial-times/o-fonts": "^4.0.0",
+        "@financial-times/o-normalise": "^2.0.0"
+      },
+      "dependencies": {
+        "@financial-times/o-brand": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-3.3.0.tgz",
+          "integrity": "sha512-2suZLjeP5WUZ8Rsl/l1+b8E7tKXXLLZTYMEOeYCMsOGzcelioDQfx/cr5U5hZJzd5Njr7dkVDtFLNHeLWnjEhA==",
+          "dev": true
+        },
+        "@financial-times/o-buttons": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-6.2.0.tgz",
+          "integrity": "sha512-B44LPK3eMmd4WcQB+EFzdnKw/42Jc+8I1Lx22ZcGbLrEw6TUAgDm0eSkiG/rdWep/gegBnWaF+wxJamnY1GU5A==",
+          "dev": true,
+          "requires": {
+            "@financial-times/o-brand": "^3.2.5",
+            "@financial-times/o-colors": "^5.0.0",
+            "@financial-times/o-icons": "^6.0.0",
+            "@financial-times/o-normalise": "^2.0.0",
+            "@financial-times/o-typography": "^6.0.0"
+          },
+          "dependencies": {
+            "@financial-times/o-colors": {
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-5.4.1.tgz",
+              "integrity": "sha512-kNLemhGYJHbyUfxd/sV895bK1QkQu2RgtUFV+xpgpspx6hkWoGuRwVGOCgQVMcXCWpucXzBFRo+e4yoQ8KbHbQ==",
+              "dev": true,
+              "requires": {
+                "@financial-times/o-brand": "^3.2.5",
+                "mathsass": "^0.10.1"
+              }
+            },
+            "@financial-times/o-typography": {
+              "version": "6.4.6",
+              "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-6.4.6.tgz",
+              "integrity": "sha512-VEmA3klKT5Uqx8LpudUP/cwlJr/6W7sValwCualXtFPYVZgYVnB2jxypciGt//DC4PE5zQna+ZYSBDFBVSh2+g==",
+              "dev": true,
+              "requires": {
+                "@financial-times/o-colors": "^5.0.0",
+                "@financial-times/o-fonts": "^4.5.0",
+                "@financial-times/o-grid": "^5.0.0",
+                "@financial-times/o-icons": "^6.0.0",
+                "@financial-times/o-normalise": "^2.0.0",
+                "@financial-times/o-spacing": "^2.0.0",
+                "fontfaceobserver": "^2.0.9"
+              }
+            }
+          }
+        },
+        "@financial-times/o-fonts": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-4.5.0.tgz",
+          "integrity": "sha512-eXlgtgdLRsHb89Yy1pANApbFDkQEHUXzVVW3DdZPNOk6F4kenuCwCumQKyNf2JGdjswfdNRjfTjhzEr37kXfzw==",
+          "dev": true,
+          "requires": {
+            "@financial-times/o-brand": "^3.2.5"
+          }
+        },
+        "@financial-times/o-grid": {
+          "version": "5.2.12",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-5.2.12.tgz",
+          "integrity": "sha512-j1oz7ClBvhAvlQoIj62rH0b5g3LAJcSDnWTPBV9/IYKY+xq0pewFOQ+SvK7fn4dzl7UUEVXSjy2iav8zo2OFTg==",
+          "dev": true,
+          "requires": {
+            "sass-mq": "^5.0.0"
+          }
+        },
+        "@financial-times/o-icons": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-6.3.0.tgz",
+          "integrity": "sha512-As9sPICDOhTnWx71K/Pi/3Vdr0tMrPcm0UFfjNm+re2/7khNzCyVQUJ3qFonjvfFgUs31kRYxdvaYccW7nSSdg==",
+          "dev": true,
+          "requires": {
+            "@financial-times/fticons": "^1.23.1",
+            "@financial-times/o-assets": "^3.4.1"
+          }
+        },
+        "@financial-times/o-normalise": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-2.0.8.tgz",
+          "integrity": "sha512-ahHhDav4BGlatzbzkFH9W/zK0Xt1RSAfLW1F6jw1othcWMaSiIIIrE6nInrpL1NxLxExfaMm80zyJAWqKlxFCA==",
+          "dev": true,
+          "requires": {
+            "@financial-times/o-colors": "^5.0.0"
+          },
+          "dependencies": {
+            "@financial-times/o-colors": {
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-5.4.1.tgz",
+              "integrity": "sha512-kNLemhGYJHbyUfxd/sV895bK1QkQu2RgtUFV+xpgpspx6hkWoGuRwVGOCgQVMcXCWpucXzBFRo+e4yoQ8KbHbQ==",
+              "dev": true,
+              "requires": {
+                "@financial-times/o-brand": "^3.2.5",
+                "mathsass": "^0.10.1"
+              }
+            }
+          }
+        },
+        "@financial-times/o-spacing": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-2.1.0.tgz",
+          "integrity": "sha512-XbrKZAA79vPHLkab4OgA8CzBEf3tma6tT49c3lRM/W2zxZ4P2wpZU3lpt9wTnKANb7gdP//QBXIsyFcazRaxpA==",
+          "dev": true
+        }
+      }
+    },
+    "@financial-times/o-assets": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-assets/-/o-assets-3.4.9.tgz",
+      "integrity": "sha512-Axv68ie1dwHGBknjqIiMNt2+eIbO7+SIKQXH7qOtnbWDGHU0DBGdjoHXpXTTUkE9DTEVr718ObLR2++jMGJcfQ==",
+      "dev": true
     },
     "@financial-times/o-audio": {
       "version": "file:components/o-audio",
@@ -49712,7 +50102,10 @@
     "@financial-times/o-autocomplete": {
       "version": "file:components/o-autocomplete",
       "requires": {
-        "@financial-times/accessible-autocomplete": "^2.1.2"
+        "@financial-times/accessible-autocomplete": "^2.1.2",
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-utils": "^2.0.0"
       }
     },
     "@financial-times/o-autoinit": {
@@ -49720,32 +50113,53 @@
     },
     "@financial-times/o-banner": {
       "version": "file:components/o-banner",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      }
     },
     "@financial-times/o-big-number": {
       "version": "file:components/o-big-number",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-brand": {
       "version": "file:libraries/o-brand"
     },
     "@financial-times/o-buttons": {
       "version": "file:components/o-buttons",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-colors": {
       "version": "file:components/o-colors",
       "requires": {
+        "@financial-times/o-autoinit": "^3.0.0",
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-overlay": "^4.0.0",
+        "@financial-times/o-syntax-highlight": "^4.0.0",
         "@financial-times/o-tabs": "^6.2.0"
       }
     },
     "@financial-times/o-comments": {
       "version": "file:components/o-comments",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-overlay": "^4.0.0"
+      }
     },
     "@financial-times/o-cookie-message": {
       "version": "file:components/o-cookie-message",
       "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
         "superstore-sync": "^2.1.1"
       }
     },
@@ -49757,11 +50171,17 @@
     },
     "@financial-times/o-editorial-layout": {
       "version": "file:components/o-editorial-layout",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-colors": "^6.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-editorial-typography": {
       "version": "file:components/o-editorial-typography",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-errors": {
       "version": "file:libraries/o-errors",
@@ -49771,7 +50191,9 @@
     },
     "@financial-times/o-expander": {
       "version": "file:components/o-expander",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-fonts": {
       "version": "file:components/o-fonts",
@@ -49779,15 +50201,25 @@
     },
     "@financial-times/o-footer": {
       "version": "file:components/o-footer",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-footer-services": {
       "version": "file:components/o-footer-services",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-forms": {
       "version": "file:components/o-forms",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-ft-affiliate-ribbon": {
       "version": "file:components/o-ft-affiliate-ribbon",
@@ -49799,11 +50231,18 @@
     },
     "@financial-times/o-header": {
       "version": "file:components/o-header",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-header-services": {
       "version": "file:components/o-header-services",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-icons": {
       "version": "file:components/o-icons",
@@ -49811,11 +50250,23 @@
     },
     "@financial-times/o-labels": {
       "version": "file:components/o-labels",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-layout": {
       "version": "file:components/o-layout",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-footer-services": "^4.0.0",
+        "@financial-times/o-forms": "^9.0.0",
+        "@financial-times/o-header-services": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-syntax-highlight": "^4.0.0",
+        "@financial-times/o-table": "^9.0.0",
+        "@financial-times/o-tabs": "^6.0.0"
+      }
     },
     "@financial-times/o-lazy-load": {
       "version": "file:components/o-lazy-load",
@@ -49827,44 +50278,75 @@
     },
     "@financial-times/o-message": {
       "version": "file:components/o-message",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      }
     },
     "@financial-times/o-meter": {
       "version": "file:components/o-meter",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.0"
+      }
     },
     "@financial-times/o-normalise": {
       "version": "file:components/o-normalise",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-colors": "^6.0.3"
+      }
     },
     "@financial-times/o-overlay": {
       "version": "file:components/o-overlay",
       "requires": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
         "focusable": "^2.3.0",
         "ftdomdelegate": "^4.0.0"
       }
     },
     "@financial-times/o-quote": {
       "version": "file:components/o-quote",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-share": {
       "version": "file:components/o-share",
       "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
         "ftdomdelegate": "^4.0.6"
       }
     },
     "@financial-times/o-spacing": {
       "version": "file:components/o-spacing",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-colors": "^6.0.3",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.1"
+      }
     },
     "@financial-times/o-stepped-progress": {
       "version": "file:components/o-stepped-progress",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-subs-card": {
       "version": "file:components/o-subs-card",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-colors": "^6.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-syntax-highlight": {
       "version": "file:components/o-syntax-highlight",
@@ -49875,33 +50357,62 @@
     "@financial-times/o-table": {
       "version": "file:components/o-table",
       "requires": {
+        "@financial-times/o-buttons": "^7",
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-forms": "^9",
+        "@financial-times/o-normalise": "^3",
+        "@financial-times/o-typography": "^7",
         "ftdomdelegate": "^4.0.6"
       }
     },
     "@financial-times/o-tabs": {
       "version": "file:components/o-tabs",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3"
+      }
     },
     "@financial-times/o-teaser": {
       "version": "file:components/o-teaser",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-date": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-teaser-collection": {
       "version": "file:components/o-teaser-collection",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-toggle": {
-      "version": "file:components/o-toggle"
+      "version": "file:components/o-toggle",
+      "requires": {
+        "@financial-times/o-buttons": "^7.0.0",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-spacing": "^3.0.0"
+      }
     },
     "@financial-times/o-tooltip": {
       "version": "file:components/o-tooltip",
       "requires": {
+        "@financial-times/o-buttons": "^7",
+        "@financial-times/o-colors": "^6",
+        "@financial-times/o-fonts": "^5",
+        "@financial-times/o-normalise": "^3",
         "ftdomdelegate": "^4.0.6"
       }
     },
     "@financial-times/o-topper": {
       "version": "file:components/o-topper",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.0"
+      }
     },
     "@financial-times/o-tracking": {
       "version": "file:libraries/o-tracking",
@@ -49918,6 +50429,8 @@
     "@financial-times/o-typography": {
       "version": "file:components/o-typography",
       "requires": {
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-normalise": "^3.0.0",
         "fontfaceobserver": "^2.0.9"
       }
     },
@@ -49926,7 +50439,10 @@
     },
     "@financial-times/o-video": {
       "version": "file:components/o-video",
-      "requires": {}
+      "requires": {
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-normalise": "^3.0.0"
+      }
     },
     "@financial-times/o-viewport": {
       "version": "file:components/o-viewport",
@@ -67811,8 +68327,7 @@
     },
     "mathsass": {
       "version": "0.10.1",
-      "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
-      "peer": true
+      "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -77353,6 +77868,12 @@
           }
         }
       }
+    },
+    "sass-mq": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
+      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA==",
+      "dev": true
     },
     "sass-true": {
       "version": "5.0.0",


### PR DESCRIPTION
This will make it possible for origami demos to be able to (for the first time) use non-origami dependencies specifically for the demos.

This also makes it possible for demo dependencies which are origami components/libraries to use the version within the monorepo, meaning we can work on for example o-forms and see how that changes all the other component demos in the codebase which pull in o-forms.

One other thing this gets us is the ability to use the npm ecosystem of tools such as [npm-check-updates](https://www.npmjs.com/package/npm-check-updates) or any npm command such as `npm install --save-dev o-tomato`