### PR TITLE
backstage: o-buttons group story, use index for key

### DIFF
--- a/components/o-buttons/stories/button-group.stories.tsx
+++ b/components/o-buttons/stories/button-group.stories.tsx
@@ -17,7 +17,7 @@ export default {
 };
 
 const ButtonGroupStory = args => <ButtonGroup>
-	{args.buttons.map(buttonProps => <Button {...buttonProps} key={buttonProps.label + buttonProps.type}/>)}
+	{args.buttons.map((buttonProps, index) => <Button {...buttonProps} key={index}/>)}
 </ButtonGroup>;
 
 export const GroupedButtons = ButtonGroupStory.bind({});


### PR DESCRIPTION
prevent duplicate keys. index is fine as the button order is unchanging