### PR TITLE
Add stories for o-date demos

### DIFF
--- a/components/o-date/src/js/date.js
+++ b/components/o-date/src/js/date.js
@@ -123,7 +123,7 @@ class ODate {
 	/**
 	 * Initialise the o-date component.
 	 *
-	 * @param {HTMLElement | string} el - The root element or CSS selector to initialise
+	 * @param {HTMLElement | string} [el] - The root element or CSS selector to initialise
 	 * @returns {Array<ODate> | ODate} - An o-date instance or array of o-date instances.
 	 */
 	static init (el) {

--- a/components/o-date/src/tsx/date.tsx
+++ b/components/o-date/src/tsx/date.tsx
@@ -31,3 +31,18 @@ export function Date({
 		</time>
 	);
 }
+
+export interface DatePrinterProps {
+	format?: DateFormat;
+}
+
+export function DatePrinter({
+	format,
+	children,
+}: React.PropsWithChildren<DatePrinterProps>): JSX.Element {
+	return (
+		<span data-o-date-printer data-o-date-format={format}>
+			{children}
+		</span>
+	);
+}

--- a/components/o-date/src/tsx/date.tsx
+++ b/components/o-date/src/tsx/date.tsx
@@ -1,0 +1,33 @@
+export type DateFormat =
+	| 'today-or-yesterday-or-nothing'
+	| 'date-only'
+	| 'time-ago-limit-4-hours'
+	| 'time-ago-limit-24-hours'
+	| 'time-ago-abbreviated'
+	| 'time-ago-abbreviated-limit-4-hours'
+	| 'time-ago-no-seconds'
+	// hack to allow any string (for custom date formatting) while still
+	// suggesting the common format variants in IDEs
+	// from https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
+	| (string & {});
+
+export interface DateProps {
+	dateTime: string;
+	format?: DateFormat;
+}
+
+export function Date({
+	dateTime,
+	format,
+	children,
+}: React.PropsWithChildren<DateProps>): JSX.Element {
+	return (
+		<time
+			data-o-component="o-date"
+			className="o-date"
+			dateTime={dateTime}
+			data-o-date-format={format}>
+			{children}
+		</time>
+	);
+}

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -45,10 +45,10 @@ export default {
 
 const Template: DateStory = ({description, ...args}) => {
 	useEffect(() => {
-		let tabs = javascript.init();
+		let dates = javascript.init();
 		return function cleanup() {
-			tabs = Array.isArray(tabs) ? tabs : [tabs];
-			tabs.forEach(tab => tab.destroy());
+			dates = Array.isArray(dates) ? dates : [dates];
+			dates.forEach(date => date.destroy());
 		};
 	});
 	return (

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -1,0 +1,118 @@
+import type {ComponentMeta, Story} from '@storybook/react';
+import withHtml from 'origami-storybook-addon-html';
+import {ComponentProps, useEffect} from 'react';
+import {withDesign} from 'storybook-addon-designs';
+import javascript from '../main';
+import {Date as ODate} from '../src/tsx/date';
+
+// the storybook args are slightly different to the Date props:
+// 1. dateTime is a UNIX timestamp, the format storybook uses in its controls
+// 2. the description field appends a description of the timestamp inline
+type DateStory = Story<
+	Omit<ComponentProps<typeof ODate>, 'dateTime'> & {
+		dateTime: number;
+		description: string;
+	}
+>;
+
+const defaultDateTimeObj = new Date();
+defaultDateTimeObj.setHours(new Date().getHours() - 6);
+const defaultDateTime = defaultDateTimeObj.getTime();
+
+export default {
+	title: 'Components/o-date',
+	component: ODate,
+	decorators: [withDesign, withHtml],
+	argTypes: {
+		dateTime: {control: 'date', defaultValue: defaultDateTime},
+		format: {
+			control: 'select',
+			options: [
+				'today-or-yesterday-or-nothing',
+				'date-only',
+				'time-ago-limit-4-hours',
+				'time-ago-limit-24-hours',
+				'time-ago-abbreviated',
+				'time-ago-abbreviated-limit-4-hours',
+				'time-ago-no-seconds',
+			],
+		},
+		// the description doesn't need to be editable
+		description: {table: {disable: true}},
+	},
+	parameters: {controls: {sort: 'requiredFirst'}},
+} as ComponentMeta<typeof ODate>;
+
+const Template: DateStory = ({description, ...args}) => {
+	useEffect(() => {
+		let tabs = javascript.init();
+		return function cleanup() {
+			tabs = Array.isArray(tabs) ? tabs : [tabs];
+			tabs.forEach(tab => tab.destroy());
+		};
+	});
+	return (
+		<>
+			<ODate {...{...args, dateTime: new Date(args.dateTime).toISOString()}} />
+			{` (${description})`}
+		</>
+	);
+};
+
+export const Abbreviated: DateStory = Template.bind({});
+Abbreviated.args = {
+	dateTime: new Date('2000-06-14T23:00:00.000Z').getTime(),
+	children: 'June 15, 2000',
+	description: 'dates far in the past are formatted as exact dates',
+};
+
+export const Relative: DateStory = Template.bind({});
+Relative.args = {
+	description: 'more recent dates are formatted as relative times',
+};
+
+export const TodayOrYesterday: DateStory = Template.bind({});
+TodayOrYesterday.args = {
+	format: 'today-or-yesterday-or-nothing',
+	description: 'using the o-date-format option',
+};
+
+export const FourHourLimit: DateStory = Template.bind({});
+FourHourLimit.storyName = '4 Hour Limit';
+FourHourLimit.args = {
+	format: 'time-ago-limit-4-hours',
+	description: 'using the o-date-format with time-ago-limit-4-hours',
+};
+
+export const TwentyFourHourLimit: DateStory = Template.bind({});
+TwentyFourHourLimit.storyName = '24 Hour Limit';
+TwentyFourHourLimit.args = {
+	format: 'time-ago-limit-24-hours',
+	description: 'using the o-date-format with time-ago-limit-24-hours',
+};
+
+export const CustomFormatting: DateStory = Template.bind({});
+CustomFormatting.args = {
+	dateTime: new Date('1912-04-15T05:18Z').getTime(),
+	format: 'h:mm a',
+	description: 'using the o-date-format with custom format string',
+};
+CustomFormatting.argTypes = {
+	format: {control: 'text'},
+};
+
+export const Multiple: DateStory = Template.bind({});
+Multiple.args = {
+	dateTime: new Date('1912-04-15T05:18Z').getTime(),
+	format: 'date-only',
+	children: (
+		<>
+			<span data-o-date-printer></span>{' '}
+			<span
+				data-o-date-printer
+				data-o-date-format="time-ago-limit-4-hours"></span>{' '}
+			<span data-o-date-printer data-o-date-format="h:mm"></span>
+		</>
+	),
+	description: 'using multiple o-date-format elements',
+};

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -5,13 +5,11 @@ import {withDesign} from 'storybook-addon-designs';
 import javascript from '../main';
 import {Date as ODate} from '../src/tsx/date';
 
-// the storybook args are slightly different to the Date props:
-// 1. dateTime is a UNIX timestamp, the format storybook uses in its controls
-// 2. the description field appends a description of the timestamp inline
+// the storybook args are slightly different to the Date props as dateTime is a
+// UNIX timestamp, the format storybook uses in its controls
 type DateStory = Story<
 	Omit<ComponentProps<typeof ODate>, 'dateTime'> & {
 		dateTime: number;
-		description: string;
 	}
 >;
 
@@ -37,13 +35,11 @@ export default {
 				'time-ago-no-seconds',
 			],
 		},
-		// the description doesn't need to be editable
-		description: {table: {disable: true}},
 	},
 	parameters: {controls: {sort: 'requiredFirst'}},
 } as ComponentMeta<typeof ODate>;
 
-const Template: DateStory = ({description, ...args}) => {
+const Template: DateStory = args => {
 	useEffect(() => {
 		let dates = javascript.init();
 		return function cleanup() {
@@ -52,10 +48,7 @@ const Template: DateStory = ({description, ...args}) => {
 		};
 	});
 	return (
-		<>
-			<ODate {...{...args, dateTime: new Date(args.dateTime).toISOString()}} />
-			{` (${description})`}
-		</>
+		<ODate {...{...args, dateTime: new Date(args.dateTime).toISOString()}} />
 	);
 };
 
@@ -63,39 +56,32 @@ export const Abbreviated: DateStory = Template.bind({});
 Abbreviated.args = {
 	dateTime: new Date('2000-06-14T23:00:00.000Z').getTime(),
 	children: 'June 15, 2000',
-	description: 'dates far in the past are formatted as exact dates',
 };
 
 export const Relative: DateStory = Template.bind({});
-Relative.args = {
-	description: 'more recent dates are formatted as relative times',
-};
+Relative.args = {};
 
 export const TodayOrYesterday: DateStory = Template.bind({});
 TodayOrYesterday.args = {
 	format: 'today-or-yesterday-or-nothing',
-	description: 'using the o-date-format option',
 };
 
 export const FourHourLimit: DateStory = Template.bind({});
 FourHourLimit.storyName = '4 Hour Limit';
 FourHourLimit.args = {
 	format: 'time-ago-limit-4-hours',
-	description: 'using the o-date-format with time-ago-limit-4-hours',
 };
 
 export const TwentyFourHourLimit: DateStory = Template.bind({});
 TwentyFourHourLimit.storyName = '24 Hour Limit';
 TwentyFourHourLimit.args = {
 	format: 'time-ago-limit-24-hours',
-	description: 'using the o-date-format with time-ago-limit-24-hours',
 };
 
 export const CustomFormatting: DateStory = Template.bind({});
 CustomFormatting.args = {
 	dateTime: new Date('1912-04-15T05:18Z').getTime(),
 	format: 'h:mm a',
-	description: 'using the o-date-format with custom format string',
 };
 CustomFormatting.argTypes = {
 	format: {control: 'text'},
@@ -114,5 +100,4 @@ Multiple.args = {
 			<span data-o-date-printer data-o-date-format="h:mm"></span>
 		</>
 	),
-	description: 'using multiple o-date-format elements',
 };

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -3,7 +3,7 @@ import withHtml from 'origami-storybook-addon-html';
 import {ComponentProps, useEffect} from 'react';
 import {withDesign} from 'storybook-addon-designs';
 import javascript from '../main';
-import {Date as ODate} from '../src/tsx/date';
+import {Date as ODate, DatePrinter} from '../src/tsx/date';
 
 // the storybook args are slightly different to the Date props as dateTime is a
 // UNIX timestamp, the format storybook uses in its controls
@@ -93,11 +93,8 @@ Multiple.args = {
 	format: 'date-only',
 	children: (
 		<>
-			<span data-o-date-printer></span>{' '}
-			<span
-				data-o-date-printer
-				data-o-date-format="time-ago-limit-4-hours"></span>{' '}
-			<span data-o-date-printer data-o-date-format="h:mm"></span>
+			<DatePrinter /> <DatePrinter format={'time-ago-limit-4-hours'} />{' '}
+			<DatePrinter format={'h:mm'} />
 		</>
 	),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5811,6 +5811,7 @@
       }
     },
     "libraries/ftdomdelegate": {
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.16",


### PR DESCRIPTION
The original o-date demo is unusual in that multiple variations are included in a single demo, with different formatting settings included in one chunk of HTML. There are demos split out into ones written in declarative and imperative styles, though the imperative demos are already hidden so I haven't ported them over. I've instead split each line of the declarative demo into its own story so that their arguments can be fiddled with individually.

o-date also has support for 'copy options', where you can intersperse computed timestamps with some custom copy. This is done via inserting `span`s with some identifying attributes (as long as optionally setting custom formatting.) I can think of a few ways we could make this fit more ergonomically with the new JSX templates (converting string templates into HTML – too abstracted, using friendlier naming conventions and then mapping them – not sure how stable this would be and seems unnecessary,) so have just left the children to be forwarded to the js code for now.

Made an effort to make the Storybook controls reflect the semantics of the `Date` props, so have properly typed them, though adding support for the Storybook date picker means we need to convert between ISO strings and UNIX timestamps, which is fun.

I've kept the inline description of each format in the stories for continuity though perhaps they should go into a documentation field somewhere instead?