### PR TITLE
alter o-buttons tsx to solve compile failures in stricter environments

### DIFF
--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -31,17 +31,7 @@ interface LinkButtonProps extends ButtonProps {
 	href: string;
 }
 
-function ButtonTemplate({
-	label,
-	type = 'secondary',
-	size = '',
-	theme,
-	icon,
-	iconOnly = false,
-	href = '',
-	attributes = {},
-	onClick
-}: ButtonProps | LinkButtonProps) {
+function makeClassNames({type, size, theme, icon, iconOnly}) {
 	const classNames = ['o-buttons', `o-buttons--${type}`];
 
 	if (size) {
@@ -59,22 +49,7 @@ function ButtonTemplate({
 	if (iconOnly) {
 		classNames.push('o-buttons-icon--icon-only');
 	}
-
-	const HtmlTag = href ? 'a' : 'button';
-
-	return (
-		<HtmlTag
-			{...(href ? {href} : {})}
-			{...(onClick ? {onClick} : {})}
-			className={classNames.join(' ')}
-			{...attributes}>
-			{icon && iconOnly ? (
-				<span className="o-buttons-icon__label">{label}</span>
-			) : (
-				label
-			)}
-		</HtmlTag>
-	);
+	return classNames.join(' ');
 }
 
 export function Button({
@@ -85,18 +60,20 @@ export function Button({
 	icon,
 	iconOnly = false,
 	attributes = {},
-	onClick
+	onClick,
 }: ButtonProps) {
-	return ButtonTemplate({
-		label,
-		type,
-		size,
-		theme,
-		icon,
-		iconOnly,
-		attributes,
-		onClick
-	});
+	return (
+		<button
+			{...(onClick ? {onClick} : {})}
+			className={makeClassNames({type, size, theme, icon, iconOnly})}
+			{...attributes}>
+			{icon && iconOnly ? (
+				<span className="o-buttons-icon__label">{label}</span>
+			) : (
+				label
+			)}
+		</button>
+	);
 }
 
 export function LinkButton({
@@ -107,18 +84,20 @@ export function LinkButton({
 	icon,
 	iconOnly = false,
 	attributes = {},
-	href = '',
-	onClick
+	href = null,
+	onClick,
 }: LinkButtonProps) {
-	return ButtonTemplate({
-		label,
-		type,
-		size,
-		theme,
-		icon,
-		iconOnly,
-		href,
-		attributes,
-		onClick
-	});
+	return (
+		<a
+			href={href}
+			{...(onClick ? {onClick} : {})}
+			className={makeClassNames({type, size, theme, icon, iconOnly})}
+			{...attributes}>
+			{icon && iconOnly ? (
+				<span className="o-buttons-icon__label">{label}</span>
+			) : (
+				label
+			)}
+		</a>
+	);
 }

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -64,7 +64,7 @@ export function Button({
 }: ButtonProps) {
 	return (
 		<button
-			{...(onClick ? {onClick} : {})}
+			onClick={onClick ? event => onClick(event) : null}
 			className={makeClassNames({type, size, theme, icon, iconOnly})}
 			{...attributes}>
 			{icon && iconOnly ? (
@@ -90,7 +90,7 @@ export function LinkButton({
 	return (
 		<a
 			href={href}
-			{...(onClick ? {onClick} : {})}
+			onClick={onClick ? event => onClick(event) : null}
 			className={makeClassNames({type, size, theme, icon, iconOnly})}
 			{...attributes}>
 			{icon && iconOnly ? (


### PR DESCRIPTION
<img width="500" alt="rabbit saying hello" src="https://user-images.githubusercontent.com/178266/184932275-15c33532-b72f-48cb-bf60-d0af423f4000.png">


hello!

changes in this pr:

- remove `ButtonTemplate` (it fails to compile because of the lack of overlap in the union)
- add a `makeClassNames` function to reduce some of the duplication between LinkButton and Button created by removing ButtonTemplate
- attach the `onClick` handler ourselves to handle React runtime expecting the handler to be a `MouseEventHandler` rather than a function, this should always work without requiring a `import type {} from "react"` in the agnostic templates
- use `null` as the default value for `href` so we can do `href={href}` rather than `{...(href ? {href} : {}}`. functionally the same i think but looks a little prettier