### PR TITLE
fix: o-cookie-message, fix tab order

### DIFF
--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -72,14 +72,13 @@ To support a core experience without JavaScript, add the full `o-cookie-message`
 			</div>
 
 			<div class="o-cookie-message__actions">
+				<div class="o-cookie-message__action o-cookie-message__action--secondary">
+					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#" class="o-cookie-message__link">Manage cookies</a>
+				</div>
 				<div class="o-cookie-message__action">
 					<a href="https://consent.ft.com/__consent/consent-record-cookie?redirect=#" class="o-cookie-message__button">
 						Accept &amp; continue
 					</a>
-				</div>
-
-				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#" class="o-cookie-message__link">Manage cookies</a>
 				</div>
 			</div>
 		</div>

--- a/components/o-cookie-message/demos/src/custom-html-full.mustache
+++ b/components/o-cookie-message/demos/src/custom-html-full.mustache
@@ -16,6 +16,11 @@
 				</p>
 			</div>
 			<div class="o-cookie-message__actions">
+				<!-- note: update action redirect, see README for more details -->
+				<div class="o-cookie-message__action o-cookie-message__action--secondary">
+					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#"
+						class="o-cookie-message__link">Manage cookies</a>
+				</div>
 
 				<!-- note: update action redirect, see README for more details -->
 				<div class="o-cookie-message__action">
@@ -23,12 +28,6 @@
 						class="o-cookie-message__button">
 						Accept &amp; continue
 					</a>
-				</div>
-
-				<!-- note: update action redirect, see README for more details -->
-				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#"
-						class="o-cookie-message__link">Manage cookies</a>
 				</div>
 			</div>
 		</div>

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -76,15 +76,14 @@ class CookieMessage {
 				${content}
 		</div>
 		<div class="o-cookie-message__actions">
+			<div class="o-cookie-message__action o-cookie-message__action--secondary">
+				<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
+			</div>
 
 			<div class="o-cookie-message__action">
 				<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
 					Accept &amp; continue
 				</a>
-			</div>
-
-			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
 			</div>
 		</div>
 	</div>

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -114,11 +114,10 @@
 		display: flex;
 		align-items: center;
 		margin-top: oSpacingByName('s6');
-		flex-direction: row-reverse;
 		justify-content: space-between;
 
 		@include oGridRespondTo($until: M) {
-			flex-direction: column-reverse;
+			flex-direction: column;
 			align-items: flex-start;
 			margin-top: 0;
 			.o-cookie-message__action {
@@ -133,6 +132,7 @@
 	}
 
 	.o-cookie-message__action--secondary {
+		order: -1;
 		@include oGridRespondTo($until: M) {
 			margin-top: div($_o-cookie-message-spacing, 4);
 		}

--- a/components/o-cookie-message/src/tsx/cookie-message.tsx
+++ b/components/o-cookie-message/src/tsx/cookie-message.tsx
@@ -74,16 +74,6 @@ export function CookieMessage({
 							</p>
 						</div>
 						<div className="o-cookie-message__actions">
-							<div className="o-cookie-message__action">
-								<a
-									href={
-										'https://consent.ft.com/__consent/consent-record-cookie?redirect=' +
-										redirectURIEncoded
-									}
-									className="o-cookie-message__button">
-									{primaryAction.copy || 'Accept & continue'}
-								</a>
-							</div>
 							<div className="o-cookie-message__action o-cookie-message__action--secondary">
 								<a
 									href={
@@ -92,6 +82,16 @@ export function CookieMessage({
 									}
 									className="o-cookie-message__link">
 									{secondaryAction.copy || 'Manage cookies'}
+								</a>
+							</div>
+							<div className="o-cookie-message__action">
+								<a
+									href={
+										'https://consent.ft.com/__consent/consent-record-cookie?redirect=' +
+										redirectURIEncoded
+									}
+									className="o-cookie-message__button">
+									{primaryAction.copy || 'Accept & continue'}
 								</a>
 							</div>
 						</div>

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -50,14 +50,13 @@ export const html = {
 			</div>
 
 				<div class="o-cookie-message__actions">
+					<div class="o-cookie-message__action o-cookie-message__action--secondary">
+						<a href="https://cookies.localhost/preferences/cookies?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__link">Manage cookies</a>
+					</div>
+
 					<div class="o-cookie-message__action">
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
-
-			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="https://cookies.localhost/preferences/cookies?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__link">Manage cookies</a>
-			</div>
-
 				</div>
 			</div>
 		</div>
@@ -80,14 +79,13 @@ export const html = {
 			</div>
 
 				<div class="o-cookie-message__actions">
+					<div class="o-cookie-message__action o-cookie-message__action--secondary">
+						<a href="https://cookies.localhost/preferences/cookies?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__link">Manage cookies</a>
+					</div>
+
 					<div class="o-cookie-message__action">
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
-
-			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="https://cookies.localhost/preferences/cookies?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__link">Manage cookies</a>
-			</div>
-
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
See issue for more details:
https://github.com/Financial-Times/origami/issues/506

Requires users to update their markup.

>The focus order is incorrect inside the component, this issue may
>affect keyboard only users who would expect the focus order to be
>sequential from top to bottom, left to right.

Uses the flexbox `order` property to ensure this is not a visually
breaking change. Both old and new markup order will continue
to work.

closes: https://github.com/Financial-Times/origami/issues/506