### PR TITLE
Delete serve.json

### DIFF
--- a/scripts/build-website.bash
+++ b/scripts/build-website.bash
@@ -9,7 +9,6 @@ bundle exec jekyll build -d ../../origami.ft.com --incremental
 cd ../storybook/
 npm run build-storybook
 cd ../../
-cp serve.json origami.ft.com
 
 if ! [ -z "$SHOULD_DELETE_ALL_YOUR_FILES" ]; then
 	rm -r apps components libraries tools

--- a/serve.json
+++ b/serve.json
@@ -1,3 +1,0 @@
-{
-	"trailingSlash": true
-}


### PR DESCRIPTION
https://github.com/vercel/serve-handler/blob/c7a40435bc28b420a725e6dc1e9565d5b845dee2/src/index.js#L121-L122

we need to just delete serve.json altogether

so that there is no redirect

then we need to go to `/storybook/` manually.

this is what we had before, when it worked. then i added the serve.json thinking it would mean we wouldn't have to remember to go to `/storybook/` by ourselves.
but that also meant that it redirects `/iframe.html` it `/iframe/`, and then when the `iframe` tries to load relative javascript files, it tries to load them from the `/iframe/` sub-dir (which doesn't exist)

maybe we should use something other than `serve` lol.