### PR TITLE
feat: o-tracking, add test mode minus debug logs

### DIFF
--- a/libraries/o-tracking/README.md
+++ b/libraries/o-tracking/README.md
@@ -90,6 +90,18 @@ const config = {
 oTracking.init(config);
 ```
 
+o-tracking also has a `test-data` mode to mark events as test events without the debugging information in the console:
+
+```js
+import oTracking from '@financial-times/o-tracking';
+
+const config = {
+    test_data: true, // Mark the events as test events without extra debug logging.
+    ...
+};
+oTracking.init(config);
+```
+
 #### Methods
 
 ##### oTracking.init

--- a/libraries/o-tracking/src/javascript/core/send.js
+++ b/libraries/o-tracking/src/javascript/core/send.js
@@ -47,7 +47,7 @@ function sendRequest(request, callback) {
 		transport: transport.name, // The transport method used.
 	});
 
-	if (getSetting('config').test) {
+	if (getSetting('config').test || getSetting('config').test_data) {
 		system.is_live = false;
 	} else {
 		system.is_live = true;

--- a/libraries/o-tracking/test/main.test.js
+++ b/libraries/o-tracking/test/main.test.js
@@ -295,6 +295,48 @@ describe('main', function () {
 		proclaim.equal(sent_data.system.is_live, true);
 	});
 
+	it('should set system.is_live to be false if `test_data` is set to true', function () {
+		oTracking.destroy();
+
+		oTracking.init({
+			test_data: true
+		});
+
+
+		const callback = sinon.spy();
+
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?3"
+		}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
+		proclaim.equal(sent_data.system.is_live, false);
+	});
+
+	it('should set system.is_live to be true if `test_data` is set to false', function () {
+		oTracking.destroy();
+
+		oTracking.init({
+			test_data: false
+		});
+
+
+		const callback = sinon.spy();
+
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?4"
+		}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
+		proclaim.equal(sent_data.system.is_live, true);
+	});
+
 	it('should set system.is_live to be false if `test` is set to true', function () {
 		oTracking.destroy();
 
@@ -337,7 +379,7 @@ describe('main', function () {
 		proclaim.equal(sent_data.system.is_live, true);
 	});
 
-	it('should set system.is_live to be true if `test` is not set', function () {
+	it('should set system.is_live to be true if `test` and `test_data` is not set', function () {
 		const callback = sinon.spy();
 
 		oTracking.page({


### PR DESCRIPTION
### Add an o-tracking config option to for test data minus the extensive debug logging

#### Context:
* The Apps team sends non live events to a splunk index specifically for test data. Thus we need to ensure our development events have `is_live: false`. 
* In old versions of o-tracking we were able to set `is_live` in the initialisation config. This is no longer possible -  https://github.com/Financial-Times/origami/commit/5b69c97aa5d015046b26fc7d95aaa3b3852bf462
* The App started using the intended `test` config option but developers are finding the o-tracking debug logs particularly noisy (and our `ft-app` console can already be a little noisy sometimes 😬) 
* This option was discussed https://financialtimes.slack.com/archives/C02FU5ARJ/p1657105962524879. 

#### In this PR:
* I've added an additional config option to trigger `is_live: false` while leaving the `test` implementation as intended. 
* I found naming this new config option extremely hard. Very open to better names or other implementation ideas!?

#### Tests:
Updated for this new config option