### PR TITLE
Add o-visual-effects Story

### DIFF
--- a/components/o-visual-effects/README.md
+++ b/components/o-visual-effects/README.md
@@ -51,7 +51,14 @@ E.g.
 }
 ```
 
-Sass users should use [Sass variables](#sass) instead for improved browser support.
+CSS Custom Properties (CSS Variables) are also available for shadows.
+
+E.g.
+```css
+.my-shadow {
+	box-shadow: var(--o-visual-effects-shadow-high);
+}
+```
 
 ## Sass
 

--- a/components/o-visual-effects/main.scss
+++ b/components/o-visual-effects/main.scss
@@ -33,9 +33,12 @@
 		}
 	}
 
-	:root {
-		@each $shadow in $shadows {
-			--o-visual-effects-shadow-#{$shadow}: #{oVisualEffectsShadow($shadow)};
+
+	@if ($shadows) {
+		:root {
+			@each $shadow in $shadows {
+				--o-visual-effects-shadow-#{$shadow}: #{oVisualEffectsShadow($shadow)};
+			}
 		}
 	}
 

--- a/components/o-visual-effects/main.scss
+++ b/components/o-visual-effects/main.scss
@@ -33,6 +33,13 @@
 		}
 	}
 
+	:root {
+		@each $shadow in $shadows {
+			--o-visual-effects-shadow-#{$shadow}: #{oVisualEffectsShadow($shadow)};
+		}
+	}
+
+
 	@if($ultralow) {
 		.o-visual-effects-shadow-ultralow {
 			@include oVisualEffectsShadowContent('ultralow');

--- a/components/o-visual-effects/src/scss/_shadows.scss
+++ b/components/o-visual-effects/src/scss/_shadows.scss
@@ -1,21 +1,29 @@
 /// Elevation
-/// @param {String} $elevation - 'ultra', 'low', 'mid' or 'high'
-/// @param {Color} $color
+/// @param {String} $elevation [] - 'ultra', 'low', 'mid' or 'high'
+/// @param {Color} $color []
 /// @output A repeating linear gradient background
 @mixin oVisualEffectsShadowContent($elevation: 'low', $color: $o-visual-effects-shadow-color) {
+	box-shadow: oVisualEffectsShadow($elevation, $color);
+}
+
+/// Elevation
+/// @param {String} $elevation [] - 'ultra', 'low', 'mid' or 'high'
+/// @param {Color} $color []
+/// @output A repeating linear gradient background
+@function oVisualEffectsShadow($elevation: 'low', $color: $o-visual-effects-shadow-color) {
 	@if $elevation == 'ultralow' {
-		box-shadow: 0 2px 2px rgba($color, 0.12), 0 4px 6px rgba($color, 0.1);
+		@return 0 2px 2px rgba($color, 0.12), 0 4px 6px rgba($color, 0.1);
 	}
 
 	@if $elevation == 'low' {
-		box-shadow: 0 1px 2px rgba($color, 0.25), 0 4px 6px rgba($color, 0.1);
+		@return 0 1px 2px rgba($color, 0.25), 0 4px 6px rgba($color, 0.1);
 	}
 
 	@if $elevation == 'mid' {
-		box-shadow: 0 1px 3px rgba($color, 0.2), 0 6px 10px rgba($color, 0.15);
+		@return 0 1px 3px rgba($color, 0.2), 0 6px 10px rgba($color, 0.15);
 	}
 
 	@if $elevation == 'high' {
-		box-shadow: 0 1px 4px rgba($color, 0.15), 0 8px 14px rgba($color, 0.2);
+		@return 0 1px 4px rgba($color, 0.15), 0 8px 14px rgba($color, 0.2);
 	}
 }

--- a/components/o-visual-effects/src/scss/_shadows.scss
+++ b/components/o-visual-effects/src/scss/_shadows.scss
@@ -26,4 +26,6 @@
 	@if $elevation == 'high' {
 		@return 0 1px 4px rgba($color, 0.15), 0 8px 14px rgba($color, 0.2);
 	}
+
+	@error 'A shadow with elevation "#{$elevation}" is not supported. Must be one of: "ultralow", "low", "mid", or "high".'
 }

--- a/components/o-visual-effects/src/scss/_shadows.scss
+++ b/components/o-visual-effects/src/scss/_shadows.scss
@@ -27,5 +27,5 @@
 		@return 0 1px 4px rgba($color, 0.15), 0 8px 14px rgba($color, 0.2);
 	}
 
-	@error 'A shadow with elevation "#{$elevation}" is not supported. Must be one of: "ultralow", "low", "mid", or "high".'
+	@error 'A shadow with elevation "#{$elevation}" is not supported. Must be one of: "ultralow", "low", "mid", or "high".';
 }

--- a/components/o-visual-effects/stories/shadows-demo.tsx
+++ b/components/o-visual-effects/stories/shadows-demo.tsx
@@ -1,0 +1,17 @@
+import {CSSProperties} from 'react';
+
+export interface ShadowProps {
+    depth: 'ultralow'|'low'|'mid'|'high';
+};
+
+export function ShadowDemo ({
+    depth
+} : ShadowProps) {
+
+    // Use CSS Properties to demo their use in the HTML tab
+    const customProperties = {
+        'box-shadow': `var(--o-visual-effects-shadow-${depth})`,
+    } as CSSProperties;
+
+    return <div style={customProperties} className="shadow-demo">{depth} shadow</div>;
+};

--- a/components/o-visual-effects/stories/shadows.stories.tsx
+++ b/components/o-visual-effects/stories/shadows.stories.tsx
@@ -1,0 +1,19 @@
+import {withDesign} from 'storybook-addon-designs';
+import './visual-effects.scss';
+import withHtml from 'origami-storybook-addon-html';
+import {ShadowDemo} from './shadows-demo';
+
+export default {
+	title: 'Components/o-visual-effects',
+    component: ShadowDemo,
+	decorators: [withDesign, withHtml],
+	parameters: {
+		guidelines: {},
+		html: {},
+	},
+};
+
+export const Shadows = ShadowDemo.bind({});
+Shadows.args = {
+    depth: 'mid'
+};

--- a/components/o-visual-effects/stories/transition-demo.tsx
+++ b/components/o-visual-effects/stories/transition-demo.tsx
@@ -1,0 +1,54 @@
+import {CSSProperties, useState} from 'react';
+
+export interface TransitionProps {
+    transition: 'fade'|'expand'|'slide';
+    timing: Number
+};
+
+export function TransitionDemo ({
+    transition,
+    timing,
+} : TransitionProps) {
+    const [active, updateActiveStatus] = useState(false);
+    const classes = ['demo-transition', `demo-transition--${transition}`];
+    let label = '';
+    switch (transition) {
+        case 'slide':
+                label = `a circle that ${active ? 'has slid' : 'can slide'} from left to right`;
+            break;
+        case 'expand':
+                label = `a square that ${active ? 'has expanded' : 'can expand'}`;
+            break;
+        case 'fade':
+                label = `a square that ${active ? 'can fade in and out' : 'has faded out'}`;
+            break;
+        default:
+            const _exhaustiveCheck: never = transition;
+            label = `a shape with a "${transition}" transition applied`;
+            console.warn(`Could not create a descriptive label for o-visual-effects transition "${_exhaustiveCheck}".`);
+            break;
+    }
+    if(active) {
+        classes.push('demo-transition--active');
+    }
+
+    // Use CSS Properties to demo their use in the HTML tab
+    const customProperties = {
+        '--demo-transition-timing-function': `var(--o-visual-effects-timing-${transition})`,
+        '--demo-transition-duration': `${timing}s`,
+    } as CSSProperties;
+
+    return <>
+        <button
+            aria-controls="demo-element"
+            aria-pressed={active}
+            className="demo-button"
+            onClick={() => {updateActiveStatus(!active)}}
+        >{transition}</button>
+        <div
+            id="demo-element"
+            className={classes.join(' ')}
+            style={customProperties}
+        ><span className="demo-transition__label" aria-live='polite'>{label}</span></div>
+    </>;
+};

--- a/components/o-visual-effects/stories/transitions.stories.tsx
+++ b/components/o-visual-effects/stories/transitions.stories.tsx
@@ -1,0 +1,32 @@
+import {withDesign} from 'storybook-addon-designs';
+import './visual-effects.scss';
+import withHtml from 'origami-storybook-addon-html';
+import {TransitionDemo} from './transition-demo';
+
+export default {
+	title: 'Components/o-visual-effects',
+    component: TransitionDemo,
+	decorators: [withDesign, withHtml],
+	parameters: {
+		guidelines: {},
+		html: {},
+	},
+};
+
+export const Expand = TransitionDemo.bind({});
+Expand.args = {
+    transition: 'expand',
+    timing: 0.3
+};
+
+export const Slide = TransitionDemo.bind({});
+Slide.args = {
+    transition: 'slide',
+    timing: 0.3
+};
+
+export const Fade = TransitionDemo.bind({});
+Fade.args = {
+    transition: 'fade',
+    timing: 0.3
+};

--- a/components/o-visual-effects/stories/visual-effects.scss
+++ b/components/o-visual-effects/stories/visual-effects.scss
@@ -11,52 +11,52 @@
 @include oVisualEffects();
 
 .demo-button {
-    @include oButtonsContent((
-        'size': 'big',
-        'type': 'primary',
-    ));
-    margin-right: oSpacingByName('s8');
-    float: left;
+	@include oButtonsContent((
+		'size': 'big',
+		'type': 'primary',
+	));
+	margin-right: oSpacingByName('s8');
+	float: left;
 }
 
 .demo-transition {
-    --demo-size: min(50vh, 50vw);
-    background-color: oColorsByName('teal-100');
-    border: 3px dashed oColorsByName('slate');
-    width: var(--demo-size);
-    height: var(--demo-size);
-    transition: all var(--demo-transition-duration) var(--demo-transition-timing-function);
-    display: inline-block;
+	--demo-size: min(50vh, 50vw);
+	background-color: oColorsByName('teal-100');
+	border: 3px dashed oColorsByName('slate');
+	width: var(--demo-size);
+	height: var(--demo-size);
+	transition: all var(--demo-transition-duration) var(--demo-transition-timing-function);
+	display: inline-block;
 }
 
 .demo-transition--slide {
-    border-radius: 100%;
-    transform: translateX(0);
-    &.demo-transition--active {
-        transform: translateX(calc(80vw - var(--demo-size)));
-    }
+	border-radius: 100%;
+	transform: translateX(0);
+	&.demo-transition--active {
+		transform: translateX(calc(80vw - var(--demo-size)));
+	}
 }
 
 .demo-transition--expand {
-    &.demo-transition--active {
-        height: calc(#{var(--demo-size)} * #{1.5});
-    }
+	&.demo-transition--active {
+		height: calc(#{var(--demo-size)} * #{1.5});
+	}
 }
 
 .demo-transition--fade {
-    opacity: 1;
-    &.demo-transition--active {
-        opacity: 0.3;
-    }
+	opacity: 1;
+	&.demo-transition--active {
+		opacity: 0.3;
+	}
 }
 
 .demo-transition__label {
-    @include oNormaliseVisuallyHidden();
+	@include oNormaliseVisuallyHidden();
 }
 
 .shadow-demo {
-    @include oTypographySans($scale: 1);
-    display: inline-flex;
+	@include oTypographySans($scale: 1);
+	display: inline-flex;
 	background: white;
 	width: 10rem;
 	height: 10rem;

--- a/components/o-visual-effects/stories/visual-effects.scss
+++ b/components/o-visual-effects/stories/visual-effects.scss
@@ -3,9 +3,11 @@
 @import "@financial-times/o-buttons/main";
 @import "@financial-times/o-spacing/main";
 @import "@financial-times/o-typography/main";
+@import "@financial-times/o-fonts/main";
 @import "@financial-times/o-colors/main";
 
 @include oNormalise();
+@include oFonts();
 @include oVisualEffects();
 
 .demo-button {

--- a/components/o-visual-effects/stories/visual-effects.scss
+++ b/components/o-visual-effects/stories/visual-effects.scss
@@ -1,0 +1,64 @@
+@import "@financial-times/o-visual-effects/main";
+@import "@financial-times/o-normalise/main";
+@import "@financial-times/o-buttons/main";
+@import "@financial-times/o-spacing/main";
+@import "@financial-times/o-typography/main";
+@import "@financial-times/o-colors/main";
+
+@include oNormalise();
+@include oVisualEffects();
+
+.demo-button {
+    @include oButtonsContent((
+        'size': 'big',
+        'type': 'primary',
+    ));
+    margin-right: oSpacingByName('s8');
+    float: left;
+}
+
+.demo-transition {
+    --demo-size: min(50vh, 50vw);
+    background-color: oColorsByName('teal-100');
+    border: 3px dashed oColorsByName('slate');
+    width: var(--demo-size);
+    height: var(--demo-size);
+    transition: all var(--demo-transition-duration) var(--demo-transition-timing-function);
+    display: inline-block;
+}
+
+.demo-transition--slide {
+    border-radius: 100%;
+    transform: translateX(0);
+    &.demo-transition--active {
+        transform: translateX(calc(80vw - var(--demo-size)));
+    }
+}
+
+.demo-transition--expand {
+    &.demo-transition--active {
+        height: calc(#{var(--demo-size)} * #{1.5});
+    }
+}
+
+.demo-transition--fade {
+    opacity: 1;
+    &.demo-transition--active {
+        opacity: 0.3;
+    }
+}
+
+.demo-transition__label {
+    @include oNormaliseVisuallyHidden();
+}
+
+.shadow-demo {
+    @include oTypographySans($scale: 1);
+    display: inline-flex;
+	background: white;
+	width: 10rem;
+	height: 10rem;
+	margin: oSpacingByName('s3');
+	justify-content: center;
+	align-items: center;
+}


### PR DESCRIPTION
This one is interesting as demo CSS and markup is required. Although we prefer to 
avoid demo CSS and allow full demo markup to be copy/paster, I think this component 
Story belongs to visualise what the component provides – i.e. it's unlike contrast checking
tools which we currently have in o-colors and would like not to port to a Story under the 
o-colors component.

To make the HTML tab useful for build service users I've used the CSS custom properties
o-visual-effects outputs inline.
![Screenshot 2022-02-14 at 12 58 14](https://user-images.githubusercontent.com/10405691/153869466-f09d18f9-c38a-4564-b203-8902b67ef0d6.png)

