### PR TITLE
o-forms: rename demo date and radio ID's to have more relatable names

### DIFF
--- a/components/o-forms/demos/src/interactive.mustache
+++ b/components/o-forms/demos/src/interactive.mustache
@@ -1,8 +1,8 @@
 <form action="" data-o-component="o-forms">
 
-	<div class="o-forms-field o-forms-field--optional" role="group" aria-labelledby="date-group-title1">
+	<div class="o-forms-field o-forms-field--optional" role="group" aria-labelledby="date-group-title">
 		<span class="o-forms-title">
-			<span class="o-forms-title__main" id="date-group-title1">Date input</span>
+			<span class="o-forms-title__main" id="date-group-title">Date input</span>
 			<span class="o-forms-title__prompt">Optional prompt text</span>
 		</span>
 
@@ -23,9 +23,9 @@
 		</span>
 	</div>
 
-	<div class="o-forms-field" role="group" aria-labelledby="date-group-title2">
+	<div class="o-forms-field" role="group" aria-labelledby="radio-group-title">
 		<span class="o-forms-title" aria-hidden="true">
-			<span class="o-forms-title__main" id="date-group-title2">Radio box input</span>
+			<span class="o-forms-title__main" id="radio-group-title">Radio box input</span>
 		</span>
 
 		<span class="o-forms-input o-forms-input--radio-box">

--- a/components/o-forms/demos/src/inverse-form-whitelabel.mustache
+++ b/components/o-forms/demos/src/inverse-form-whitelabel.mustache
@@ -17,9 +17,9 @@
 		</ul>
 	</div>
 
-		<div class="o-forms-field o-forms-field--optional o-forms-field--inverse" role="group" aria-labelledby="date-group-title1">
+		<div class="o-forms-field o-forms-field--optional o-forms-field--inverse" role="group" aria-labelledby="date-group-title">
 			<span class="o-forms-title">
-				<span class="o-forms-title__main" id="date-group-title1">Date input</span>
+				<span class="o-forms-title__main" id="date-group-title">Date input</span>
 				<span class="o-forms-title__prompt">Optional prompt text</span>
 			</span>
 
@@ -40,9 +40,9 @@
 			</span>
 		</div>
 
-		<div class="o-forms-field o-forms-field--inverse" role="group" aria-labelledby="date-group-title2">
+		<div class="o-forms-field o-forms-field--inverse" role="group" aria-labelledby="radio-group-title">
 			<span class="o-forms-title" aria-hidden="true">
-				<span class="o-forms-title__main" id="date-group-title2">Radio box input</span>
+				<span class="o-forms-title__main" id="radio-group-title">Radio box input</span>
 			</span>
 
 			<span class="o-forms-input o-forms-input--radio-box">

--- a/components/o-forms/demos/src/inverse-form.mustache
+++ b/components/o-forms/demos/src/inverse-form.mustache
@@ -17,9 +17,9 @@
 		</ul>
 	</div>
 
-		<div class="o-forms-field o-forms-field--optional o-forms-field--inverse" role="group" aria-labelledby="date-group-title1">
+		<div class="o-forms-field o-forms-field--optional o-forms-field--inverse" role="group" aria-labelledby="date-group-title">
 			<span class="o-forms-title">
-				<span class="o-forms-title__main" id="date-group-title1">Date input</span>
+				<span class="o-forms-title__main" id="date-group-title">Date input</span>
 				<span class="o-forms-title__prompt">Optional prompt text</span>
 			</span>
 
@@ -40,9 +40,9 @@
 			</span>
 		</div>
 
-		<div class="o-forms-field o-forms-field--inverse" role="group" aria-labelledby="date-group-title2">
+		<div class="o-forms-field o-forms-field--inverse" role="group" aria-labelledby="radio-group-title">
 			<span class="o-forms-title" aria-hidden="true">
-				<span class="o-forms-title__main" id="date-group-title2">Radio box input</span>
+				<span class="o-forms-title__main" id="radio-group-title">Radio box input</span>
 			</span>
 
 			<span class="o-forms-input o-forms-input--radio-box">

--- a/components/o-forms/test/helpers/fixtures.js
+++ b/components/o-forms/test/helpers/fixtures.js
@@ -1,9 +1,9 @@
 export default `
 <form action="" data-o-component="o-forms">
 
-	<div class="o-forms-field" role="group" aria-labelledby="date-group-title1">
+	<div class="o-forms-field" role="group" aria-labelledby="date-group-title">
 		<span class="o-forms-title" aria-hidden="true">
-			<span class="o-forms-title__main" id="date-group-title1">Date input</span>
+			<span class="o-forms-title__main" id="date-group-title">Date input</span>
 		</span>
 
 		<span class="o-forms-input o-forms-input--date">
@@ -42,9 +42,9 @@ export default `
 		</span>
 	</label>
 
-	<div class="o-forms-field" role="group" aria-labelledby="date-group-title2">
+	<div class="o-forms-field" role="group" aria-labelledby="radio-group-title">
 		<span class="o-forms-title" aria-hidden="true">
-			<span class="o-forms-title__main" id="date-group-title2">Radio box input</span>
+			<span class="o-forms-title__main" id="radio-group-title">Radio box input</span>
 		</span>
 
 		<span class="o-forms-input o-forms-input--radio-box">


### PR DESCRIPTION
The ID's for the radio inputs were previously named date-group-title2 when they had nothing to do with dates