### PR TITLE
fix: center ft logo in o-header when right/left columns are missing

### DIFF
--- a/components/o-header/demos/src/header-logo-only.mustache
+++ b/components/o-header/demos/src/header-logo-only.mustache
@@ -1,0 +1,13 @@
+<header class="o-header{{#variants}} o-header--{{.}}{{/variants}}" data-o-component="o-header" data-o-header--no-js>
+	<div class="o-header__row o-header__top">
+		<div class="o-header__container">
+			<div class="o-header__top-wrapper">
+				<div class="o-header__top-column o-header__top-column--center">
+					<a class="o-header__top-logo" href="/" title="Go to Financial Times homepage">
+						<span class="o-header__visually-hidden">Financial Times</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</header>

--- a/components/o-header/origami.json
+++ b/components/o-header/origami.json
@@ -65,6 +65,13 @@
 			"description": "The subnav may have right aligned actions, for example to sign out of an admin area. Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
+			"name": "header-logo-only",
+			"title": "Logo only header",
+			"data": "demos/src/header.json",
+			"template": "demos/src/header-logo-only.mustache",
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
+		},
+		{
 			"name": "simple-header",
 			"title": "Simple header",
 			"data": "demos/src/header.json",

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -21,15 +21,18 @@
 	}
 
 	.o-header__top-column--left {
+		grid-column-start: 1;
 		justify-self: left;
 	}
 
-	.o-header__top-column--right {
-		justify-self: right;
+	.o-header__top-column--center {
+		grid-column-start: 2;
+		justify-self: center;
 	}
 
-	.o-header__top-column--center {
-		justify-self: center;
+	.o-header__top-column--right {
+		grid-column-start: 3;
+		justify-self: right;
 	}
 
 	.o-header__top-takeover {


### PR DESCRIPTION
this pattern is used on login/signup pages for a full size logo