### PR TITLE
register essentials before a11y so the controls panel is default panel

### DIFF
--- a/apps/storybook/config/main.js
+++ b/apps/storybook/config/main.js
@@ -10,9 +10,9 @@ module.exports.stories = [
 ]
 
 module.exports.addons = [
+	"@storybook/addon-essentials",
 	"@storybook/addon-a11y",
 	"@storybook/addon-links",
-	"@storybook/addon-essentials",
 	{
 		name: "@storybook/preset-scss",
 		options: {


### PR DESCRIPTION
this is the panel we usually want to use i think