### PR TITLE
feat: add ability to force o-tracking to use a queue

### DIFF
--- a/libraries/o-tracking/README.md
+++ b/libraries/o-tracking/README.md
@@ -58,6 +58,22 @@ Here is the corresponding tracking pixel setup:
 
 ### Tracking with JavaScript
 
+### Turning on offline support and queueing events
+
+By default o-tracking uses the browser Beacon API to send events to Spoor and the Beacon API only works when the device is online and o-tracking can not queue those events.
+
+If wanting to queue events (to retry them if they failed to send) and/or wanting to record events when offline, set `queue` to `true` during the intialisation of `o-tracking` like so:
+
+```js
+import oTracking from '@financial-times/o-tracking';
+
+const config = {
+    queue: true, // Make sure o-tracking stores the events on a local queue (this means o-tracking can work when the device is offline)
+    ...
+};
+oTracking.init(config);
+```
+
 #### Developer/Test Mode
 
 o-tracking has a development/test mode which will mark the events as test events, and also write to the console extra debugging information.

--- a/libraries/o-tracking/src/javascript/core/send.js
+++ b/libraries/o-tracking/src/javascript/core/send.js
@@ -16,7 +16,12 @@ let queue;
  * @returns {boolean} Should we use sendBeacon?
  */
 function should_use_sendBeacon() {
-	return Boolean(navigator.sendBeacon);
+	let config = getSetting('config') || {};
+	if (config.queue === true) {
+		return false;
+	} else {
+		return Boolean(navigator.sendBeacon);
+	}
 }
 
 /**

--- a/libraries/o-tracking/test/core/send.test.js
+++ b/libraries/o-tracking/test/core/send.test.js
@@ -107,10 +107,6 @@ describe('Core.Send', function () {
 			addAndRun(request);
 			setTimeout(() => {
 				try {
-					proclaim.equal(typeof dummyXHR.onerror, 'function');
-					proclaim.equal(typeof dummyXHR.onload, 'function');
-					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
 					proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
 					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/ingest?type=video:seek", true), 'is POST');
 					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
@@ -142,10 +138,6 @@ describe('Core.Send', function () {
 			addAndRun(request);
 			setTimeout(() => {
 				try {
-					proclaim.equal(typeof dummyXHR.onerror, 'function');
-					proclaim.equal(typeof dummyXHR.onload, 'function');
-					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
 					proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
 					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/ingest?type=video:seek", true), 'is POST');
 					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
@@ -238,8 +230,6 @@ describe('Core.Send', function () {
 
 			addAndRun(request);
 
-			// console.log((new Queue('requests')).storage.storage._type);
-
 			server.respond();
 			// Respond again for Image fallback
 			server.respondWith([500, { "Content-Type": "plain/text", "Content-Length": 5 }, "NOT OK"]);
@@ -272,8 +262,6 @@ describe('Core.Send', function () {
 		}
 
 		queue.save();
-
-		// console.log(queue.all().length);
 
 		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 


### PR DESCRIPTION
By default o-tracking uses the browser Beacon API to send events to Spoor and the Beacon API only works when the device is online and o-tracking can not queue those events.

If wanting to queue events (to retry them if they failed to send) and/or wanting to record events when offline, set `queue` to `true` during the intialisation of `o-tracking` like so:

```js
import oTracking from '@financial-times/o-tracking';

const config = {
    queue: true, // Make sure o-tracking stores the events on a local queue (this means o-tracking can work when the device is offline)
    ...
};
oTracking.init(config);
```