### PR TITLE
backstage: remove Build Service v2 use / links

### DIFF
--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -112,7 +112,7 @@ In rare cases, a user may have already set their display name in a different par
 
 ## JavaScript
 
-No code will run automatically unless you are using the [Build Service](https://www.ft.com/__origami/service/build/v2/). You must either construct an `o-comments` object or fire the `o.DOMContentLoaded` event, which o-comments listens for.
+No code will run automatically unless you are using the [Build Service](https://www.ft.com/__origami/service/build/). You must either construct an `o-comments` object or fire the `o.DOMContentLoaded` event, which o-comments listens for.
 
 ### Constructing an o-comments
 

--- a/components/o-forms/MIGRATION.md
+++ b/components/o-forms/MIGRATION.md
@@ -209,20 +209,7 @@ In the v0.x.x of o-forms, the module loaded webfonts itself and was setting its 
 
 The module now inherits the `font-family` set in your application and doesn't embed web fonts anymore.
 
-Solution: products must load webfonts themselves (tipically, with [o-fonts](https://github.com/Financial-Times/o-fonts) and [o-ft-icons](https://github.com/Financial-Times/o-ft-icons)).
-
-```html
-<!-- Load web fonts and icons with @font-face declarations  -->
-<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^3.0.0,o-icons@^5.0.0" />
-
-<!-- Set the font family on the whole document -->
-<style>
-	html {
-		font-family: BentonSans, sans-serif;
-	}
-</style>
-```
-
+Solution: products must load webfonts themselves (with [o-fonts](https://github.com/Financial-Times/o-fonts) and [o-ft-icons](https://github.com/Financial-Times/o-ft-icons)).
 
 #### 3. Helper classes name changes
 

--- a/components/o-grid/bookmarklet/bookmarklet.js
+++ b/components/o-grid/bookmarklet/bookmarklet.js
@@ -167,7 +167,7 @@
 
 	var head = document.getElementsByTagName("head")[0];
 	var gridScript = document.createElement("script");
-	gridScript.src = "https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^5.0.0";
+	gridScript.src = "https://www.ft.com/__origami/service/build/v3/bundles/js?components=o-grid@^6.0.0&system_code=origami";
 	gridScript.onload = init();
 	head.appendChild(gridScript);
 

--- a/components/o-overlay/README.md
+++ b/components/o-overlay/README.md
@@ -98,7 +98,7 @@ This table outlines all of the possible variants you can request in the [`oOverl
 
 ### Declarative
 
-JavaScript is initialised on `o-overlay` elements automatically for [Origami Build Service](https://www.ft.com/__origami/service/build/v2/) users. If your project is using a manual build process, [initialise `o-overlay` manually](https://origami.ft.com/documentation/components/initialising/).
+JavaScript is initialised on `o-overlay` elements automatically for [Origami Build Service](https://www.ft.com/__origami/service/build/) users. If your project is using a manual build process, [initialise `o-overlay` manually](https://origami.ft.com/documentation/components/initialising/).
 
 For example call the `init` method to initialise all `o-overlay` instances in the document:
 ```js

--- a/components/o-overlay/test/specs/smoke.test.js
+++ b/components/o-overlay/test/specs/smoke.test.js
@@ -388,7 +388,7 @@ describe("smoke-tests (./overlay.js)", function() {
 		this.timeout(10000);
 
 		const mod = new Overlay('testOverlay', {
-			src: 'https://www.ft.com/__origami/service/build/v2/files/o-card@2.2.3/demos/standard.html',
+			src: 'https://www.ft.com/__origami/service/build/v3/demo/html?component=o-typography%407.3.2&demo=links&system_code=origami&brand=core',
 			trigger: document.querySelector('.o-overlay-trigger')
 		});
 
@@ -396,7 +396,7 @@ describe("smoke-tests (./overlay.js)", function() {
 			let overlays = document.querySelectorAll('.o-overlay');
 			proclaim.equal(overlays.length, 1);
 
-			proclaim.include(mod.content.innerHTML, '<div class="o-card__container">');
+			proclaim.include(mod.content.innerHTML, 'o-typography-body');
 
 			mod.close();
 			overlays = document.querySelectorAll('.o-overlay');

--- a/components/o-spacing/README.md
+++ b/components/o-spacing/README.md
@@ -15,7 +15,7 @@ A styling utility component to aid projects and component with consistent spacin
 
 Check out [how to include Origami components in your project](https://origami.ft.com/documentation/components/#including-origami-components-in-your-project) to get started with `o-spacing`.
 
-For [Build Service](https://www.ft.com/__origami/service/build/v2/) users, `o-spacing` provides [CSS classes](#markup) for vertical space and [CSS Custom Properties (CSS Variables)](#css-custom-properties) for other usecases. For Sass users `o-spacing` also provides a number of [Sass functions and mixins](#sass) for applying space to a project.
+For [Build Service](https://www.ft.com/__origami/service/build/) users, `o-spacing` provides [CSS classes](#markup) for vertical space and [CSS Custom Properties (CSS Variables)](#css-custom-properties) for other usecases. For Sass users `o-spacing` also provides a number of [Sass functions and mixins](#sass) for applying space to a project.
 
 ## Spaces
 
@@ -62,7 +62,7 @@ To apply spaces to other properties `o-spacing` provides [CSS Custom Properties 
 
 ### Named Space Custom Properties
 
-`o-spacing` outputs a CSS Custom Property (CSS Variable) for each named space. E.g. `--o-spacing-s1`. These may be used to apply spaces in custom CSS if your project [supports](https://caniuse.com/#feat=css-variables) CSS Custom Properties. This is particularly useful for [Build Service](https://www.ft.com/__origami/service/build/v2/) users who do not have access to `o-spacing`'s [Sass](#sass) functions.
+`o-spacing` outputs a CSS Custom Property (CSS Variable) for each named space. E.g. `--o-spacing-s1`. These may be used to apply spaces in custom CSS if your project [supports](https://caniuse.com/#feat=css-variables) CSS Custom Properties. This is particularly useful for [Build Service](https://www.ft.com/__origami/service/build/) users who do not have access to `o-spacing`'s [Sass](#sass) functions.
 
 ```scss
 .example {

--- a/components/o-subs-card/README.md
+++ b/components/o-subs-card/README.md
@@ -66,7 +66,7 @@ The subs card standard theme is teal. To differentiate amongst different subscri
 
 ## JavaScript
 
-If you're using the [Build Service](https://www.ft.com/__origami/service/build/v2/) to get this component, you won't need to initialise your JavaScript, it should just work.
+If you're using the [Build Service](https://www.ft.com/__origami/service/build/) to get this component, you won't need to initialise your JavaScript, it should just work.
 
 If you aren't using the Build Service, you'll need to fire an `o.DOMContentLoaded` event (which o-subs-card listens for) or construct an `oSubsCard` object.
 

--- a/components/o-table/README.md
+++ b/components/o-table/README.md
@@ -134,9 +134,9 @@ Or to disable sort per table column, add `data-o-table-heading-disable-sort` to 
 
 There are three options for small viewports where the table does not fit.
 
-1. [overflow](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-overflow) - Scroll the whole table including headings horizontally. This option also supports an [expander](#expander).
-2. [scroll](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-scroll) - Flip the table so headings are in the first column and sticky, data is scrollable horizontally.
-3. [flat](https://www.ft.com/__origami/service/build/v2/demos/o-table/responsive-flat) - Split each row into an individual item and repeat headings.
+1. [overflow](https://registry.origami.ft.com/components/o-table#demo-responsive-overflow) - Scroll the whole table including headings horizontally. This option also supports an [expander](#expander).
+2. [scroll](https://registry.origami.ft.com/components/o-table#demo-responsive-scroll) - Flip the table so headings are in the first column and sticky, data is scrollable horizontally.
+3. [flat](https://registry.origami.ft.com/components/o-table#demo-responsive-flat) - Split each row into an individual item and repeat headings.
 
 To enable these set `data-o-table-responsive` to the type of responsive table desired and add the classes for that type of table. Then wrap the table in `o-table-container`, `o-table-overlay-wrapper`, `o-table-scroll-wrapper`. E.g for an "overflow" table:
 

--- a/components/o-typography/README.md
+++ b/components/o-typography/README.md
@@ -46,7 +46,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 
 ## Markup
 
-Predefined CSS classes in `o-typography` are available when using the [build service](https://www.ft.com/__origami/service/build/v2/), and can be included optionally via [Sass](#sass).
+Predefined CSS classes in `o-typography` are available when using the [Build Service](https://www.ft.com/__origami/service/build/), and can be included optionally via [Sass](#sass).
 
 Classes do not depend on specific HTML, but we encourage developers to use semantic elements.
 


### PR DESCRIPTION
One remains: o-comments. It uses Build Service v2 to compile `src/scss/coral-talk-iframe/main.scss` for the coral iframe. However Build Service v3 no longer supports building arbitrary source files.