### PR TITLE
fix: bring support for firefox to ft-concept-button

### DIFF
--- a/components/ft-concept-button/src/js/ft-concept-button.js
+++ b/components/ft-concept-button/src/js/ft-concept-button.js
@@ -49,7 +49,8 @@ export default class FtConceptButton {
 		) {
 			this.button.setAttribute('aria-label', state
 				? this.options.ariaLabelPressedText
-				: this.options.ariaLabelUnpressedText;
+				: this.options.ariaLabelUnpressedText
+			);
 		}
 	}
 


### PR DESCRIPTION
ariaPressed and ariaLabel are not yet supported in Firefox - we can use setAttribute instead

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaPressed#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaLabel#browser_compatibility