### PR TITLE
Change origami code to origami-website

### DIFF
--- a/apps/website/RUNBOOK.md
+++ b/apps/website/RUNBOOK.md
@@ -8,7 +8,7 @@ A site to document the Origami team, components, and services.
 
 ## Code
 
-origami
+origami-website
 
 ## Service Tier
 


### PR DESCRIPTION
This has been bugging me for some time as the website isn't all of origami and it might be useful to repurpose the `origami` code to e.g. be used for changelogs for the origami project

I will take care of fixing up biz ops data for you if you approve this