### PR TITLE
o-banner: do not repeat the description for the banner close button

### DIFF
--- a/components/o-banner/src/js/banner.js
+++ b/components/o-banner/src/js/banner.js
@@ -227,7 +227,6 @@ class Banner {
 		const closeButton = document.createElement('button');
 		closeButton.className = classNames.close;
 		closeButton.setAttribute('aria-label', this.options.closeButtonLabel);
-		closeButton.setAttribute('title', this.options.closeButtonLabel);
 		if (this.bannerElement.id) {
 			closeButton.setAttribute('aria-controls', this.bannerElement.id);
 		}

--- a/components/o-banner/test/banner.test.js
+++ b/components/o-banner/test/banner.test.js
@@ -488,7 +488,7 @@ describe('Banner', () => {
 											<a href="#" class="o-banner__link">Give feedback</a>
 										</div>
 									</div>
-									<button class="o-banner__close" aria-label="Close banner" title="Close banner" aria-controls="o-banner-test"></button>
+									<button class="o-banner__close" aria-label="Close banner" aria-controls="o-banner-test"></button>
 								</div>
 							</div>
 						</div>`
@@ -850,7 +850,7 @@ describe('Banner', () => {
 
 			it('constructs the element HTML based on the given options', () => {
 				assert.dom.equal(returnValue, `
-					<button class="o-banner__close" aria-label="mockCloseButtonLabel" title="mockCloseButtonLabel"></button>
+					<button class="o-banner__close" aria-label="mockCloseButtonLabel"></button>
 				`);
 			});
 


### PR DESCRIPTION
If an element has both a title attribute and an aria-label attribute, then both will be read out by screen-readers

This change removes the aria-label attribute and keeps the title attribute.

This resolves issue https://github.com/Financial-Times/origami/issues/554