### PR TITLE
o-tabs: implement all the required features for a tab component which implements the wai-aria tabs design pattern

### DIFF
--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -4,6 +4,8 @@
 
 `disableFocus` has been removed as it is now the default behaviour and there is no way to change the behavior. This was changed because during an accessibility audit it was explained that focus should stay within the tab-list and not move away when a tab is activated.
 
+The method `getTabPanelEls` has now been marked as "private" as it is only meant to be used internally within o-tabs. If you need to use this method, please raise an issue on GitHub or Slack.
+
 ## Migrating from v6 to v7
 
 The html for o-tabs was changed to bring support for assistive technologies.

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -6,6 +6,8 @@
 
 The method `getTabPanelEls` has now been marked as "private" as it is only meant to be used internally within o-tabs. If you need to use this method, please raise an issue on GitHub or Slack.
 
+The method `keyPressHandler` has now been renamed to `keyUpHandler`.
+
 ## Migrating from v6 to v7
 
 The html for o-tabs was changed to bring support for assistive technologies.

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -4,7 +4,7 @@
 
 `disableFocus` has been removed as it is now the default behaviour and there is no way to change the behavior. This was changed because during an accessibility audit it was explained that focus should stay within the tab-list and not move away when a tab is activated.
 
-The method `getTabPanelEls` has now been marked as "private" as it is only meant to be used internally within o-tabs. If you need to use this method, please raise an issue on GitHub or Slack.
+The method `getTabPanelEls` has now been renamed to `_getTabPanelEls` and marked as "private" as it is only meant to be used internally within o-tabs. If you need to use this method, please raise an issue on GitHub or Slack.
 
 The method `keyPressHandler` has now been renamed to `keyUpHandler`.
 

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -10,11 +10,11 @@ The component no longer uses `ul` and `li` elements and instead uses `div` and `
 -<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 +<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 -	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
-+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1">Tab 1</a>
++	<a role="tab" aria-controls="tabContent1" href="#tabContent1">Tab 1</a>
 -	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
-+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
++	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
 -	<li role="tab"><a href="#tabContent3">Tab 3</a></li>
-+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
++	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 -</ul>
 +</div>
 ```

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -10,11 +10,11 @@ The component no longer uses `ul` and `li` elements and instead uses `div` and `
 -<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 +<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 -	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
-+	<a role="tab" href="#tabContent1">Tab 1</a>
++	<a role="tab" aria-controls="#tabContent1" href="#tabContent1">Tab 1</a>
 -	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
-+	<a role="tab" href="#tabContent2">Tab 2</a>
++	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
 -	<li role="tab"><a href="#tabContent3">Tab 3</a></li>
-+	<a role="tab" href="#tabContent3">Tab 3</a>
++	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 -</ul>
 +</div>
 ```

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migration
 
+## Migrating from v7 to v8
+
+`disableFocus` has been removed as it is now the default behaviour and there is no way to change the behavior. This was changed because during an accessibility audit it was explained that focus should stay within the tab-list and not move away when a tab is activated.
+
 ## Migrating from v6 to v7
 
 The html for o-tabs was changed to bring support for assistive technologies.

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -53,7 +53,6 @@ You can set config options declaratively by using `[data-o-tabs-]` prefixed data
 
 Options consist of:
 
-- `data-o-tabs-disablefocus="true"` - prevent the tabpanel being focused when selected.
 - `data-o-tabs-update-url="true"` - update the URL with the `#` of the selected panel.
 
 ### Core experience
@@ -99,9 +98,7 @@ Note that for browsers that do not support `DOMContentLoaded` (IE8 etc), the eve
 
 ```javascript
 import Tabs from '@financial-times/o-tabs';
-const tabsObjects = Tabs.init(document.body, {
-	disablefocus: false
-});
+const tabsObjects = Tabs.init(document.body);
 ```
 
 An array of any constructed Tabs objects will be returned.
@@ -113,7 +110,6 @@ An array of any constructed Tabs objects will be returned.
 ```javascript
 import Tabs from '@financial-times/o-tabs';
 const myTabs = new Tabs(document.getElementById('myTabsRootElement'), {
-	disablefocus: false
 });
 ```
 
@@ -135,7 +131,6 @@ Tabs are indexed starting from 0.
 The following API methods are provided:
 
 - `init(config)`: Set attributes/classes, bind events. Called automatically on construction. Does nothing if already been called. `config` object accepts:
-	- `disablefocus`: If set to `true`, it will stop the aria-selected tab from receiving focus.
 - `selectTab(idx)`: Select tab `idx`. Does nothing if tab `idx` does not exist or is already selected.
 - `destroy()`: Unbind events, remove `o-tabs--js` class. After calling this, `init()` can be called again to re-initialise the tabs.
 

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -27,9 +27,9 @@ This is an example of an HTML structure that **o-tabs** will accept:
 
 ```html
 <div data-o-component="o-tabs" class="o-tabs" role="tablist">
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	Tab content 1

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -6,7 +6,8 @@ Tabs component for dividing content into meaningful sections.
 - [Markup](#markup)
 - [JavaScript](#javascript)
 - [Sass](#sass)
-- [Migration guide](#migration-guide)
+- [Keyboard Support](#keyboard-support)
+- [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
@@ -201,6 +202,18 @@ This table outlines some of the possible button themes you can request in the [`
 | inverse   | Included by default                      | core, internal             |
 | mono      | Not included by default                  | core, internal             |
 | b2c       | Not included by default                  | core                       |
+
+## Keyboard Support
+
+### When focus is within the tab list
+
+Key|Function
+---|---
+Tab | When focus moves into the tab list, places focus on the active tab element. When the tab list already contains the focus, moves focus to the next element in the page tab sequence outside the tablist.
+Left Arrow | Moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Activates the tabpanel which is associated with the newly focused tab.
+Right Arrow | Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Activates the tabpanel which is associated with the newly focused tab.
+Space or Enter | Activates the tabpanel which is associated with the focused if it was not already activated.
+
 
 ## Migration Guide
 

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -206,8 +206,9 @@ This table outlines some of the possible button themes you can request in the [`
 
 | State | Major Version | Last Minor Release | Migration guide |
 | :---: | :---: | :---: | :---: |
-| ✨ active | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ✨ active | 5 | 5.0 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ✨ active | 6 | N/A | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ⚠ maintained | 6 | 6.2 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ⚠ maintained | 5 | 5.0 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 | ⚠ maintained | 4 | 4.3 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 | ╳ deprecated | 3 | 3.0 | N/A |
 | ╳ deprecated | 2 | 2.2 | N/A |

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -207,7 +207,7 @@ Key|Function
 Tab | When focus moves into the tab list, places focus on the active tab element. When the tab list already contains the focus, moves focus to the next element in the page tab sequence outside the tablist.
 Left Arrow | Moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Activates the tabpanel which is associated with the newly focused tab.
 Right Arrow | Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Activates the tabpanel which is associated with the newly focused tab.
-Space or Enter | Activates the tabpanel which is associated with the focused if it was not already activated.
+Space or Enter | Activates the tabpanel which is associated with the focused tab if it was not already activated.
 
 
 ## Migration Guide

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -25,11 +25,11 @@ The _tabpanel_ elements must have a `o-tabs__tabpanel` class added to them.
 This is an example of an HTML structure that **o-tabs** will accept:
 
 ```html
-<ul data-o-component="o-tabs" class="o-tabs" role="tablist">
-	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
-	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
-	<li role="tab"><a href="#tabContent3">Tab 3</a></li>
-</ul>
+<div data-o-component="o-tabs" class="o-tabs" role="tablist">
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+</div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	Tab content 1
 </div>

--- a/components/o-tabs/demos/src/base-style.mustache
+++ b/components/o-tabs/demos/src/base-style.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/base-style.mustache
+++ b/components/o-tabs/demos/src/base-style.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-big.mustache
+++ b/components/o-tabs/demos/src/buttontabs-big.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary o-tabs--big" role="tablist">
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-big.mustache
+++ b/components/o-tabs/demos/src/buttontabs-big.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary o-tabs--big" role="tablist">
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-inverse.mustache
+++ b/components/o-tabs/demos/src/buttontabs-inverse.mustache
@@ -1,9 +1,9 @@
 <div class="container-inverse">
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary o-tabs--inverse" role="tablist">
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-inverse.mustache
+++ b/components/o-tabs/demos/src/buttontabs-inverse.mustache
@@ -1,9 +1,9 @@
 <div class="container-inverse">
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary o-tabs--inverse" role="tablist">
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-primary.mustache
+++ b/components/o-tabs/demos/src/buttontabs-primary.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--primary" role="tablist">
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs-primary.mustache
+++ b/components/o-tabs/demos/src/buttontabs-primary.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--primary" role="tablist">
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs.mustache
+++ b/components/o-tabs/demos/src/buttontabs.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary" role="tablist">
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/buttontabs.mustache
+++ b/components/o-tabs/demos/src/buttontabs.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--secondary" role="tablist">
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/pa11y.mustache
+++ b/components/o-tabs/demos/src/pa11y.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
-	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
-	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
-	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -17,9 +17,9 @@
 </div>
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs" role="tablist">
-	<a role="tab" href="#tabContent1A" aria-controls="#tabContent1A">Tab 1</a>
-	<a role="tab" href="#tabContent2A" aria-controls="#tabContent2A">Tab 2</a>
-	<a role="tab" href="#tabContent3A" aria-controls="#tabContent3A">Tab 3</a>
+	<a role="tab" href="#tabContent1A" aria-controls="tabContent1A">Tab 1</a>
+	<a role="tab" href="#tabContent2A" aria-controls="tabContent2A">Tab 2</a>
+	<a role="tab" href="#tabContent3A" aria-controls="tabContent3A">Tab 3</a>
 </div>
 <div id="tabContent1A" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -35,9 +35,9 @@
 </div>
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs" role="tablist">
-	<a role="tab" href="#tabContent1B" aria-controls="#tabContent1B">Tab 1</a>
-	<a role="tab" href="#tabContent2B" aria-controls="#tabContent2B">Tab 2</a>
-	<a role="tab" aria-selected="true" href="#tabContent3B" aria-controls="#tabContent3B">Tab 3</a>
+	<a role="tab" href="#tabContent1B" aria-controls="tabContent1B">Tab 1</a>
+	<a role="tab" href="#tabContent2B" aria-controls="tabContent2B">Tab 2</a>
+	<a role="tab" aria-selected="true" href="#tabContent3B" aria-controls="tabContent3B">Tab 3</a>
 </div>
 <div id="tabContent1B" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -54,9 +54,9 @@
 
 <div class="demo-inverse">
 	<div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--inverse" role="tablist">
-		<a role="tab" href="#tabContent1C" aria-controls="#tabContent1C">Tab 1</a>
-		<a role="tab" href="#tabContent2C" aria-controls="#tabContent2C">Tab 2</a>
-		<a role="tab" aria-selected="true" href="#tabContent3C" aria-controls="#tabContent3C">Tab 3</a>
+		<a role="tab" href="#tabContent1C" aria-controls="tabContent1C">Tab 1</a>
+		<a role="tab" href="#tabContent2C" aria-controls="tabContent2C">Tab 2</a>
+		<a role="tab" aria-selected="true" href="#tabContent3C" aria-controls="tabContent3C">Tab 3</a>
 	</div>
 	<div id="tabContent1C" class="o-tabs__tabpanel">
 		<h3>Tab content 1</h3>

--- a/components/o-tabs/demos/src/pa11y.mustache
+++ b/components/o-tabs/demos/src/pa11y.mustache
@@ -1,7 +1,7 @@
 <div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
-	<a role="tab" href="#tabContent1">Tab 1</a>
-	<a role="tab" href="#tabContent2">Tab 2</a>
-	<a role="tab" href="#tabContent3">Tab 3</a>
+	<a role="tab" aria-controls="#tabContent1" href="#tabContent1" >Tab 1</a>
+	<a role="tab" aria-controls="#tabContent2" href="#tabContent2">Tab 2</a>
+	<a role="tab" aria-controls="#tabContent3" href="#tabContent3">Tab 3</a>
 </div>
 <div id="tabContent1" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -17,9 +17,9 @@
 </div>
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs" role="tablist">
-	<a role="tab" href="#tabContent1A">Tab 1</a>
-	<a role="tab" href="#tabContent2A">Tab 2</a>
-	<a role="tab" href="#tabContent3A">Tab 3</a>
+	<a role="tab" href="#tabContent1A" aria-controls="#tabContent1A">Tab 1</a>
+	<a role="tab" href="#tabContent2A" aria-controls="#tabContent2A">Tab 2</a>
+	<a role="tab" href="#tabContent3A" aria-controls="#tabContent3A">Tab 3</a>
 </div>
 <div id="tabContent1A" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -35,9 +35,9 @@
 </div>
 
 <div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs" role="tablist">
-	<a role="tab" href="#tabContent1B">Tab 1</a>
-	<a role="tab" href="#tabContent2B">Tab 2</a>
-	<a role="tab" aria-selected="true" href="#tabContent3B">Tab 3</a>
+	<a role="tab" href="#tabContent1B" aria-controls="#tabContent1B">Tab 1</a>
+	<a role="tab" href="#tabContent2B" aria-controls="#tabContent2B">Tab 2</a>
+	<a role="tab" aria-selected="true" href="#tabContent3B" aria-controls="#tabContent3B">Tab 3</a>
 </div>
 <div id="tabContent1B" class="o-tabs__tabpanel">
 	<h3>Tab content 1</h3>
@@ -54,9 +54,9 @@
 
 <div class="demo-inverse">
 	<div data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--inverse" role="tablist">
-		<a role="tab" href="#tabContent1C">Tab 1</a>
-		<a role="tab" href="#tabContent2C">Tab 2</a>
-		<a role="tab" aria-selected="true" href="#tabContent3C">Tab 3</a>
+		<a role="tab" href="#tabContent1C" aria-controls="#tabContent1C">Tab 1</a>
+		<a role="tab" href="#tabContent2C" aria-controls="#tabContent2C">Tab 2</a>
+		<a role="tab" aria-selected="true" href="#tabContent3C" aria-controls="#tabContent3C">Tab 3</a>
 	</div>
 	<div id="tabContent1C" class="o-tabs__tabpanel">
 		<h3>Tab content 1</h3>

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -15,8 +15,8 @@ class Tabs {
 
 		this.boundClickHandler = this.clickHandler.bind(this);
 		this.rootEl.addEventListener('click', this.boundClickHandler, false);
-		this.boundKeyPressHandler = this.keyPressHandler.bind(this);
-		this.rootEl.addEventListener('keyup', this.boundKeyPressHandler, false);
+		this.boundKeyUpHandler = this.keyUpHandler.bind(this);
+		this.rootEl.addEventListener('keyup', this.boundKeyUpHandler, false);
 		this.boundHashChangeHandler = this.hashChangeHandler.bind(this);
 		window.addEventListener('hashchange', this.boundHashChangeHandler, false);
 
@@ -157,7 +157,7 @@ class Tabs {
 		}
 	}
 
-	keyPressHandler(event) {
+	keyUpHandler(event) {
 		const tabEl = event.target;
 		const key = event.keyCode;
 		if (tabEl) {
@@ -240,7 +240,7 @@ class Tabs {
 
 	destroy() {
 		this.rootEl.removeEventListener('click', this.boundClickHandler, false);
-		this.rootEl.removeEventListener('keyup', this.boundKeyPressHandler, false);
+		this.rootEl.removeEventListener('keyup', this.boundKeyUpHandler, false);
 		window.removeEventListener('hashchange', this.boundHashChangeHandler, false);
 		this.rootEl.removeAttribute('data-o-tabs--js');
 
@@ -250,7 +250,7 @@ class Tabs {
 
 		// unset the bound event handlers
 		this.boundClickHandler = undefined;
-		this.boundKeyPressHandler = undefined;
+		this.boundKeyUpHandler = undefined;
 		this.boundHashChangeHandler = undefined;
 		// Destroy ALL the things!
 		this.tabEls = undefined;

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -67,6 +67,8 @@ class Tabs {
 				targetEl.setAttribute('role', 'tabpanel');
 				targetEl.setAttribute('tabindex', '0');
 				panelEls.push(targetEl);
+			} else {
+				targetEl.setAttribute('tabindex', '-1');
 			}
 		}
 
@@ -98,6 +100,7 @@ class Tabs {
 	hidePanel(panelEl) { // eslint-disable-line class-methods-use-this
 		panelEl.setAttribute('aria-expanded', 'false');
 		panelEl.setAttribute('aria-hidden', 'true');
+		panelEl.removeAttribute('tabindex');
 	}
 
 	showPanel(panelEl) { // eslint-disable-line class-methods-use-this

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -11,7 +11,7 @@ class Tabs {
 
 		this.tabEls = this.rootEl.querySelectorAll('[role=tab]');
 		this.tabEls = [].slice.call(this.tabEls).filter(this.tabHasValidUrl);
-		this.tabpanelEls = this.getTabPanelEls(this.tabEls);
+		this.tabpanelEls = this._getTabPanelEls(this.tabEls);
 
 		this.boundClickHandler = this.clickHandler.bind(this);
 		this.rootEl.addEventListener('click', this.boundClickHandler, false);
@@ -56,7 +56,7 @@ class Tabs {
 	 * @param {HTMLElement[]} tabEls Array of the elements which are the tabs for this o-tabs instance
 	 * @returns {HTMLElement[]} The same array that was passed in via the tabEls argument
 	 */
-	getTabPanelEls(tabEls) {
+	_getTabPanelEls(tabEls) {
 		const panelEls = [];
 
 		for (const tab of tabEls) {

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -143,9 +143,11 @@ class Tabs {
 				for (let i = 0; i < this.tabEls.length; i++) {
 					if (newIndex === i) {
 						this.tabEls[i].setAttribute('aria-selected', 'true');
-						this.showPanel(this.tabpanelEls[i], this.config.disablefocus);
+						this.tabEls[i].removeAttribute('tabindex');
+						this.showPanel(this.tabpanelEls[i]);
 					} else {
 						this.tabEls[i].setAttribute('aria-selected', 'false');
+						this.tabEls[i].setAttribute('tabindex', '-1');
 						this.hidePanel(this.tabpanelEls[i]);
 					}
 				}

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -102,27 +102,11 @@ class Tabs {
 		panelEl.setAttribute('aria-hidden', 'true');
 	}
 
-	showPanel(panelEl, disableFocus) { // eslint-disable-line class-methods-use-this
+	showPanel(panelEl) { // eslint-disable-line class-methods-use-this
 		panelEl.setAttribute('aria-expanded', 'true');
 		panelEl.setAttribute('aria-hidden', 'false');
+		panelEl.setAttribute('tabindex', '0');
 
-		// Remove the focus ring for sighted users
-		panelEl.style.outline = 0;
-
-		if (disableFocus) {
-			return;
-		}
-
-		// Get current scroll position
-		const x = window.scrollX || window.pageXOffset;
-		const y = window.scrollY || window.pageYOffset;
-
-		// Give focus to the panel for screen readers
-		// This might cause the browser to scroll up or down
-		panelEl.focus();
-
-		// Scroll back to the original position
-		window.scrollTo(x, y);
 	}
 
 	dispatchCustomEvent(event, data = {}, namespace = 'oTabs') {

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -171,7 +171,7 @@ class Tabs {
 							this.updateCurrentTab(tabEl.previousElementSibling);
 						}
 					} else {
-						const lastTab = tabEl.parentElement.children[tabEl.parentElement.children-1];
+						const lastTab = tabEl.parentElement.lastElementChild;
 						if (this.tabHasValidUrl(lastTab)) {
 							event.preventDefault();
 							lastTab.focus();
@@ -188,7 +188,7 @@ class Tabs {
 							this.updateCurrentTab(tabEl.nextElementSibling);
 						}
 					} else {
-						const firstTab = tabEl.parentElement.children[0];
+						const firstTab = tabEl.parentElement.firstElementChild;
 						if (this.tabHasValidUrl(firstTab)) {
 							event.preventDefault();
 							firstTab.focus();

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -240,7 +240,7 @@ class Tabs {
 
 	destroy() {
 		this.rootEl.removeEventListener('click', this.boundClickHandler, false);
-		this.rootEl.removeEventListener('keypress', this.boundKeyPressHandler, false);
+		this.rootEl.removeEventListener('keyup', this.boundKeyPressHandler, false);
 		window.removeEventListener('hashchange', this.boundHashChangeHandler, false);
 		this.rootEl.removeAttribute('data-o-tabs--js');
 

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -59,9 +59,7 @@ class Tabs {
 			const targetEl = document.getElementById(tabTargetId);
 
 			if (targetEl) {
-				tab.setAttribute('aria-controls', tabTargetId);
 				tab.setAttribute('tabindex', '0');
-
 				const label = tab;
 				const labelId = tabTargetId + '-label';
 				label.id = labelId;

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -64,7 +64,6 @@ class Tabs {
 
 				const label = tab;
 				const labelId = tabTargetId + '-label';
-				label.setAttribute('tabindex', '-1');
 				label.id = labelId;
 				targetEl.setAttribute('aria-labelledby', labelId);
 				targetEl.setAttribute('role', 'tabpanel');

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -51,6 +51,11 @@ class Tabs {
 		return tabEl ? tabEl.getAttribute('href').replace('#','') : '';
 	}
 
+	/**
+	 * @private
+	 * @param {HTMLElement[]} tabEls Array of the elements which are the tabs for this o-tabs instance
+	 * @returns {HTMLElement[]} The same array that was passed in via the tabEls argument
+	 */
 	getTabPanelEls(tabEls) {
 		const panelEls = [];
 

--- a/components/o-tabs/src/js/Tabs.js
+++ b/components/o-tabs/src/js/Tabs.js
@@ -16,7 +16,7 @@ class Tabs {
 		this.boundClickHandler = this.clickHandler.bind(this);
 		this.rootEl.addEventListener('click', this.boundClickHandler, false);
 		this.boundKeyPressHandler = this.keyPressHandler.bind(this);
-		this.rootEl.addEventListener('keypress', this.boundKeyPressHandler, false);
+		this.rootEl.addEventListener('keyup', this.boundKeyPressHandler, false);
 		this.boundHashChangeHandler = this.hashChangeHandler.bind(this);
 		window.addEventListener('hashchange', this.boundHashChangeHandler, false);
 
@@ -170,12 +170,55 @@ class Tabs {
 		}
 	}
 
-	keyPressHandler(ev) {
-		const tabEl = ev.target.closest('[role=tab]');
-		// Only update if key pressed is enter key
-		if (tabEl && ev.keyCode === 13 && this.tabHasValidUrl(tabEl)) {
-			ev.preventDefault();
-			this.updateCurrentTab(tabEl);
+	keyPressHandler(event) {
+		const tabEl = event.target;
+		const key = event.keyCode;
+		if (tabEl) {
+			// eslint-disable-next-line default-case
+			switch (key) {
+				case 37: { //left
+					if (tabEl.previousElementSibling) {
+						if (this.tabHasValidUrl(tabEl.previousElementSibling)) {
+							event.preventDefault();
+							tabEl.previousElementSibling.focus();
+							this.updateCurrentTab(tabEl.previousElementSibling);
+						}
+					} else {
+						const lastTab = tabEl.parentElement.children[tabEl.parentElement.children-1];
+						if (this.tabHasValidUrl(lastTab)) {
+							event.preventDefault();
+							lastTab.focus();
+							this.updateCurrentTab(lastTab);
+						}
+					}
+					break;
+				}
+				case 39: { //right
+					if (tabEl.nextElementSibling) {
+						if (this.tabHasValidUrl(tabEl.nextElementSibling)) {
+							event.preventDefault();
+							tabEl.nextElementSibling.focus();
+							this.updateCurrentTab(tabEl.nextElementSibling);
+						}
+					} else {
+						const firstTab = tabEl.parentElement.children[0];
+						if (this.tabHasValidUrl(firstTab)) {
+							event.preventDefault();
+							firstTab.focus();
+							this.updateCurrentTab(firstTab);
+						}
+					}
+					break;
+				}
+				case 13: //enter
+				case 32: { //space
+					if (this.tabHasValidUrl(tabEl)) {
+						event.preventDefault();
+						this.updateCurrentTab(tabEl);
+					}
+					break;
+				}
+			}
 		}
 	}
 

--- a/components/o-tabs/test/Tabs.test.js
+++ b/components/o-tabs/test/Tabs.test.js
@@ -7,7 +7,10 @@ import {assert} from '@open-wc/testing';
 import sinon from 'sinon/pkg/sinon-esm.js';
 import Tabs from '../main.js';
 
-let testTabs;
+/**
+ * @type {Tabs}
+ */
+let oTabs;
 let tabsEl;
 let tabs;
 let tabPanels;
@@ -19,7 +22,7 @@ describe('tabs', () => {
 		tabsEl = screen.getByRole('tablist');
 		tabs = screen.getAllByRole('tab');
 		tabPanels = screen.getAllByRole('tabpanel');
-		testTabs = new Tabs(tabsEl);
+		oTabs = new Tabs(tabsEl);
 	});
 
 	afterEach(() => {
@@ -29,10 +32,10 @@ describe('tabs', () => {
 	it('destroy()', () => {
 		let spy;
 		try {
-			testTabs.destroy();
+			oTabs.destroy();
 
 			assert.isFalse(tabsEl.classList.contains('o-tabs--js'));
-			spy = sinon.spy(testTabs, 'selectTab');
+			spy = sinon.spy(oTabs, 'selectTab');
 
 			assert.isTrue(spy.notCalled);
 
@@ -50,7 +53,7 @@ describe('tabs', () => {
 	describe('tabs behaviour', () => {
 
 		afterEach(() => {
-			testTabs.destroy();
+			oTabs.destroy();
 		});
 
 		it('is defined', () => {
@@ -75,9 +78,9 @@ describe('tabs', () => {
 			assert.strictEqual(tabs[2].getAttribute('tabindex'), '-1');
 
 			// all tab panels are focusable but only one is ever shown on the screen at a time
-			for (const tab of tabPanels) {
-				assert.strictEqual(tab.getAttribute('tabindex'), '0');
-			}
+			assert.strictEqual(tabPanels[0].getAttribute('tabindex'), '0');
+			assert.isFalse(tabPanels[1].hasAttribute('tabindex'));
+			assert.isFalse(tabPanels[2].hasAttribute('tabindex'));
 		});
 
 		it('has correct initial state', () => {
@@ -93,11 +96,11 @@ describe('tabs', () => {
 		});
 
 		it('can set the config declaratively', () => {
-			assert.isTrue(testTabs.config['update-url']);
+			assert.isTrue(oTabs.config['update-url']);
 		});
 
 		it('selectTab(1)', () => {
-			testTabs.selectTab(1);
+			oTabs.selectTab(1);
 			assert.strictEqual(tabs[0].getAttribute('aria-selected'), 'false');
 			assert.strictEqual(tabs[1].getAttribute('aria-selected'), 'true');
 			assert.strictEqual(tabs[2].getAttribute('aria-selected'), 'false');
@@ -112,7 +115,7 @@ describe('tabs', () => {
 		it('click tab', () => {
 			let spy;
 			try {
-				spy = sinon.spy(testTabs, 'selectTab');
+				spy = sinon.spy(oTabs, 'selectTab');
 
 				userEvent.click(tabs[2]);
 				assert.isTrue(spy.calledWith(2));
@@ -131,7 +134,7 @@ describe('tabs', () => {
 		it('enter key press tab', () => {
 			let spy;
 			try {
-				spy = sinon.spy(testTabs, 'selectTab');
+				spy = sinon.spy(oTabs, 'selectTab');
 
 				tabs[2].focus();
 				userEvent.keyboard('{enter}');
@@ -169,8 +172,8 @@ describe('tabs', () => {
 				} else {
 					tabsEl.removeAttribute('data-o-tabs-update-url');
 				}
-				testTabs.destroy();
-				testTabs = new Tabs(tabsEl);
+				oTabs.destroy();
+				oTabs = new Tabs(tabsEl);
 			};
 
 			beforeEach(() => {
@@ -183,7 +186,7 @@ describe('tabs', () => {
 
 			it('Should update the hash part of the url to the id of the active tab', () => {
 				rebuildTabs(true);
-				testTabs.selectTab(0);
+				oTabs.selectTab(0);
 				const expectedHash = document.querySelector('.o-tabs a:first-child').hash;
 				assert.strictEqual(location.hash, expectedHash);
 			});
@@ -195,7 +198,7 @@ describe('tabs', () => {
 
 			it('Should not update the url if the data attribute is not present', () => {
 				rebuildTabs(false);
-				testTabs.selectTab(0);
+				oTabs.selectTab(0);
 				assert.strictEqual(location.hash, '');
 			});
 
@@ -214,7 +217,7 @@ describe('tabs', () => {
 
 			it('Should respond to the hashchange event', (done) => {
 				rebuildTabs(true);
-				testTabs.selectTab(0);
+				oTabs.selectTab(0);
 				location.hash = '#tabContent3';
 				tabsEl.addEventListener('oTabs.tabSelect', (ev) => {
 					try {
@@ -224,6 +227,425 @@ describe('tabs', () => {
 						done(error);
 					}
 				});
+			});
+		});
+	});
+
+	describe('pointer accessibility', () => {
+		/**
+		 * @type {HTMLElement}
+		 */
+		 let tabList;
+		 /**
+		  * @type {HTMLElement}
+		  */
+		 let firstTab;
+		 /**
+		  * @type {HTMLElement}
+		  */
+		 let secondTab;
+		 /**
+		  * @type {HTMLElement}
+		  */
+		 let lastTab;
+		 beforeEach(() => {
+			 tabList = screen.queryByRole('tablist');
+			 const tabs = tabList.querySelectorAll('[role=tab]');
+			 firstTab = tabs[0];
+			 secondTab = tabs[1];
+			 lastTab = tabs[2];
+		 });
+
+		 afterEach(() => {
+			 oTabs.destroy();
+		 });
+		context('clicking onto an unactive tab in the tab-list', () => {
+			beforeEach(() => {
+				secondTab.click();
+			});
+			it('will remove the other tabs from the tabbing order', () => {
+				assert.equal(firstTab.getAttribute('tabindex'), '-1');
+				assert.equal(lastTab.getAttribute('tabindex'), '-1');
+			});
+			it('deselects the other tabs', () => {
+				assert.equal(firstTab.getAttribute('aria-selected'), 'false');
+				assert.equal(lastTab.getAttribute('aria-selected'), 'false');
+			});
+			it('selects the clicked tab', () => {
+				assert.equal(secondTab.getAttribute('aria-selected'), 'true');
+			});
+			it('will add the clicked tab to the tabbing order', () => {
+				assert.isFalse(secondTab.hasAttribute('tabindex'));
+			});
+			it('activates the tabpanel which is associated with the newly selected tab', () => {
+				const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+				assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'true');
+				assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'false');
+			});
+			it('adds the tabpanel which is associated with the newly selected tab to the tabbing order', () => {
+				const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+				assert.equal(panelAssociatedWithSecondTab.getAttribute('tabindex'), '0');
+			});
+			it('deactivates any tabpanels in the tab component which are not associated with the newly selected tab', () => {
+				const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+				assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'false');
+				assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'true');
+				assert.isFalse(panelAssociatedWithFirstTab.hasAttribute('tabindex'));
+
+				const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+				assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'false');
+				assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'true');
+				assert.isFalse(panelAssociatedWithLastTab.hasAttribute('tabindex'));
+			});
+		});
+
+	});
+
+	describe('keyboard accessibility', () => {
+		/**
+		 * @type {HTMLElement}
+		 */
+		let tabList;
+		/**
+		 * @type {HTMLElement}
+		 */
+		let firstTab;
+		/**
+		 * @type {HTMLElement}
+		 */
+		let secondTab;
+		/**
+		 * @type {HTMLElement}
+		 */
+		let lastTab;
+		beforeEach(() => {
+			tabList = screen.queryByRole('tablist');
+			const tabs = tabList.querySelectorAll('[role=tab]');
+			firstTab = tabs[0];
+			secondTab = tabs[1];
+			lastTab = tabs[2];
+		});
+
+		afterEach(() => {
+			oTabs.destroy();
+		});
+
+		context('when tabbing into the tab-list', () => {
+			it('the active tab is the one which is focused onto', () => {
+				// Bring the focus onto the body element
+				document.body.focus();
+				// Tab to the next focusable item which will be the o-tabs component
+				userEvent.tab();
+				const elementInFocus = document.activeElement;
+				const activeTab = screen.getByRole('tab', { selected: true });
+				assert.strictEqual(elementInFocus, activeTab);
+			});
+		});
+
+		context('when on the first tab in the tab-list', () => {
+			beforeEach(() => {
+				oTabs.selectTab(0);
+				firstTab.focus();
+			});
+
+			context('pressing the left arrow key', () => {
+				beforeEach(() => {
+					firstTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 37,
+						bubbles:true
+					}));
+				});
+				it('will remove the first tab from the tabbing order', () => {
+					assert.equal(firstTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the first tab', () => {
+					assert.equal(firstTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the last tab', () => {
+					assert.equal(lastTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the last tab to the tabbing order', () => {
+					assert.isFalse(lastTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithFirstTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithSecondTab.hasAttribute('tabindex'));
+				});
+			});
+			context('pressing the right arrow key', () => {
+				beforeEach(() => {
+					firstTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 39,
+						bubbles:true
+					}));
+				});
+				it('will remove the first tab from the tabbing order', () => {
+					assert.equal(firstTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the first tab', () => {
+					assert.equal(firstTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the second tab', () => {
+					assert.equal(secondTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the second tab to the tabbing order', () => {
+					assert.isFalse(secondTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithFirstTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithLastTab.hasAttribute('tabindex'));
+				});
+			});
+			it('pressing the tab key will change the focus to the open tab-panel', () => {
+				const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+				userEvent.tab();
+				assert.strictEqual(document.activeElement, panelAssociatedWithFirstTab);
+			});
+			it('pressing the space key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{space}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithFirstTab);
+			});
+			it('pressing the enter key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{enter}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithFirstTab);
+			});
+		});
+
+		context('when on the second tab in the tab-list', () => {
+			beforeEach(() => {
+				oTabs.selectTab(1);
+				secondTab.focus();
+			});
+			context('pressing the left arrow key', () => {
+				beforeEach(() => {
+					secondTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 37,
+						bubbles:true
+					}));
+				});
+				it('will remove the second tab from the tabbing order', () => {
+					assert.equal(secondTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the second tab', () => {
+					assert.equal(secondTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the first tab', () => {
+					assert.equal(firstTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the first tab to the tabbing order', () => {
+					assert.isFalse(firstTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithSecondTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithLastTab.hasAttribute('tabindex'));
+				});
+			});
+			context('pressing the right arrow key', () => {
+				beforeEach(() => {
+					secondTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 39,
+						bubbles:true
+					}));
+				});
+				it('will remove the second tab from the tabbing order', () => {
+					assert.equal(secondTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the second tab', () => {
+					assert.equal(secondTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the last tab', () => {
+					assert.equal(lastTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the last tab to the tabbing order', () => {
+					assert.isFalse(lastTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithFirstTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithSecondTab.hasAttribute('tabindex'));
+				});
+			});
+			it('pressing the tab key will change the focus to the open tab-panel', () => {
+				const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+				userEvent.tab();
+				assert.strictEqual(document.activeElement, panelAssociatedWithSecondTab);
+			});
+			it('pressing the space key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{space}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithSecondTab);
+			});
+			it('pressing the enter key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{enter}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithSecondTab);
+			});
+		});
+
+		context('when on the last tab in the tab-list', () => {
+			beforeEach(() => {
+				oTabs.selectTab(2);
+				lastTab.focus();
+			});
+			context('pressing the left arrow key', () => {
+				beforeEach(() => {
+					lastTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 37,
+						bubbles:true
+					}));
+				});
+				it('will remove the last tab from the tabbing order', () => {
+					assert.equal(lastTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the last tab', () => {
+					assert.equal(lastTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the second tab', () => {
+					assert.equal(secondTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the second tab to the tabbing order', () => {
+					assert.isFalse(secondTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithFirstTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithLastTab.hasAttribute('tabindex'));
+				});
+			});
+			context('pressing the right arrow key', () => {
+				beforeEach(() => {
+					lastTab.dispatchEvent(new KeyboardEvent('keyup', {
+						keyCode: 39,
+						bubbles:true
+					}));
+				});
+				it('will remove the last tab from the tabbing order', () => {
+					assert.equal(lastTab.getAttribute('tabindex'), '-1');
+				});
+				it('deselects the last tab', () => {
+					assert.equal(lastTab.getAttribute('aria-selected'), 'false');
+				});
+				it('selects the first tab', () => {
+					assert.equal(firstTab.getAttribute('aria-selected'), 'true');
+				});
+				it('will add the first tab to the tabbing order', () => {
+					assert.isFalse(firstTab.hasAttribute('tabindex'));
+				});
+				it('activates the tabpanel which is associated with the newly focused tab', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-expanded'), 'true');
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('aria-hidden'), 'false');
+				});
+				it('adds the tabpanel which is associated with the newly focused tab to the tabbing order', () => {
+					const panelAssociatedWithFirstTab = document.getElementById(firstTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithFirstTab.getAttribute('tabindex'), '0');
+				});
+				it('deactivates any tabpanels in the tab component which are not associated with the newly focused tab', () => {
+					const panelAssociatedWithSecondTab = document.getElementById(secondTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithSecondTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithSecondTab.hasAttribute('tabindex'));
+
+					const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-expanded'), 'false');
+					assert.equal(panelAssociatedWithLastTab.getAttribute('aria-hidden'), 'true');
+					assert.isFalse(panelAssociatedWithLastTab.hasAttribute('tabindex'));
+				});
+			});
+			it('pressing the tab key will change the focus to the open tab-panel', () => {
+				const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+				userEvent.tab();
+				assert.strictEqual(document.activeElement, panelAssociatedWithLastTab);
+			});
+			it('pressing the space key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{space}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithLastTab);
+			});
+			it('pressing the enter key activates the tabpanel which is associated with the focused tab', () => {
+				const panelAssociatedWithLastTab = document.getElementById(lastTab.getAttribute('aria-controls'));
+				userEvent.keyboard('{enter}');
+				assert.strictEqual(document.activeElement, panelAssociatedWithLastTab);
 			});
 		});
 	});

--- a/components/o-tabs/test/Tabs.test.js
+++ b/components/o-tabs/test/Tabs.test.js
@@ -102,7 +102,7 @@ describe('tabs', () => {
 		});
 
 		it('can set the config declaratively', () => {
-			proclaim.isTrue(testTabs.config.disablefocus);
+			proclaim.isTrue(testTabs.config.dataOTabsUpdateUrl);
 		});
 
 		it('selectTab(1)', () => {
@@ -168,7 +168,7 @@ describe('tabs', () => {
 				if (withUpdateUrl) {
 					tabsEl.setAttribute('data-o-tabs-update-url', '');
 				}
-				tabsEl.setAttribute('data-o-tabs-disablefocus', 'false');
+				tabsEl.setAttribute('data-o-tabs-update-url', "true");
 				testTabs.destroy();
 				testTabs = new Tabs(tabsEl);
 			};

--- a/components/o-tabs/test/helpers/fixtures.js
+++ b/components/o-tabs/test/helpers/fixtures.js
@@ -22,18 +22,18 @@ function insert(html) {
 function insertSimple() {
 	const html = `
 		<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url="true" id="tab-element">
-			<a role="tab" class="should-be-focusable" href="#tabContent1">Tab 1</a>
-			<a role="tab" class="should-be-focusable" href="#tabContent2">Tab 2</a>
-			<a role="tab" class="should-be-focusable" href="#tabContent3">Tab 3</a>
+			<a role="tab" aria-controls="tabContent1" href="#tabContent1">Tab 1</a>
+			<a role="tab" aria-controls="tabContent2" href="#tabContent2">Tab 2</a>
+			<a role="tab" aria-controls="tabContent3" href="#tabContent3">Tab 3</a>
 		</div>
-		<div id="tabContent1" class="o-tabs__tabpanel should-be-focusable" role="tabpanel">Tab content 1</div>
-		<div id="tabContent2" class="o-tabs__tabpanel should-be-focusable" role="tabpanel">Tab content 2</div>
-		<div id="tabContent3" class="o-tabs__tabpanel should-be-focusable" role="tabpanel">Tab content 3</div>
+		<div id="tabContent1" class="o-tabs__tabpanel" role="tabpanel">Tab content 1</div>
+		<div id="tabContent2" class="o-tabs__tabpanel" role="tabpanel">Tab content 2</div>
+		<div id="tabContent3" class="o-tabs__tabpanel" role="tabpanel">Tab content 3</div>
 	`;
 	insert(html);
 }
 
-export default {
+export {
 	insertSimple,
 	reset
 };

--- a/components/o-tabs/test/helpers/fixtures.js
+++ b/components/o-tabs/test/helpers/fixtures.js
@@ -21,7 +21,7 @@ function insert(html) {
 
 function insertSimple() {
 	const html = `
-		<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-disablefocus="true" id="tab-element">
+		<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url="true" id="tab-element">
 			<a role="tab" class="should-be-focusable" href="#tabContent1">Tab 1</a>
 			<a role="tab" class="should-be-focusable" href="#tabContent2">Tab 2</a>
 			<a role="tab" class="should-be-focusable" href="#tabContent3">Tab 3</a>

--- a/components/o-tabs/test/origami.test.js
+++ b/components/o-tabs/test/origami.test.js
@@ -1,34 +1,46 @@
 /* eslint-env mocha */
 
-import proclaim from 'proclaim';
+import * as fixtures from './helpers/fixtures.js';
+import { fireEvent, createEvent } from '@testing-library/dom';
+import {assert} from '@open-wc/testing';
 import sinon from 'sinon/pkg/sinon-esm.js';
-
-import fixtures from './helpers/fixtures.js';
-
 import Tabs from '../main.js';
 
 describe("Tabs", () => {
 	it('is defined', () => {
-		proclaim.equal(typeof Tabs, 'function');
+		assert.isFunction(Tabs);
 	});
 
 	it('has a static init method', () => {
-		proclaim.equal(typeof Tabs.init, 'function');
+		assert.isFunction(Tabs.init);
 	});
 
 	it("should autoinitialize", (done) => {
-		const initSpy = sinon.spy(Tabs, 'init');
-		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-		setTimeout(function(){
-			proclaim.equal(initSpy.called, true);
+		let initSpy;
+		try {
+			initSpy = sinon.spy(Tabs, 'init');
+			fireEvent(document, createEvent('o.DOMContentLoaded', document));
+			setTimeout(function() {
+				try {
+					assert.isTrue(initSpy.called);
+					done();
+				} catch(error) {
+					done(error);
+				}
+			}, 100);
+		} finally {
 			initSpy.restore();
-			done();
-		}, 100);
+		}
 	});
 
 	it("should not autoinitialize when the event is not dispached", () => {
-		const initSpy = sinon.spy(Tabs, 'init');
-		proclaim.equal(initSpy.called, false);
+		let initSpy;
+		try {
+			initSpy = sinon.spy(Tabs, 'init');
+			assert.isFalse(initSpy.called);
+		} finally {
+			initSpy.restore();
+		}
 	});
 
 	describe("should create a new", () => {
@@ -42,13 +54,13 @@ describe("Tabs", () => {
 
 		it("component array when initialized", () => {
 			const tab = Tabs.init();
-			proclaim.equal(tab instanceof Array, true);
-			proclaim.equal(tab[0] instanceof Tabs, true);
+			assert.instanceOf(tab, Array);
+			assert.instanceOf(tab[0], Tabs);
 		});
 
 		it("single component when initialized with a root element", () => {
 			const tab = Tabs.init('#tab-element');
-			proclaim.equal(tab instanceof Tabs, true);
+			assert.instanceOf(tab, Tabs);
 		});
 	});
 });


### PR DESCRIPTION
This is an o-tabs implementation of [WAI-ARIA tab-panels](https://www.w3.org/TR/wai-aria-practices/#tabpanel)

Resolves #559 

The changes in this component include:

- added keyboard support for moving between tabs using arrow keys
- when navigating the tab-list or selecting a tab, keep focus within the tab-list and do not move focus to the shown tab-panel
- add aria-controls relationships between tabs and their associated tab-panel
- added support to activate a tab by pressing the space-bar