### PR TITLE
o-forms remove demo inputs which have no ID

### DIFF
--- a/components/o-forms/demos/src/interactive.mustache
+++ b/components/o-forms/demos/src/interactive.mustache
@@ -64,18 +64,6 @@
 		</span>
 	</label>
 
-	<!-- with no id the error summary can not link to this -->
-	<label class="o-forms-field">
-		<span class="o-forms-title">
-			<span class="o-forms-title__main">Text input with missing id attribute to link to</span>
-			<span class="o-forms-title__prompt">prompt text</span>
-		</span>
-
-		<span class="o-forms-input o-forms-input--text">
-			<input type="text" name="required-no-id" value="" required>
-		</span>
-	</label>
-
 	<!-- with no o-forms-title this is not able to show in the error summary -->
 	<div class="o-forms-field">
 		<span class="o-forms-input o-forms-input--checkbox">

--- a/components/o-forms/demos/src/inverse-form-whitelabel.mustache
+++ b/components/o-forms/demos/src/inverse-form-whitelabel.mustache
@@ -81,18 +81,6 @@
 			</span>
 		</label>
 
-		<!-- with no id the error summary can not link to this -->
-		<label class="o-forms-field o-forms-field--inverse">
-			<span class="o-forms-title">
-				<span class="o-forms-title__main">Text input with missing id attribute to link to</span>
-				<span class="o-forms-title__prompt">prompt text</span>
-			</span>
-
-			<span class="o-forms-input o-forms-input--text">
-				<input type="text" name="required-no-id" value required>
-			</span>
-		</label>
-
 		<!-- with no o-forms-title this is not able to show in the error summary -->
 		<div class="o-forms-field o-forms-field--inverse">
 			<span class="o-forms-input o-forms-input--checkbox">

--- a/components/o-forms/demos/src/inverse-form.mustache
+++ b/components/o-forms/demos/src/inverse-form.mustache
@@ -81,18 +81,6 @@
 			</span>
 		</label>
 
-		<!-- with no id the error summary can not link to this -->
-		<label class="o-forms-field o-forms-field--inverse">
-			<span class="o-forms-title">
-				<span class="o-forms-title__main">Text input with missing id attribute to link to</span>
-				<span class="o-forms-title__prompt">prompt text</span>
-			</span>
-
-			<span class="o-forms-input o-forms-input--text">
-				<input type="text" name="required-no-id" value required>
-			</span>
-		</label>
-
 		<!-- with no o-forms-title this is not able to show in the error summary -->
 		<div class="o-forms-field o-forms-field--inverse">
 			<span class="o-forms-input o-forms-input--checkbox">


### PR DESCRIPTION
Some of the demos contain inputs which have no IDs. If an input has no ID and the input has an error state - then when the error summary is shown it will not be able to link to the input, which violates the WCAG 2.4.1 Bypass Blocks (Level A) rule.

I think it's best to remove these inputs from the demos as we should not be demoing how to create inaccessible forms/inputs


Resolves #524 