### PR TITLE
fix: upgrade n-map-content-to-topper version in o-topper

### DIFF
--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -22,7 +22,7 @@
     "watch": "bash ../../scripts/component/watch.bash"
   },
   "peerDependencies": {
-    "@financial-times/n-map-content-to-topper": "^1.5.0",
+    "@financial-times/n-map-content-to-topper": "^2.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-editorial-typography": "^2.0.1",
     "@financial-times/o-grid": "^6.0.0",

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -22,7 +22,6 @@
     "watch": "bash ../../scripts/component/watch.bash"
   },
   "peerDependencies": {
-    "@financial-times/n-map-content-to-topper": "^2.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-editorial-typography": "^2.0.1",
     "@financial-times/o-grid": "^6.0.0",
@@ -34,6 +33,9 @@
     "@financial-times/o-fonts": "^5.2.0",
     "@financial-times/o-normalise": "^3.2.0",
     "@financial-times/o-typography": "^7.2.0"
+  },
+  "dependencies": {
+    "@financial-times/n-map-content-to-topper": "^2.1.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5746,6 +5746,9 @@
       "name": "@financial-times/o-topper",
       "version": "5.3.0",
       "license": "MIT",
+      "dependencies": {
+        "@financial-times/n-map-content-to-topper": "^2.1.0"
+      },
       "devDependencies": {
         "@financial-times/o-fonts": "^5.2.0",
         "@financial-times/o-normalise": "^3.2.0",
@@ -5755,7 +5758,6 @@
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
-        "@financial-times/n-map-content-to-topper": "^2.1.0",
         "@financial-times/o-colors": "^6.0.1",
         "@financial-times/o-editorial-typography": "^2.0.1",
         "@financial-times/o-grid": "^6.0.0",
@@ -8656,7 +8658,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-2.1.0.tgz",
       "integrity": "sha512-KteIgFTF0jk4sqolFZV7Rff03vsiyFRmTfznhookw2/RHO8d8TGXsEo0SVzpUmeSmIr6azFmFPNa3OuLpZzFOw==",
-      "peer": true,
       "engines": {
         "node": "16.x"
       }
@@ -55443,8 +55444,7 @@
     "@financial-times/n-map-content-to-topper": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-2.1.0.tgz",
-      "integrity": "sha512-KteIgFTF0jk4sqolFZV7Rff03vsiyFRmTfznhookw2/RHO8d8TGXsEo0SVzpUmeSmIr6azFmFPNa3OuLpZzFOw==",
-      "peer": true
+      "integrity": "sha512-KteIgFTF0jk4sqolFZV7Rff03vsiyFRmTfznhookw2/RHO8d8TGXsEo0SVzpUmeSmIr6azFmFPNa3OuLpZzFOw=="
     },
     "@financial-times/n-notification": {
       "version": "file:components/n-notification",
@@ -55835,6 +55835,7 @@
     "@financial-times/o-topper": {
       "version": "file:components/o-topper",
       "requires": {
+        "@financial-times/n-map-content-to-topper": "^2.1.0",
         "@financial-times/o-fonts": "^5.2.0",
         "@financial-times/o-normalise": "^3.2.0",
         "@financial-times/o-typography": "^7.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5019,7 +5019,7 @@
     },
     "components/o-cookie-message": {
       "name": "@financial-times/o-cookie-message",
-      "version": "6.4.2",
+      "version": "6.4.3",
       "license": "MIT",
       "dependencies": {
         "superstore-sync": "^2.1.1"
@@ -5744,7 +5744,7 @@
     },
     "components/o-topper": {
       "name": "@financial-times/o-topper",
-      "version": "5.2.3",
+      "version": "5.3.0",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-fonts": "^5.2.0",
@@ -5755,7 +5755,7 @@
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
-        "@financial-times/n-map-content-to-topper": "^1.5.0",
+        "@financial-times/n-map-content-to-topper": "^2.1.0",
         "@financial-times/o-colors": "^6.0.1",
         "@financial-times/o-editorial-typography": "^2.0.1",
         "@financial-times/o-grid": "^6.0.0",
@@ -8653,10 +8653,13 @@
       "link": true
     },
     "node_modules/@financial-times/n-map-content-to-topper": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-1.6.0.tgz",
-      "integrity": "sha512-7AezWXpfEEZkz21Taw47h9SoM6Ycg7vrKZ3SOVpo1f0vqRbK7VpnvLOTjhTGOkMdPi5z/5kvjN5ag5P4yvpRMg==",
-      "peer": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-2.1.0.tgz",
+      "integrity": "sha512-KteIgFTF0jk4sqolFZV7Rff03vsiyFRmTfznhookw2/RHO8d8TGXsEo0SVzpUmeSmIr6azFmFPNa3OuLpZzFOw==",
+      "peer": true,
+      "engines": {
+        "node": "16.x"
+      }
     },
     "node_modules/@financial-times/n-notification": {
       "resolved": "components/n-notification",
@@ -55438,9 +55441,9 @@
       }
     },
     "@financial-times/n-map-content-to-topper": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-1.6.0.tgz",
-      "integrity": "sha512-7AezWXpfEEZkz21Taw47h9SoM6Ycg7vrKZ3SOVpo1f0vqRbK7VpnvLOTjhTGOkMdPi5z/5kvjN5ag5P4yvpRMg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-2.1.0.tgz",
+      "integrity": "sha512-KteIgFTF0jk4sqolFZV7Rff03vsiyFRmTfznhookw2/RHO8d8TGXsEo0SVzpUmeSmIr6azFmFPNa3OuLpZzFOw==",
       "peer": true
     },
     "@financial-times/n-notification": {
@@ -67664,7 +67667,7 @@
         "nixt": "^0.5.1",
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
-        "tree-cli": "*",
+        "tree-cli": "^0.6.7",
         "ts-jest": "^26.5.3",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.3"


### PR DESCRIPTION
upgrade n-map-content-to-topper version in order to be able tu use alphaville branding
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1158)