### PR TITLE
Revert "backstage: handle single quotes in commit messages on release"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,9 +25,8 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}
-      - run: node ./scripts/publish.js
+      - run: node ./scripts/publish.js '${{toJSON(steps.release.outputs)}}'
         env:
-          RELEASE_PLEASE_OUTPUT: ${{steps.release.outputs}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           REPO_DATA_KEY: ${{secrets.REPO_DATA_KEY}}
           REPO_DATA_SECRET: ${{secrets.REPO_DATA_SECRET}}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,10 +3,9 @@ import {$} from "zx"
 import {readPackage} from "read-pkg"
 import {request} from "undici"
 
-let {REPO_DATA_KEY, REPO_DATA_SECRET, RELEASE_PLEASE_OUTPUT} = process.env
-console.log({'release please output': RELEASE_PLEASE_OUTPUT});
+let outputs = JSON.parse(process.argv[2])
 
-let outputs = JSON.parse(RELEASE_PLEASE_OUTPUT)
+let {REPO_DATA_KEY, REPO_DATA_SECRET} = process.env
 
 for (let key in outputs) {
 	let value = outputs[key]


### PR DESCRIPTION
This reverts commit 170c31f39d3e82a188e40dd0818c60dd2419976f.
See PR: https://github.com/Financial-Times/origami/pull/747

`steps.release.outputs` is a "map" [what kind of map? that's what I
would like to know] of outputs for a job and so the previous change
did not work and all releases fail.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs

With this revert only releases which contain commits with
single quotes in the commit  messages will fail – I haven't
had time to figure out how to escape them yet