### PR TITLE
fix: correct error summary links in the demos to use the correct IDs

### DIFF
--- a/components/o-forms/demos/src/inverse-form-whitelabel.mustache
+++ b/components/o-forms/demos/src/inverse-form-whitelabel.mustache
@@ -5,9 +5,9 @@
 		<ul class="o-forms__error-summary__list">
 			<li class="o-forms__error-summary__item">
 				<!-- link to the invalid input -->
-				<a href="#my-date-input">
+				<a href="#date-group-title">
 					<!-- the name of the invalid input -->
-					<span class="o-forms__error-summary__item-overview">My date input</span>:
+					<span class="o-forms__error-summary__item-overview">Date input</span>:
 					<!-- a description of what is wrong and how to fix it -->
 					<span class="o-forms__error-summary__item-detail">
 						Please use the format (DD/MM/YYYY)

--- a/components/o-forms/demos/src/inverse-form.mustache
+++ b/components/o-forms/demos/src/inverse-form.mustache
@@ -5,9 +5,9 @@
 		<ul class="o-forms__error-summary__list">
 			<li class="o-forms__error-summary__item">
 				<!-- link to the invalid input -->
-				<a href="#my-date-input">
+				<a href="#date-group-title">
 					<!-- the name of the invalid input -->
-					<span class="o-forms__error-summary__item-overview">My date input</span>:
+					<span class="o-forms__error-summary__item-overview">Date input</span>:
 					<!-- a description of what is wrong and how to fix it -->
 					<span class="o-forms__error-summary__item-detail">
 						Please use the format (DD/MM/YYYY)


### PR DESCRIPTION
Currently the error summary link uses an in-page ID which does not exist, which means clicking the link does nothing.

This commit uses the correct in-page ID for the link and also updates the link text to match the title/label of the input it is linking to

This will resolve https://github.com/Financial-Times/origami/issues/524