### PR TITLE
o-banner: remove unused line-separator in demo

### DIFF
--- a/components/o-banner/demos/src/custom.mustache
+++ b/components/o-banner/demos/src/custom.mustache
@@ -7,7 +7,7 @@
 					<p>Limited time only</p>
 					<h1>You qualify for a special offer: Save 33%</h1>
 				</header>
-				<p>Pay just $4.29 per week for annual Standard  Digital access.</p>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
 				<ul>
 					<li>Global news and opinion from experts in 50+ countries</li>
 					<li>Access on desktop and mobile</li>
@@ -19,7 +19,7 @@
 					<p>Limited time only</p>
 					<h1>You qualify for a special offer: Save 33%</h1>
 				</header>
-				<p>Pay just $4.29 per week for annual Standard  Digital access.</p>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
 			</div>
 			<div class="o-banner__actions">
 				<div class="o-banner__action">


### PR DESCRIPTION
vscode complains about it -- should we replace it with a word-break-opportunity element? `<wbr>`

vscode says this:
>The file 'custom.mustache' contains one or more unusual line terminator characters, like Line Separator (LS) or Paragraph Separator (PS).
>It is recommended to remove them from the file. This can be configured via `editor.unusualLineTerminators`.