### PR TITLE
o-header: add the ability to close any open mega-menus by pressing the escape key

### DIFF
--- a/components/o-header/src/js/mega.js
+++ b/components/o-header/src/js/mega.js
@@ -24,8 +24,11 @@ function addEvents (parent, menu) {
 	});
 
 
-	const handleKeydown = (e) => {
-		if (e.keyCode === 27) {
+	const handleKeydown = (event) => {
+		const key = event.key || event.keyCode;
+
+		// Internet Explorer 11 incorrectly maps the escape key to `Esc` instead of `Escape`
+		if (key === 'Escape' || key === 'Esc' || key === 27) {
 			if (isOpen(menu)) {
 				hide(menu);
 			}

--- a/components/o-header/src/js/mega.js
+++ b/components/o-header/src/js/mega.js
@@ -23,6 +23,17 @@ function addEvents (parent, menu) {
 		}, INTENT_ENTER);
 	});
 
+
+	const handleKeydown = (e) => {
+		if (e.keyCode === 27) {
+			if (isOpen(menu)) {
+				hide(menu);
+			}
+		}
+	};
+
+	document.addEventListener('keydown', handleKeydown);
+
 	parent.addEventListener('mouseleave', () => {
 		clearTimeout(timeout);
 		timeout = setTimeout(() => isOpen(menu) && hide(menu), INTENT_LEAVE);

--- a/components/o-header/test/mega.test.js
+++ b/components/o-header/test/mega.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import proclaim from 'proclaim';
-
+import userEvent from '@testing-library/user-event';
 import mega from '../src/js/mega.js';
 
 function dispatch (target, type) {
@@ -69,6 +69,15 @@ describe('Mega', () => {
 
 			proclaim.equal(menu.classList.contains('o-header__mega--animation'), false);
 		});
+	});
+
+	it('hides the menu when escape key is pressed', () => {
+		const menu = containerEl.querySelector('div');
+		mega.show(menu, true);
+		userEvent.keyboard('{esc}');
+		proclaim.equal(menu.getAttribute('aria-hidden'), 'true');
+		proclaim.equal(menu.getAttribute('aria-expanded'), 'false');
+		proclaim.equal(menu.classList.contains('o-header__mega--animation'), false);
 	});
 
 	it('skips animation when switching menus', () => {


### PR DESCRIPTION
this is required to meet WCAG 1.4.13 Content on Hover or Focus (Level AA)

this resolves https://github.com/Financial-Times/origami/issues/549