### PR TITLE
fix: o-fonts, support self hosted fonts

### DIFF
--- a/components/o-fonts/README.md
+++ b/components/o-fonts/README.md
@@ -204,7 +204,7 @@ _Note: If your project has multiple Sass entry points call `oFontsVariantsInclud
 
 Note: font files are contained in a separate, private repository ([o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets)).
 
-1.  Open `src/scss/_variables.scss` and update the `$o-fonts-path` variable to the release of [o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets) which includes your new font.
+1.  Open `src/scss/_variables.scss` and update the `$o-fonts-build-service-path` variable to the release of [o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets) which includes your new font.
 
 2.  Add the font family name (if it's an entirely new family) and the variant styles to the private `$_o-fonts-families` map.
 

--- a/components/o-fonts/src/scss/_mixins.scss
+++ b/components/o-fonts/src/scss/_mixins.scss
@@ -137,15 +137,24 @@
 
 		// By default, suffix is the weight
 		$font-suffix: _oFontsStringCapitalise($weight);
-
 		@if ($style != 'normal') {
 			$capitalised-weight: _oFontsStringCapitalise($weight);
 			$capitalised-style: _oFontsStringCapitalise($style);
 			$font-suffix: #{$capitalised-weight}#{$capitalised-style};
 		}
 
+		$font-file: '#{$family}-#{$font-suffix}';
+		// set path for self hosted font
+		$self-host-path: $o-fonts-self-host-path + $font-file;
+		// set path using existing o-fonts-path variable, for font hosted on Build Service api implementation
+		$build-service-path: $o-fonts-build-service-path + '&font_name=#{$font-file}&system_code=origami';
+
+		// use $o-fonts-self-host-path if set, $o-fonts-build-service-path otherwise
+		$font-url-woff: if($o-fonts-self-host-path == '', '#{$build-service-path}&font_format=woff', '#{$self-host-path}.woff');
+		$font-url-woff2: if($o-fonts-self-host-path == '', '#{$build-service-path}&font_format=woff2', '#{$self-host-path}.woff2');
+
 		@font-face {
-			src: url($o-fonts-path + '&font_name=#{$family}-#{$font-suffix}&font_format=woff2&system_code=origami') format('woff2'), url($o-fonts-path + '&font_name=#{$family}-#{$font-suffix}&font_format=woff&system_code=origami') format('woff');
+			src: url($font-url-woff2) format('woff2'), url($font-url-woff) format('woff');
 			font-family: $family;
 			font-weight: oFontsWeight($weight);
 			font-style: unquote($style);

--- a/components/o-fonts/src/scss/_variables.scss
+++ b/components/o-fonts/src/scss/_variables.scss
@@ -3,10 +3,24 @@
 /// @type Bool
 $o-fonts-is-silent: true !default;
 
-/// Path to default font files.
+/// Origami Build Service path to font files.
 ///
+/// @deprecated - Use "$o-fonts-build-service-path" or "$o-fonts-self-host-path" instead.
 /// @type String
 $o-fonts-path: 'https://www.ft.com/__origami/service/build/v3/font?version=1.12' !default;
+
+/// Origami Build Service path to font files.
+///
+/// @type String
+$o-fonts-build-service-path: $o-fonts-path !default;
+
+/// Alternative path to self hosted font files, hosted on a service which does not 
+/// conform to the Origami Build Service api. For example this is used by 
+/// Financial-Times/ft-app to support offline fonts.
+///
+/// @see $o-fonts-build-service-path - If not set the Origami Build Service is used to host fonts.
+/// @type String
+$o-fonts-self-host-path: '' !default;
 
 /// The default `font-display` property of included font faces.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display


### PR DESCRIPTION
The latest o-fonts major updated `$o-fonts-path` to point to
v3 of the Origami Build Service. This required setting font file
names in a query parameter, rather than sending a request for a
file explicity.

`https://www.ft.com/__origami/service/build/v3/font?version=1.12&font_name=MetricWeb-Regular&font_format=woff2&system_code=origami`

vs.

`https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/MetricWeb-Regular.woff`

This meant users could no longer set `$o-fonts-path` to self host fonts. 
This is something Financial-Times/ft-app does to support offline fonts.

As a fix this commit deprecates `$o-fonts-path` and replaces it with
`$o-fonts-build-service-path`, to specify a Build Service url to load
fonts from – this could be customised to point to a different version
of o-fonts on the Build Service, or a self hosted version of the Build
Service, but is unlikely to be used and perhaps could be removed in a
future major version. `$o-fonts-self-host-path` has been added to
mimic the previous behaviour of `$o-fonts-path` for self hosted fonts.