### PR TITLE
fix: o-tooltip show close button when opened on construction

### DIFF
--- a/components/o-tooltip/src/js/tooltip.js
+++ b/components/o-tooltip/src/js/tooltip.js
@@ -169,7 +169,7 @@ class Tooltip {
 			this.tooltipEl.style.zIndex = this.opts.zIndex;
 		}
 
-		if (this.opts.showOnClick || this.opts.toggleOnClick) {
+		if (this.opts.showOnConstruction || this.opts.showOnClick || this.opts.toggleOnClick) {
 			// Build and append the close button
 			const button = document.createElement('button');
 			button.className = 'o-tooltip-close';

--- a/components/o-tooltip/test/Tooltip.test.js
+++ b/components/o-tooltip/test/Tooltip.test.js
@@ -291,6 +291,16 @@ describe("Tooltip", () => {
 			proclaim.strictEqual(tooltipEl.style.zIndex, fakeZ);
 		});
 
+		it("adds a close button with an aria label, role and title when opts.showOnConstruction is set to true", () => {
+			const tooltip = new Tooltip(document.getElementById('tooltip-demo-8'));
+			tooltip.show();
+			tooltipEl = document.getElementById('tooltip-demo-8');
+			const buttonEl = tooltipEl.querySelector('.o-tooltip-close');
+			proclaim.isDefined(buttonEl);
+			proclaim.isTrue(buttonEl.hasAttribute('aria-label'));
+			proclaim.isTrue(buttonEl.hasAttribute('title'));
+		});
+
 		it("adds a close button with an aria label, role and title when opts.showOnClick is set to true", () => {
 			const tooltip = new Tooltip(document.getElementById('tooltip-demo-3'));
 			tooltip.show();

--- a/components/o-tooltip/test/helpers/fixtures.js
+++ b/components/o-tooltip/test/helpers/fixtures.js
@@ -25,61 +25,61 @@ function declarativeCode () {
 			<div class='tooltip-target' id="demo-tooltip-target">
 				Thing to point the tooltip at.
 			</div>
-	
+
 			<div id='tooltip-demo' data-o-component="o-tooltip"
 			data-o-tooltip-target='demo-tooltip-target'>
 				Tooltip content
 			</div>
-	
+
 			<div class='tooltip-target' id="demo-tooltip-target-2">
 					Thing to point the tooltip at.
 			</div>
-	
+
 			<div id='tooltip-demo-2' data-o-component="o-tooltip"
 				data-o-tooltip-target='demo-tooltip-target-2'>
 					Tooltip content
 			</div>
-	
+
 			<button class='tooltip-target' id="demo-tooltip-target-3">
 					Thing to point the tooltip at.
 			</button>
-	
+
 			<div id="tooltip-demo-3"
 				data-o-component="o-tooltip"
 				data-o-tooltip-target="demo-tooltip-target-3"
 				data-o-tooltip-show-on-click="true">
 					Tooltip content
 			</div>
-	
+
 			<div class='tooltip-target' id="demo-tooltip-target-4">
 					Thing to point the tooltip at.
 			</div>
-	
+
 			<div id="tooltip-demo-4"
 				data-o-component="o-tooltip"
 				data-o-tooltip-target="demo-tooltip-target-4"
 				data-o-tooltip-show-on-hover="true">
 					Tooltip content
 			</div>
-	
+
 			<div class='tooltip-target' id="demo-tooltip-target-5" style='position:fixed'>
 					Thing to point the tooltip at.
 			</div>
-	
+
 			<div id="tooltip-demo-5"
 				data-o-component="o-tooltip"
 				data-o-tooltip-target="demo-tooltip-target-5"
 				data-o-tooltip-show-on-hover="true">
 					Tooltip content
 			</div>
-			
+
 			<div id="tooltip-demo-6"
 				data-o-component="o-tooltip"
 				data-o-tooltip-target="demo-tooltip-target-6"
 				data-o-tooltip-show-on-focus="true">
 					Tooltip content
 			</div>
-			
+
 			<div class='tooltip-target' id="demo-tooltip-target-6" style='position:fixed'>
 					Thing to point the tooltip at.
 			</div>
@@ -90,15 +90,26 @@ function declarativeCode () {
 				data-o-tooltip-toggle-on-click="true">
 					Tooltip content
 			</div>
-			
+
 			<div class='tooltip-target' id="demo-tooltip-target-7">
 					Thing to point the tooltip at.
-			</div>			
-	
+			</div>
+
+			<button class='tooltip-target' id="demo-tooltip-target-8">
+					Thing to point the tooltip at.
+			</button>
+
+			<div id="tooltip-demo-8"
+				data-o-component="o-tooltip"
+				data-o-tooltip-target="demo-tooltip-target-8"
+				data-o-tooltip-show-on-construction="true">
+					Tooltip content
+			</div>
+
 			<div class='tooltip-target' id="demo-tooltip-target-below">
 					Thing to point the tooltip at.
 			</div>
-	
+
 			<div id="tooltip-demo-below"
 				data-o-tooltip-position="below"
 				data-o-component="o-tooltip"
@@ -106,23 +117,23 @@ function declarativeCode () {
 				data-o-tooltip-show-on-hover="true">
 					Tooltip content
 			</div>
-	
+
 			<!-- note lack of whitespace is there to make sure there is no next sibling (otherwise text node :-O) -->
 			<div id="demo-tooltip-insertion-test-1"><div class='tooltip-target' id="demo-tooltip-insertion-test-1-target">Thing to point the tooltip at.</div></div>
-	
+
 			<div id="demo-tooltip-insertion-test-2">
 				<div class='tooltip-target' id="demo-tooltip-insertion-test-2-target">
 					Thing to point the tooltip at.
 				</div>
 				<div></div>
 			</div>
-			
+
 			<div id="demo-tooltip-removal-test-1">
 				<div class='tooltip-target' id="demo-tooltip-removal-test-1-target">
 					Thing to point the tooltip at.
 				</div>
 			</div>
-		
+
 		</div>
 
 	`;


### PR DESCRIPTION
>A previous change made it so the close button doesn’t show if a tooltip is shown on hover or focus, but does show on click. It accidentally made it so if a tooltip is open by default on page load there is no close button, when there should be.

Relates to the following PR:
https://github.com/Financial-Times/origami/pull/419