### PR TITLE
fix: o-table filter when a second filter or more is applied

### DIFF
--- a/components/o-table/src/scss/_base.scss
+++ b/components/o-table/src/scss/_base.scss
@@ -71,10 +71,12 @@
 		margin-left: 10px;
 	}
 
-	// Visually hide any filtered rows.
-	// `display: none` is not used to avoid recalculating column row.
+	// Hide any filtered or hidden rows.
+	// `visibility: hidden` ensures children can't be tabbed to.
+	// `display: none` is not used as o-table relies on row being rendered to get their height.
 	// `visibility: collaposed` is not used due to inconsistent browser support.
 	// stylelint-disable-next-line selector-no-qualifying-type
+	tr[aria-hidden="true"],
 	tr[data-o-table-filtered="true"] {
 		visibility: hidden;
 	}

--- a/components/o-table/src/scss/_base.scss
+++ b/components/o-table/src/scss/_base.scss
@@ -75,10 +75,10 @@
 	// `visibility: hidden` ensures children can't be tabbed to.
 	// `display: none` is not used as o-table relies on row being rendered to get their height.
 	// `visibility: collaposed` is not used due to inconsistent browser support.
-	// stylelint-disable-next-line selector-no-qualifying-type
+	//stylelint-disable selector-no-qualifying-type
 	tr[aria-hidden="true"],
 	tr[data-o-table-filtered="true"] {
 		visibility: hidden;
 	}
-	// sass-lint:enable no-qualifying-elements
+	//stylelint-enable selector-no-qualifying-type
 }

--- a/components/o-table/src/scss/_responsive-overflow.scss
+++ b/components/o-table/src/scss/_responsive-overflow.scss
@@ -5,13 +5,6 @@
 @mixin _oTableResponsiveOverflow {
 	@include _oTableOverflowControlsOverlay;
 	@include _oTableOverflowFadeOverlay;
-	.o-table--responsive-overflow {
-		// Remove all hidden cells.
-		tr[aria-hidden="true"] { // stylelint-disable-line selector-no-qualifying-type
-			display: none;
-		}
-		// sass-lint:enable no-qualifying-elements
-	}
 }
 
 /// Styles for controls which overlay the table. Such as scroll forward/back buttons,


### PR DESCRIPTION
fix: o-table filter when a second filter or more is applied

This commit sets filtered table rows to `display: none`, to remove
filtered row content from tabindex.
https://github.com/Financial-Times/origami/commit/e9e7a173581c9a58fc04f91f5c71bb32c0e905dc

However o-table requires that rows are rendered to figure out
what height to set on the table:
https://github.com/Financial-Times/origami/blob/f49145eab4acaed27d8268138082e3480af3f02f/components/o-table/src/js/Tables/BaseTable.js#L248

This means setting `display: none` broke table sorting visually.

Filtered rows already apply `visibility: hidden`:
https://github.com/Financial-Times/origami/blob/7a0971d7bb70b25b9f6484f0a4e982a5f27b18e5/components/o-table/src/scss/_base.scss#L74

Which means no child receives focus (according to mdn and limited testing at least):
https://developer.mozilla.org/en-US/docs/Web/CSS/visibility

It appears `display: none` was introduced because of switching to axe
for markup tests, rather than from an audit or report.
https://github.com/Financial-Times/origami/pull/477

Update:
After further exploration it's large tables with rows hidden by
an expander which caused this issue. As rows hidden behind the
expander, and not filtered, did not have `visibility: hidden`
applied.
