### PR TITLE
fix: o-header-service, prevent error where `data-o-header-services-le…

### DIFF
--- a/components/o-header-services/src/js/drop-down.js
+++ b/components/o-header-services/src/js/drop-down.js
@@ -12,7 +12,10 @@ class DropDown {
 		this.drawer = drawer;
 		this.headerEl = headerEl;
 
-		this.navItems = [...headerEl.querySelectorAll('[data-o-header-services-level="1"]')];
+		/**
+		 * @type {Element[]} - Nav items with a dropdown.
+		 */
+		this.navItems = [...headerEl.querySelectorAll('[data-o-header-services-level="1"]')].filter(item => item.querySelector('ul'));
 		this.navItems.forEach(item => {
 			const button = item.querySelector('button');
 			if (!button) {


### PR DESCRIPTION
…vel` is used with no dropdown drawer

The drop down of o-header-services is optional. o-header-services expected to see the data attribute `data-o-header-services-level` only on nav items with a dropdown. Where users adding `data-o-header-services-level="1"` to heading items without a child unordered list (`data-o-header-services-level="2"`) o-header-services would error. Instead it now only treats a nav item as a drop down item if there is a child list.