### PR TITLE
fix: o-grid, retain existing max grid width when adding larger layout

### DIFF
--- a/components/o-grid/src/scss/_mixins.scss
+++ b/components/o-grid/src/scss/_mixins.scss
@@ -56,8 +56,6 @@
 	@if $gutter-width {
 		$o-grid-gutters: $temp-gutters !global;
 	}
-
-	$_o-grid-max-width: map-get($o-grid-layouts, nth($_o-grid-layout-names, -1)) !global;
 }
 
 /// Apply styles at a given layout size (breakpoint) as the grid. It should be


### PR DESCRIPTION
`oGridAddLayout` used to error when adding a new larger layout.
Since that has been fixed we discovered it also sets the max
grid width to the new larger layout. A user doesn't necessarily
want this, for example when the new breakpoint is used to
target background imagery for large screens.