### PR TITLE
add polyfill.io urls to local demos

### DIFF
--- a/tools/demo-build/index.js
+++ b/tools/demo-build/index.js
@@ -2,7 +2,7 @@
 import mergeDeep from 'merge-deep';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import * as path from 'node:path'
-import { files } from 'origami-tools-helpers'
+import { files, constructPolyfillUrl } from 'origami-tools-helpers'
 import { buildSass } from './build-sass.js';
 import buildJs from './build-js.js';
 import mustache from 'mustache';
@@ -168,6 +168,7 @@ async function buildDemoHtml(buildConfig) {
 	const brand = buildConfig.brand;
 	data.oDemoTitle = moduleName + ': ' + buildConfig.demo.name + ' demo';
 	data.oDemoDocumentClasses = buildConfig.demo.documentClasses || buildConfig.demo.bodyClasses;
+	data.oDemoPolyfillUrl = buildConfig.demo.polyfillUrl;
 
 	data.oDemoComponentStylePath = buildConfig.demo.sassDestination ?
 		path.basename(buildConfig.demo.sassDestination) :
@@ -237,6 +238,7 @@ function demoSupportsBrand(demoConfig, brand) {
 }
 
 const brands = await getBrands(origamiConfig);
+const polyfillUrl = await constructPolyfillUrl();
 for (const brand of brands) {
 	const demoDefaultConfiguration = getComponentDefaultDemoConfig(origamiConfig);
 	const demoBuildConfig = [];
@@ -246,7 +248,8 @@ for (const brand of brands) {
 			demoBuildConfig.push(mergeDeep(
 				{
 					documentClasses: '',
-					description: ''
+					description: '',
+					polyfillUrl
 				},
 				demoDefaultConfiguration,
 				demoConfig

--- a/tools/origami-tools-helpers/construct-polyfill-url.js
+++ b/tools/origami-tools-helpers/construct-polyfill-url.js
@@ -1,0 +1,47 @@
+'use strict';
+
+import path from 'node:path'
+import {globby} from 'globby'
+import { readFile } from 'node:fs/promises'
+import execa from 'execa'
+import { dirname, join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function removeDuplicateArrayItems(array) {
+	return Array.from(new Set(array))
+}
+
+const projectRoot = path.join(__dirname, '../..');
+
+export async function constructPolyfillUrl() {
+	const componentName = process.cwd().split(sep).pop();
+	// Find all dependencies for the component
+	const { stdout: componentsDependencies} = await execa(`npx`, ['npm', 'ls', `-w components/${componentName}`], {
+		cwd: projectRoot
+	})
+	// Filter the list of all dependencies to find only those which are other origami components
+	const origamiDependencies = componentsDependencies.split('\n').filter(line => line.includes('-> ./components/')).map(line => {
+		return line.match(/\-> (?<location>.+)/).groups.location + '/origami.json'
+	})
+	// Include the components own origami.json file so we can find it's own features which may need to be polyfilled
+	origamiDependencies.push('./origami.json');
+
+	// Read all the origami.json files from the component and it's origami dependencies and
+	// combine all their features which may need to be polyfilled into one array
+	const requiredFeatures = [];
+	await Promise.all(origamiDependencies.map(async dependency => {
+		const origami = JSON.parse(await readFile(path.resolve(projectRoot, dependency), 'utf-8'));
+		if (origami.browserFeatures && origami.browserFeatures.required) {
+			requiredFeatures.push(...origami.browserFeatures.required);
+		}
+	}));
+	const features = removeDuplicateArrayItems(requiredFeatures);
+
+	if (features.length > 0) {
+		return `https://polyfill.io/v3/polyfill.min.js?features=${features.join(',')}&flags=gated&unknown=polyfill`;
+	} else {
+		return 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill';
+	}
+}

--- a/tools/origami-tools-helpers/index.js
+++ b/tools/origami-tools-helpers/index.js
@@ -2,4 +2,5 @@
 
 export * as files from "./files.js"
 import log from "./log.js"
-export {log}
+import { constructPolyfillUrl } from "./construct-polyfill-url.js";
+export {log, constructPolyfillUrl}


### PR DESCRIPTION
this enables us to test demos locally in older browsers such as ie11

this is relying on the origami.json.browserFeatures array which I know we plan to remove. When we do remove it, we will need to find a replacement solution for running local demos in older browsers

this code is a rewrite of what was in origami-build-tools (https://github.com/Financial-Times/origami-build-tools/blob/e7fe4046aca39bd4823f109fcd45cb4b33cd7ce2/lib/helpers/construct-polyfill-url.js) to make it work in a monorepo