### PR TITLE
fix: show the entire focus ring for links within the drawer

### DIFF
--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -246,8 +246,11 @@
 		}
 	}
 
+	// These values exist to show the focus ring
+	// We need to keep them at-least equal to the outline width in o-normalise
 	.o-header__drawer-menu-item {
-		margin-top: 1px;
+		margin-top: 2px;
+		margin-bottom: 2px;
 	}
 
 	.o-header__drawer-menu-item--divide {

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -246,11 +246,8 @@
 		}
 	}
 
-	// These values exist to show the focus ring
-	// We need to keep them at-least equal to the outline width in o-normalise
 	.o-header__drawer-menu-item {
-		margin-top: 2px;
-		margin-bottom: 2px;
+		margin-top: 1px;
 	}
 
 	.o-header__drawer-menu-item--divide {
@@ -332,6 +329,10 @@
 		border-bottom: 0;
 		font-size: 18px;
 		text-decoration: none;
+		// This value exists to show the focus ring
+		// We need to keep it in sync to the outline width in o-normalise
+		// TODO: We should find a more maintainable way of setting focus rings
+		outline-offset: -2px;
 
 		&:hover {
 			color: _oHeaderGet('drawer-menu-link-hover-text');


### PR DESCRIPTION
previously only the top line of the focus ring was being shown

resolves https://github.com/Financial-Times/origami/issues/548


Without this change applied:
![image](https://user-images.githubusercontent.com/1569131/153246595-26d64f81-1db5-4ff8-aae9-f3b6a71f1cbd.png)


With this change applied:
![image](https://user-images.githubusercontent.com/1569131/153251494-af354d37-e838-4b94-99f4-4b80e16d706e.png)


