### PR TITLE
feat: publish o-buttons tsx

### DIFF
--- a/components/o-buttons/.npmignore
+++ b/components/o-buttons/.npmignore
@@ -8,7 +8,6 @@
 .eslintignore
 .stylelintignore
 stories/
-src/tsx/
 .github/
 test/
 demos/local/

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -24,6 +24,7 @@ export interface ButtonProps {
 	attributes?: {
 		[attribute: string]: string | boolean;
 	};
+	onClick?: Function;
 }
 
 interface LinkButtonProps extends ButtonProps {
@@ -39,6 +40,7 @@ function ButtonTemplate({
 	iconOnly = false,
 	href = '',
 	attributes = {},
+	onClick
 }: ButtonProps | LinkButtonProps) {
 	const classNames = ['o-buttons', `o-buttons--${type}`];
 
@@ -63,6 +65,7 @@ function ButtonTemplate({
 	return (
 		<HtmlTag
 			{...(href ? {href} : {})}
+			{...(onClick ? {onClick} : {})}
 			className={classNames.join(' ')}
 			{...attributes}>
 			{icon && iconOnly ? (
@@ -82,6 +85,7 @@ export function Button({
 	icon,
 	iconOnly = false,
 	attributes = {},
+	onClick
 }: ButtonProps) {
 	return ButtonTemplate({
 		label,
@@ -91,6 +95,7 @@ export function Button({
 		icon,
 		iconOnly,
 		attributes,
+		onClick
 	});
 }
 
@@ -103,6 +108,7 @@ export function LinkButton({
 	iconOnly = false,
 	attributes = {},
 	href = '',
+	onClick
 }: LinkButtonProps) {
 	return ButtonTemplate({
 		label,
@@ -113,5 +119,6 @@ export function LinkButton({
 		iconOnly,
 		href,
 		attributes,
+		onClick
 	});
 }

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -7,7 +7,13 @@ export default {
 	title: 'Components/o-buttons',
 	component: Button,
 	decorators: [withDesign, withHtml],
-	args: {},
+	args: {
+		onClick: {
+			table: {
+				disable: true
+			}
+		}
+	},
 	parameters: {
 		design: {
 			type: 'figma',


### PR DESCRIPTION
As part of slowly rolling out TSX templates. Let's allow Spark to experiment with the o-buttons tsx template, if they would like :)  https://github.com/Financial-Times/spark/pull/2410#discussion_r927528465