### PR TITLE
docs: add o-spacing storybook

### DIFF
--- a/components/o-spacing/stories/spacing-demo.tsx
+++ b/components/o-spacing/stories/spacing-demo.tsx
@@ -1,0 +1,14 @@
+export interface SpacingDemoProps {
+	name: 's1' | 's2' | 's3' | 's4' | 's6' | 's8' | 'm12'| 'm16'| 'l18'| 'l24';
+}
+
+export function SpacingDemo ({name}: SpacingDemoProps) {
+    const dimensionCSS = {
+        height: `var(--o-spacing-${name})`,
+        width: `var(--o-spacing-${name})`
+    };
+    return <><div className="demo" style={dimensionCSS}>
+        <span className='demo-visually-hidden'>space: {name}</span>
+    </div>
+    </>
+};

--- a/components/o-spacing/stories/spacing.scss
+++ b/components/o-spacing/stories/spacing.scss
@@ -1,0 +1,23 @@
+@import "@financial-times/o-spacing/main";
+@import "@financial-times/o-normalise/main";
+@import "@financial-times/o-fonts/main";
+@import "@financial-times/o-colors/main";
+@import "@financial-times/o-brand/main";
+
+@include oNormalise();
+@include oFonts();
+@include oSpacing();
+
+.demo {
+	@if oBrandIs('whitelabel') {
+		background-color: oColorsByName('white');
+		outline: 3px dashed oColorsByName('black');
+	} @else {
+		background-color: oColorsByName('teal-100');
+		outline: 3px dashed oColorsByName('slate');
+	}
+}
+
+.demo-visually-hidden {
+	@include oNormaliseVisuallyHidden;
+}

--- a/components/o-spacing/stories/spacing.stories.tsx
+++ b/components/o-spacing/stories/spacing.stories.tsx
@@ -1,0 +1,19 @@
+import {withDesign} from 'storybook-addon-designs';
+import './spacing.scss';
+import {SpacingDemo} from './spacing-demo';
+import withHtml from 'origami-storybook-addon-html';
+
+export default {
+	title: 'Components/o-spacing',
+    component: SpacingDemo,
+	decorators: [withDesign, withHtml],
+	parameters: {
+		guidelines: {},
+		html: {},
+	},
+};
+
+export const Spacing = SpacingDemo.bind({});
+Spacing.args = {
+    name: 'm12'
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4890,7 +4890,7 @@
     },
     "components/o-autocomplete": {
       "name": "@financial-times/o-autocomplete",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@financial-times/accessible-autocomplete": "^2.1.2"


### PR DESCRIPTION
I do not think it makes sense to provide public tsx templates for o-spacing

e.g. demo....
<img width="1552" alt="Screenshot 2022-09-14 at 17 17 59" src="https://user-images.githubusercontent.com/10405691/190208177-03f78c24-9e8d-4f66-80b3-0f672d58ee69.png">

e.g. html (with different props to demo screenshot above)...
"demo" indicates demo css. I chose to use o-spacing css custom props which a user could copy from the html tab
<img width="621" alt="Screenshot 2022-09-14 at 17 19 11" src="https://user-images.githubusercontent.com/10405691/190208476-d7145394-e247-4fb6-9ee1-ca344d04f876.png">
