### PR TITLE
move component stories into a subdir and rename to component name

### DIFF
--- a/components/o-banner/stories/banner.stories.tsx
+++ b/components/o-banner/stories/banner.stories.tsx
@@ -6,11 +6,10 @@ import './banner.scss';
 import withHtml from 'origami-storybook-addon-html';
 
 export default {
-	title: 'Banner',
+	title: 'Components/o-banner',
 	component: Banner,
 	decorators: [withDesign, withHtml],
-	args: {
-	},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -29,14 +28,15 @@ const Story = args => {
 		return function cleanup() {
 			banners = Array.isArray(banners) ? banners : [banners];
 			banners.forEach(banner => banner.destroy());
-		}
+		};
 	}, [args.showCloseButton, args.closeButtonLabel]);
 	return <Banner {...args} />;
 };
 
 export const Default = Story.bind({});
 Default.args = {
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -46,18 +46,21 @@ Default.args = {
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: '',
-	layout: ''
+	layout: '',
 };
 // Exclude layout and heading controls to discourage use of the default layout with a heading.
 // https://github.com/Financial-Times/origami/pull/523
-Default.parameters = {controls: { exclude: ['heading', 'abbreviatedHeading', 'layout'] }};
+Default.parameters = {
+	controls: {exclude: ['heading', 'abbreviatedHeading', 'layout']},
+};
 
 export const FormPrimaryAction = Story.bind({});
 FormPrimaryAction.args = {
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -65,25 +68,27 @@ FormPrimaryAction.args = {
 		action: '#',
 		encoding: 'application/x-www-form-urlencoded',
 		method: 'POST',
-		copy: 'Try it now'
+		copy: 'Try it now',
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: '',
-	layout: ''
+	layout: '',
 };
 // Exclude layout and heading controls to discourage use of the default layout with a heading.
 // https://github.com/Financial-Times/origami/pull/523
-FormPrimaryAction.parameters = {controls: { exclude: ['heading', 'abbreviatedHeading', 'layout'] }};
-
+FormPrimaryAction.parameters = {
+	controls: {exclude: ['heading', 'abbreviatedHeading', 'layout']},
+};
 
 export const Small = Story.bind({});
 Small.args = {
 	heading: 'FT Compact',
 	abbreviatedHeading: 'FT Compact',
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -93,20 +98,21 @@ Small.args = {
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: '',
-	layout: 'small'
+	layout: 'small',
 };
 // Exclude layout to discourage use of the default layout with a heading.
 // https://github.com/Financial-Times/origami/pull/523
-Small.parameters = {controls: { exclude: ['layout'] }};
+Small.parameters = {controls: {exclude: ['layout']}};
 
 export const Compact = Story.bind({});
 Compact.args = {
 	heading: 'FT Compact',
 	abbreviatedHeading: 'FT Compact',
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -116,20 +122,21 @@ Compact.args = {
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: '',
-	layout: 'compact'
+	layout: 'compact',
 };
 // Exclude layout to discourage use of the default layout with a heading.
 // https://github.com/Financial-Times/origami/pull/523
-Compact.parameters = {controls: { exclude: ['layout'] }};
+Compact.parameters = {controls: {exclude: ['layout']}};
 
 export const Marketing = Story.bind({});
 Marketing.args = {
 	heading: 'FT Compact',
 	abbreviatedHeading: 'FT Compact',
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -139,17 +146,18 @@ Marketing.args = {
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: 'marketing',
-	layout: 'small'
+	layout: 'small',
 };
 
 export const Product = Story.bind({});
 Product.args = {
 	heading: 'FT Compact',
 	abbreviatedHeading: 'FT Compact',
-	content: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	content:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
@@ -159,8 +167,8 @@ Product.args = {
 	},
 	secondaryAction: {
 		copy: 'Give feedback',
-		url: '#'
+		url: '#',
 	},
 	theme: 'product',
-	layout: 'small'
+	layout: 'small',
 };

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -4,7 +4,7 @@ import './button.scss';
 import withHtml from 'origami-storybook-addon-html';
 
 export default {
-	title: 'Button',
+	title: 'Components/o-buttons',
 	component: Button,
 	decorators: [withDesign, withHtml],
 	args: {
@@ -24,49 +24,49 @@ export default {
 
 const Story = args => <Button {...args} />;
 
-export const Primary = Story.bind({});
-Primary.args = {
+export const PrimaryButton = Story.bind({});
+PrimaryButton.args = {
 	label: 'Press button',
 	type: 'primary',
 };
 
-export const Secondary = Story.bind({});
-Secondary.args = {
+export const SecondaryButton = Story.bind({});
+SecondaryButton.args = {
 	label: 'Press button',
 	type: 'secondary',
 };
 
-export const Big = Story.bind({});
-Big.args = {
+export const BigButton = Story.bind({});
+BigButton.args = {
 	size: 'big',
 	label: 'Press button',
 };
 
-export const Inverse = Story.bind({});
-Inverse.args = {
+export const InverseButton = Story.bind({});
+InverseButton.args = {
 	label: 'Press button',
 	theme: 'inverse',
 };
-Inverse.parameters = {
+InverseButton.parameters = {
 	backgrounds: {
 		default: 'slate',
 	},
 };
 
-export const Mono = Story.bind({});
-Mono.args = {
+export const MonoButton = Story.bind({});
+MonoButton.args = {
 	label: 'Press button',
 	theme: 'mono',
 };
 
-export const Icon = Story.bind({});
-Icon.args = {
+export const ButtonWithIcon = Story.bind({});
+ButtonWithIcon.args = {
 	label: 'Upload',
 	icon: 'upload',
 };
 
-export const IconOnly = Story.bind({});
-IconOnly.args = {
+export const IconOnlyButton = Story.bind({});
+IconOnlyButton.args = {
 	label: 'Next',
 	icon: 'arrow-right',
 	iconOnly: true,

--- a/components/o-cookie-message/stories/cookie-message.stories.tsx
+++ b/components/o-cookie-message/stories/cookie-message.stories.tsx
@@ -6,7 +6,7 @@ import './cookie-message.scss';
 import withHtml from 'origami-storybook-addon-html';
 
 export default {
-	title: 'Cookie Message',
+	title: 'Components/o-cookie-message',
 	component: CookieMessage,
 	decorators: [withDesign, withHtml],
 	args: {},
@@ -32,7 +32,7 @@ const Story = args => {
 		</div>
 	);
 };
-export const Default = Story.bind({});
+const Default = Story.bind({});
 Default.args = {
 	fullMarkupForDefaultContent: false,
 	heading: '',
@@ -47,8 +47,10 @@ Default.args = {
 	theme: '',
 };
 
-export const Alternative = Story.bind({});
-Alternative.args = {
+export {Default as CookieMessage};
+
+export const AlternativeDesignCookieMessage = Story.bind({});
+AlternativeDesignCookieMessage.args = {
 	fullMarkupForDefaultContent: false,
 	heading: '',
 	copy: '',

--- a/components/o-stepped-progress/stories/stepped-progress.stories.tsx
+++ b/components/o-stepped-progress/stories/stepped-progress.stories.tsx
@@ -6,7 +6,7 @@ import javascript from '@financial-times/o-stepped-progress';
 import withHtml from 'origami-storybook-addon-html';
 
 export default {
-	title: 'Stepped Progress',
+	title: 'Components/o-stepped-progress',
 	component: SteppedProgress,
 	decorators: [withDesign, withHtml],
 	parameters: {
@@ -25,7 +25,7 @@ const Story = args => {
 	return <SteppedProgress {...args} />;
 };
 
-export const Example = Story.bind({});
+const Example = Story.bind({});
 Example.args = {
 	steps: [
 		{label: 'Wake up', state: 'complete'},
@@ -34,6 +34,8 @@ Example.args = {
 		{label: 'Defeat everyone'},
 	],
 };
+
+export {Example as SteppedProgress};
 
 export const ErrorStep = Story.bind({});
 ErrorStep.args = {


### PR DESCRIPTION
i think this is probably more clear, and then later we can add
a nice Guidance directory, maybe a Design directory and an Accessibility directory?

whatever the future holds.

before:
![](https://user-images.githubusercontent.com/178266/151372057-da6b20fc-cc4f-4629-ab11-d0d6c6383ce2.png)


looks like this now:

![](https://user-images.githubusercontent.com/178266/151372008-166f1d64-f9a5-438c-8277-a7d031c60024.png)
