### PR TITLE
use `--o-colors-page-background` as default page background colour

### DIFF
--- a/apps/storybook/addons/background/src/preset/preview.js
+++ b/apps/storybook/addons/background/src/preset/preview.js
@@ -1,18 +1,23 @@
-import { withOrigamiBackground } from '../withOrigamiBackground';
+import {withOrigamiBackground} from "../withOrigamiBackground"
 
-export const decorators = [withOrigamiBackground];
+export const decorators = [withOrigamiBackground]
 
 export const globalTypes = {
-    origamiBackground: {
-      name: 'Origami Background',
-      description: 'Background colour to show components on.',
-      toolbar: {
-        icon: 'photo',
-        items: [{
-          value: '',
-          title: 'recommended',
-        }, 'paper', 'wheat', 'slate'],
-        showName: false,
-      },
-    },
-  };
+	origamiBackground: {
+		name: "Origami Background",
+		description: "Background colour to show components on.",
+		toolbar: {
+			icon: "photo",
+			items: [
+				{
+					value: "",
+					title: "recommended",
+				},
+				"paper",
+				"wheat",
+				"slate",
+			],
+			showName: false,
+		},
+	},
+}

--- a/apps/storybook/addons/background/src/withOrigamiBackground.js
+++ b/apps/storybook/addons/background/src/withOrigamiBackground.js
@@ -9,9 +9,9 @@ export const withOrigamiBackground = (Story, context) => {
 		context.parameters.origamiBackground ||
 		"page-background"
 
-	const origamiBackgroundHex = getComputedStyle(document.body).getPropertyValue(
-		`--o-colors-${origamiBackground}`
-	)
+	const origamiBackgroundHex = getComputedStyle(document.body)
+		.getPropertyValue(`--o-colors-${origamiBackground}`)
+		.trim()
 
 	const foreground =
 		contrast(origamiBackgroundHex, "black") >= 4.5 ? "black" : "white"

--- a/apps/storybook/addons/background/src/withOrigamiBackground.js
+++ b/apps/storybook/addons/background/src/withOrigamiBackground.js
@@ -1,27 +1,30 @@
-import { useGlobals } from '@storybook/addons';
-import { contrast } from 'chroma-js';
+import {useGlobals} from "@storybook/addons"
+import {contrast} from "chroma-js"
 
 export const withOrigamiBackground = (Story, context) => {
-  let css = '';
-  let [{ origamiBackground }] = useGlobals();
-  origamiBackground = origamiBackground || context.parameters.origamiBackground;
+	let css = ""
+	let [{origamiBackground}] = useGlobals()
+	origamiBackground =
+		origamiBackground ||
+		context.parameters.origamiBackground ||
+		"page-background"
 
-  if (origamiBackground) {
-    const origamiBackgroundHex = getComputedStyle(document.body).getPropertyValue(`--o-colors-${origamiBackground}`);
-    const foreground = contrast(origamiBackgroundHex, 'black') >= 4.5 ? 'black' : 'white';
-    css = `
+	const origamiBackgroundHex = getComputedStyle(document.body).getPropertyValue(
+		`--o-colors-${origamiBackground}`
+	)
+
+	const foreground =
+		contrast(origamiBackgroundHex, "black") >= 4.5 ? "black" : "white"
+	css = `
       body {
         background: var(--o-colors-${origamiBackground});
         color: ${foreground};
-      }`;
-  }
+      }`
 
-  return <>
-       <style>{css}</style>
-       <Story />
-     </>
-
-};
-
-
-
+	return (
+		<>
+			<style>{css}</style>
+			<Story />
+		</>
+	)
+}

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -54,7 +54,7 @@ InverseButton.args = {
 	theme: 'inverse',
 };
 InverseButton.parameters = {
-	origamiBackground: 'slate'
+	origamiBackground: 'slate',
 };
 
 export const MonoButton = ButtonStory.bind({});


### PR DESCRIPTION
## changes

- line 10 of withOrigamiBackground.js adds `|| "page-background"`
	-  so we default to whatever is the right background for the current theme
-  line 14 of withOrigamiBackground.js`.trim()`s the origamiBackgroundHex before using it
	- because for some reason the returned hex on it had a space in it when i was testing locally!?!?!
- prettier was run on the code