### PR TITLE
backstage: bump github-pages-deploy-action used to release the site

### DIFF
--- a/.github/workflows/build-websites.yml
+++ b/.github/workflows/build-websites.yml
@@ -26,7 +26,7 @@ jobs:
     - run: npm ci
     - run: bash ./scripts/build-website.bash
     - name: deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.5
+      uses: JamesIves/github-pages-deploy-action@4.2.2
       with:
         branch: origami.ft.com
         folder: origami.ft.com


### PR DESCRIPTION
A new Storybook Story is throwing an unhelpful error in production.
Hmm. Building locally works with:
`NODE_ENV=production npm run build-storybook`
`npx serve origami.ft.com/storybook`

I see the production release seems to request more js files on load than my local build, and that
the build dir includes a bunch of older files from previous builds. They are hashed so I don't
think this is a problem but I would expect previous build assets to be removed as the
github-pages-deploy-action `clean` option is `true` by default.
https://github.com/Financial-Times/origami/tree/cc2710bc80432128b1cda8d3dd009936ed625131/storybook
https://github.com/JamesIves/github-pages-deploy-action#optional-choices

I don't have time to look into the problem further right now,
so let's bump the version and hope for the best anyway.
There is a release related to the `clean` option, but not
for a problem we are having.