### PR TITLE
backstage: handle single quotes in commit messages on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,8 +25,9 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}
-      - run: node ./scripts/publish.js '${{toJSON(steps.release.outputs)}}'
+      - run: node ./scripts/publish.js
         env:
+          RELEASE_PLEASE_OUTPUT: ${{steps.release.outputs}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           REPO_DATA_KEY: ${{secrets.REPO_DATA_KEY}}
           REPO_DATA_SECRET: ${{secrets.REPO_DATA_SECRET}}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,9 +3,10 @@ import {$} from "zx"
 import {readPackage} from "read-pkg"
 import {request} from "undici"
 
-let outputs = JSON.parse(process.argv[2])
+let {REPO_DATA_KEY, REPO_DATA_SECRET, RELEASE_PLEASE_OUTPUT} = process.env
+console.log({'release please output': RELEASE_PLEASE_OUTPUT});
 
-let {REPO_DATA_KEY, REPO_DATA_SECRET} = process.env
+let outputs = JSON.parse(RELEASE_PLEASE_OUTPUT)
 
 for (let key in outputs) {
 	let value = outputs[key]


### PR DESCRIPTION
The release-please Github Action would fail to publish components if the output
from release please contained a single quote, e.g. from a commit message.
To avoid this pass release please output via an enviroment variable.

Example of issue:
```
node ./scripts/publish.js '{
  node ./scripts/publish.js '{
    "releases_created": "true",
    "components/o-date--release_created": "true",
    "components/o-date--major": "5",
    "components/o-date--minor": "3",
    "components/o-date--patch": "0",
    "components/o-date--sha": "8ef3512aaf867b3bc6b7c60b57e1557fc23e27d0",
    "components/o-date--version": "5.3.0",
    "components/o-date--pr": "745",
    "components/o-date--html_url": "https://github.com/Financial-Times/origami/releases/tag/o-date-v5.3.0",
    "components/o-date--name": "@financial-times/o-date o-date-v5.3.0",
    "components/o-date--tag_name": "o-date-v5.3.0",
    "components/o-date--upload_url": "https://uploads.github.com/repos/Financial-Times/origami/releases/68164403/assets{?name,label}",
    "components/o-date--draft": "false",
    "components/o-date--body": "\n\n### Features\n\n* add stories for o-date demos ([7a8d77a](https://www.github.com/Financial-Times/origami/commit/7a8d77a15ade1356ec9bdf5ec72710693294ad31))\n* create date printer JSX component ([bced601](https://www.github.com/Financial-Times/origami/commit/bced601f3184ddc1100c9b1369687be22cf1e51b))\n\n\n### Bug Fixes\n\n* don't inline descriptions for o-date stories ([e8816b3](https://www.github.com/Financial-Times/origami/commit/e8816b331952f0db705270cd86123a8bbd8ec2d0))\n",
    "components/o-icons--release_created": "true",
    "components/o-icons--major": "7",
    "components/o-icons--minor": "4",
    "components/o-icons--patch": "0",
    "components/o-icons--sha": "8ef3512aaf867b3bc6b7c60b57e1557fc23e27d0",
    "components/o-icons--version": "7.4.0",
    "components/o-icons--pr": "745",
    "components/o-icons--html_url": "https://github.com/Financial-Times/origami/releases/tag/o-icons-v7.4.0",
    "components/o-icons--name": "@financial-times/o-icons o-icons-v7.4.0",
    "components/o-icons--tag_name": "o-icons-v7.4.0",
    "components/o-icons--upload_url": "https://uploads.github.com/repos/Financial-Times/origami/releases/68164405/assets{?name,label}",
    "components/o-icons--draft": "false",
    "components/o-icons--body": "\n\n### Features\n\n* add stories for o-icons demos ([a4b8d65](https://www.github.com/Financial-Times/origami/commit/a4b8d65c8a4caa5d56d45c3d83e8a6567d019dd6))\n* generate string union type of icons ([577f6dc](https://www.github.com/Financial-Times/origami/commit/577f6dcc0c07867ef9ccb1543b11fa57c4036e3d))\n\n\n### Bug Fixes\n\n* remove custom icons story ([9ccb3cc](https://www.github.com/Financial-Times/origami/commit/9ccb3ccfe998b89de74b5277f10c03f966d95d85))\n",
    "components/o-tooltip--release_created": "true",
    "components/o-tooltip--major": "5",
    "components/o-tooltip--minor": "2",
    "components/o-tooltip--patch": "3",
    "components/o-tooltip--sha": "8ef3512aaf867b3bc6b7c60b57e1557fc23e27d0",
    "components/o-tooltip--version": "5.2.3",
    "components/o-tooltip--pr": "745",
    "components/o-tooltip--html_url": "https://github.com/Financial-Times/origami/releases/tag/o-tooltip-v5.2.3",
    "components/o-tooltip--name": "@financial-times/o-tooltip o-tooltip-v5.2.3",
    "components/o-tooltip--tag_name": "o-tooltip-v5.2.3",
    "components/o-tooltip--upload_url": "https://uploads.github.com/repos/Financial-Times/origami/releases/68164409/assets{?name,label}",
    "components/o-tooltip--draft": "false",
    "components/o-tooltip--body": "\n\n### Bug Fixes\n\n* o-tooltip, add missing o-brand peerDep ([42690c3](https://www.github.com/Financial-Times/origami/commit/42690c301e3832fef616cf180aa2fb59e4a09944))\n",
    "paths_released": "[\"components/o-date\",\"components/o-icons\",\"components/o-tooltip\"]"
  }'
```

https://github.com/Financial-Times/origami/runs/6656276116?check_suite_focus=true