### PR TITLE
backstage: Storybook, fix internal brand build.

### DIFF
--- a/tools/origami-tools-helpers/files.js
+++ b/tools/origami-tools-helpers/files.js
@@ -94,7 +94,7 @@ function getComponentName(cwd) {
 		});
 }
 
-function getModuleBrands(cwd) {
+function getComponentBrands(cwd) {
 	return getOrigamiJson(cwd)
 		.then(origamiJson => {
 			const hasBrandsDefined = origamiJson && origamiJson.brands && Array.isArray(origamiJson.brands) && origamiJson.brands.length > 0;
@@ -180,7 +180,7 @@ export {
 	getSassFilesList,
 	getMustacheFilesList,
 	getSassTestFiles,
-	getModuleBrands,
+	getComponentBrands,
 	getComponentDemos,
-	getSassIncludePaths,	
+	getSassIncludePaths,
 }


### PR DESCRIPTION
I can’t build storybook for the internal brand due to an unrelated sass error `ORIGAMI_STORYBOOK_BRAND=internal npm run storybook`
– it tries to build `ft-concept-button` which doesn’t support the internal brand, and uses colours not supported by the internal
brand’s colour palette.

This commit updates Storybook config to check a component supports the current brand before building its stories. Currently this
does not support brand specific stories within a component, which we may want to support in the future.

To inspect a component's supported brands I chose to copy helper functions from the tools directory rather than create
some shared dependency between packages (tools and storybook).