### PR TITLE
o-footer-services: include text for screen-readers to explain external links open in a new window

### DIFF
--- a/components/o-footer-services/src/scss/_mixins.scss
+++ b/components/o-footer-services/src/scss/_mixins.scss
@@ -142,6 +142,16 @@
 				$include-base-styles: false
 			);
 		}
+		.o-footer-services__content--external::after {
+			content: "(opens in a new window)";
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			height: 1px;
+			overflow: hidden;
+			position: absolute;
+			white-space: nowrap;
+			width: 1px;
+		}
 	}
 
 	@if $brand-strip {


### PR DESCRIPTION
Currently we have a visual indication that the link will open in a new window but we do not supply any text to indicate this to users using screen-readers

This pull-request adds a textual description via an "after" pseudo-element which is visually hidden but available in the accessibility tree for screen-readers to read out.

An alternative solution to this would be to include the text description in a "span" element which has a class to visually hide the content. I went with the "after" pseudo-element approach as it involves zero markup changes and will apply to all external links which make use of the visual indicator via the "o-footer-services__content--external" class

This resolves https://github.com/Financial-Times/origami/issues/516