### PR TITLE
fix: o-header, handle nav icon spacing within `o-header__nav-item`

### DIFF
--- a/components/o-header/demos/src/deprecated-markup.mustache
+++ b/components/o-header/demos/src/deprecated-markup.mustache
@@ -33,8 +33,11 @@
 					</a>
 				</div>
 				<div class="o-header__top-column o-header__top-column--right">
+					{{#anon}}
+						<a class="o-header__top-button" href="">Subscribe</a>
+					{{/anon}}
 					{{#hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/hasMyFT}}

--- a/components/o-header/demos/src/grid-demo.mustache
+++ b/components/o-header/demos/src/grid-demo.mustache
@@ -35,8 +35,11 @@
 					</a>
 				</div>
 				<div class="o-header__top-column o-header__top-column--right">
+					{{#anon}}
+						<a class="o-header__top-button" href="">Subscribe</a>
+					{{/anon}}
 					{{#hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/hasMyFT}}

--- a/components/o-header/demos/src/header.mustache
+++ b/components/o-header/demos/src/header.mustache
@@ -35,8 +35,11 @@
 					</a>
 				</div>
 				<div class="o-header__top-column o-header__top-column--right">
+					{{#anon}}
+						<a class="o-header__top-button" href="">Subscribe</a>
+					{{/anon}}
 					{{#hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/hasMyFT}}

--- a/components/o-header/demos/src/pa11y.mustache
+++ b/components/o-header/demos/src/pa11y.mustache
@@ -33,8 +33,11 @@
 					</a>
 				</div>
 				<div class="o-header__top-column o-header__top-column--right">
+					{{#anon}}
+						<a class="o-header__top-button" href="">Subscribe</a>
+					{{/anon}}
 					{{#hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/hasMyFT}}

--- a/components/o-header/demos/src/simple-header.mustache
+++ b/components/o-header/demos/src/simple-header.mustache
@@ -24,7 +24,7 @@
 				<div class="o-header__top-column o-header__top-column--right">
 					<!--<div class="o-header__top-takeover"></div>-->
 					{{#top.hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/top.hasMyFT}}

--- a/components/o-header/demos/src/sticky-header.mustache
+++ b/components/o-header/demos/src/sticky-header.mustache
@@ -53,8 +53,12 @@
 						</div>
 						{{/nav.isSignedIn}}
 
+						{{#anon}}
+							<a class="o-header__top-button" href="">Subscribe</a>
+						{{/anon}}
+
 						{{#nav.isSignedIn}}
-						<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T" tabindex="-1">
+						<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T" tabindex="-1">
 							<span class="o-header__visually-hidden">myFT</span>
 						</a>
 						{{/nav.isSignedIn}}

--- a/components/o-header/demos/src/sticky-header.mustache
+++ b/components/o-header/demos/src/sticky-header.mustache
@@ -54,7 +54,7 @@
 						{{/nav.isSignedIn}}
 
 						{{#anon}}
-							<a class="o-header__top-button" href="">Subscribe</a>
+							<a class="o-header__top-button" href="" tabindex="-1">Subscribe</a>
 						{{/anon}}
 
 						{{#nav.isSignedIn}}

--- a/components/o-header/demos/src/subbrand.mustache
+++ b/components/o-header/demos/src/subbrand.mustache
@@ -22,7 +22,7 @@
 
 				<div class="o-header__top-column o-header__top-column--right">
 					{{#top.hasMyFT}}
-					<a class="o-header__top-link o-header__top-link--myft" href="/myft" aria-label="My F T">
+					<a class="o-header__top-link o-header__top-link--hide-s o-header__top-link--myft" href="/myft" aria-label="My F T">
 						<span class="o-header__visually-hidden">myFT</span>
 					</a>
 					{{/top.hasMyFT}}

--- a/components/o-header/main.scss
+++ b/components/o-header/main.scss
@@ -33,6 +33,12 @@
 /// @param {Boolean} $include-base-styles [true]
 @mixin oHeader($opts: $_o-header-features, $include-base-styles: true) {
 
+	@include oGridAddLayout(
+		$layout-name: 'oHeaderL',
+		$layout-width: 1080px,
+		$gutter-width: map-get($o-grid-gutters, 'M')
+	);
+
 	@if $include-base-styles == true {
 		@include _oHeaderBase;
 	}
@@ -45,6 +51,16 @@
 		}
 
 		// Output feature.
+		@if ($feature == 'top' or $feature == 'nav') and _oHeaderSupports($feature) {
+			.o-header__top-button,
+			.o-header__nav-button {
+				@include oButtonsContent((
+					'type': 'primary',
+					'theme': $_o-header-buttons-theme
+				));
+			}
+		}
+
 		@if $feature == 'top' and _oHeaderSupports($feature) {
 			@include _oHeaderTop;
 		}

--- a/components/o-header/src/scss/_variables.scss
+++ b/components/o-header/src/scss/_variables.scss
@@ -1,5 +1,7 @@
 $o-header-is-silent: true !default;
 
+$_o-header-column-item-margin-s: 10px;
+$_o-header-column-item-margin-l: 20px;
 $_o-header-padding-x: 14px;
 $_o-header-padding-y: 8px;
 $_o-header-buttons-theme: 'mono';

--- a/components/o-header/src/scss/features/_anon.scss
+++ b/components/o-header/src/scss/features/_anon.scss
@@ -2,7 +2,7 @@
 	.o-header__anon {
 		text-align: center;
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			display: none;
 		}
 	}

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -152,7 +152,7 @@
 		border-top: 2px solid oColorsByName('black-10');
 		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			display: none;
 		}
 	}

--- a/components/o-header/src/scss/features/_nav.scss
+++ b/components/o-header/src/scss/features/_nav.scss
@@ -14,7 +14,7 @@
 	.o-header__nav--mobile {
 		white-space: nowrap;
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			display: none;
 		}
 	}
@@ -22,7 +22,7 @@
 	.o-header__nav--desktop {
 		display: none;
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			display: block;
 		}
 	}
@@ -85,12 +85,5 @@
 		// sass-lint:disable no-vendor-prefixes
 		-webkit-font-smoothing: antialiased;
 		// sass-lint:enable no-vendor-prefixes
-	}
-
-	.o-header__nav-button {
-		@include oButtonsContent((
-			'type': 'primary',
-			'theme': $_o-header-buttons-theme
-		));
 	}
 }

--- a/components/o-header/src/scss/features/_simple.scss
+++ b/components/o-header/src/scss/features/_simple.scss
@@ -14,7 +14,7 @@
 			margin-top: 0;
 			margin-bottom: 0;
 
-			@include oGridRespondTo('L') {
+			@include oGridRespondTo('oHeaderL') {
 				@include _oHeaderLogoSize('M');
 			}
 		}

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -1,38 +1,41 @@
 @mixin _oHeaderTop() {
 	.o-header__top-wrapper {
-		display: table;
-		width: 100%;
-	}
-
-	.o-header__top-column {
-		display: table-cell;
-		vertical-align: middle;
+		display: grid;
+		grid-template-columns: 1fr min-content 1fr;
+		align-items: center;
+		gap: $_o-header-column-item-margin-s;
+		@include oGridRespondTo('XL') {
+			gap: $_o-header-column-item-margin-l;
+		}
 	}
 
 	.o-header__top-column--left,
 	.o-header__top-column--right {
-		// to keep the logo horizontally centered relative to the page these columns must be equal...
-		// ... can be removed from layout by fixing table layout and setting width to zero.
-		width: 12.5%;
+		display: flex;
+		align-items: center;
 		white-space: nowrap;
+		gap: $_o-header-column-item-margin-s;
+		@include oGridRespondTo('XL') {
+			gap: $_o-header-column-item-margin-l;
+		}
 	}
 
 	.o-header__top-column--left {
-		text-align: left;
+		justify-self: left;
 	}
 
 	.o-header__top-column--right {
-		text-align: right;
+		justify-self: right;
 	}
 
 	.o-header__top-column--center {
-		text-align: center;
+		justify-self: center;
 	}
 
 	.o-header__top-takeover {
 		display: none;
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			display: block;
 
 			& ~ * {
@@ -44,7 +47,6 @@
 	.o-header__top-link {
 		@include _oHeaderLink;
 		display: inline-block;
-		margin-left: 10px;
 		text-transform: uppercase;
 		font-size: 10px;
 		text-align: center;
@@ -52,8 +54,7 @@
 		margin-top: 4px;
 		margin-bottom: 4px;
 
-		@include oGridRespondTo('L') {
-			margin-left: 20px;
+		@include oGridRespondTo('oHeaderL') {
 			margin-top: 30px;
 			margin-bottom: 30px;
 		}
@@ -71,20 +72,14 @@
 		}
 	}
 
-	.o-header__nav-item:first-child {
-		> .o-header__top-link--menu,
-		> .o-header__top-link--search,
-		> .o-header__top-link--myft {
-			margin-left: -#{$_o-header-icon-size-large * 0.25px}; // remove space built into icon image, -10px size given 40px icon.
+	.o-header__top-link--hide-s {
+		@include oGridRespondTo($until: 'S') {
+			display: none;
 		}
 	}
 
-	.o-header__top-column {
-		> .o-header__top-link--menu:first-child,
-		> .o-header__top-link--search:first-child,
-		> .o-header__top-link--myft:first-child {
-			margin-left: -#{$_o-header-icon-size-large * 0.25px}; // remove space built into icon image, -10px size given 40px icon.
-		}
+	.o-header__top-link--menu {
+		margin-left: -#{$_o-header-icon-size-large * 0.25px}; // remove space built into icon image, -10px size given 40px icon.
 	}
 
 	.o-header__top-link--menu {
@@ -120,7 +115,7 @@
 				width: 44px;
 			}
 
-			@include oGridRespondTo('L') {
+			@include oGridRespondTo('oHeaderL') {
 				width: 52px;
 			}
 		}
@@ -151,7 +146,7 @@
 			margin-bottom: 24px;
 		}
 
-		@include oGridRespondTo('L') {
+		@include oGridRespondTo('oHeaderL') {
 			@include _oHeaderLogoSize('L');
 			margin-top: 30px;
 			margin-bottom: 30px;

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -69,10 +69,21 @@
 			width: #{$_o-header-icon-size-large}px;
 			height: #{$_o-header-icon-size-large}px;
 		}
+	}
 
-		// first child for old IE
-		&:first-child {
-			margin-left: -10px; // -10px to remove the padding that the icon image has around it when used at a size of 40px.
+	.o-header__nav-item:first-child {
+		> .o-header__top-link--menu,
+		> .o-header__top-link--search,
+		> .o-header__top-link--myft {
+			margin-left: -#{$_o-header-icon-size-large * 0.25px}; // remove space built into icon image, -10px size given 40px icon.
+		}
+	}
+
+	.o-header__top-column {
+		> .o-header__top-link--menu:first-child,
+		> .o-header__top-link--search:first-child,
+		> .o-header__top-link--myft:first-child {
+			margin-left: -#{$_o-header-icon-size-large * 0.25px}; // remove space built into icon image, -10px size given 40px icon.
 		}
 	}
 

--- a/components/o-header/src/scss/features/_transparent.scss
+++ b/components/o-header/src/scss/features/_transparent.scss
@@ -24,6 +24,7 @@
 			@include _oHeaderBrandImage('brand-ft-masthead', _oHeaderGet('header-icon', $from: 'transparent'), 500);
 		}
 
+		.o-header__top-button,
 		.o-header__nav-button {
 			@include oButtonsContent((
 				'type': 'primary',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,7 +1597,7 @@
     },
     "libraries/o-autoinit": {
       "name": "@financial-times/o-autoinit",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "engines": {
         "npm": "^7 || ^8"
@@ -1623,7 +1623,7 @@
     },
     "libraries/o-tracking": {
       "name": "@financial-times/o-tracking",
-      "version": "4.2.1",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "ftdomdelegate": "^5"


### PR DESCRIPTION
Suppports work to move the subscribe button to the sticky nav
for users who are logged in but not subscribed:

https://github.com/Financial-Times/dotcom-page-kit/pull/939

This state is not reflected in our demos. When we recreate
o-header demos in Storybook and provide JSX templates that
should be improved:
https://github.com/Financial-Times/origami/issues/522