### PR TITLE
Checks for document before adding o.DOMContentLoaded event listener in o-toggle

### DIFF
--- a/components/o-toggle/main.js
+++ b/components/o-toggle/main.js
@@ -5,6 +5,6 @@ const constructAll = () => {
 	document.removeEventListener('o.DOMContentLoaded', constructAll);
 };
 
-if (document) document.addEventListener('o.DOMContentLoaded', constructAll);
+if (typeof document !== 'undefined') document.addEventListener('o.DOMContentLoaded', constructAll);
 
 export default Toggle;

--- a/components/o-toggle/main.js
+++ b/components/o-toggle/main.js
@@ -5,6 +5,6 @@ const constructAll = () => {
 	document.removeEventListener('o.DOMContentLoaded', constructAll);
 };
 
-document.addEventListener('o.DOMContentLoaded', constructAll);
+if (document) document.addEventListener('o.DOMContentLoaded', constructAll);
 
 export default Toggle;

--- a/components/o-toggle/main.js
+++ b/components/o-toggle/main.js
@@ -5,6 +5,8 @@ const constructAll = () => {
 	document.removeEventListener('o.DOMContentLoaded', constructAll);
 };
 
-if (typeof document !== 'undefined') document.addEventListener('o.DOMContentLoaded', constructAll);
+if (typeof document !== 'undefined') {
+	document.addEventListener('o.DOMContentLoaded', constructAll);
+}
 
 export default Toggle;


### PR DESCRIPTION
At present, o-toggle is used in both o-header and o-footer.

I want to be able to SSR headers and footers, because there's not much point in SSR if you need a client-side effect to render the header and footer (resulting in large CLS, part of the point of SSR being to avoid). However, because of the Origami practise of accessing `document` as a module-importing side-effect, this is utterly impossible at present and causes e.g. NextJS to throw `ReferenceError: document is not defined`

If Origami is going to continue to follow its idiom of adding event listeners as a side effect on module import, could you please at least existence check for `document` before accessing it? This would solve like 90% of my problems.