### PR TITLE
fix: add missing Slavery Statement & Policies to footer demos / docs

### DIFF
--- a/apps/website/_includes/footer.html
+++ b/apps/website/_includes/footer.html
@@ -11,10 +11,10 @@
 	<div class="o-footer-services__container">
 		<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 			<div class="o-footer-services__links">
-			<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-			<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-			<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-			<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+			<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+			<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+			<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+			<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 			<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 		</div>
 		<p><span>&copy; THE FINANCIAL TIMES LTD {{ site.time | date: '%Y' }}.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/apps/website/_includes/footer.html
+++ b/apps/website/_includes/footer.html
@@ -15,6 +15,7 @@
 			<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 			<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 			<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+			<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 		</div>
 		<p><span>&copy; THE FINANCIAL TIMES LTD {{ site.time | date: '%Y' }}.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 	</div>

--- a/components/o-cookie-message/MIGRATION.md
+++ b/components/o-cookie-message/MIGRATION.md
@@ -76,7 +76,7 @@ The 2.0.0 release changes the default behaviour of o-cookie-message. Instead of 
 ```diff
 <div class="o-cookie-message__container">
 -	<p class="o-cookie-message__description">
--		By continuing to use this site you consent to the use of cookies on your device as described in our <a href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">cookie policy</a> unless you have disabled them. You can change your <a href="http://help.ft.com/help/legal-privacy/cookies/how-to-mange-cookies/">cookie settings</a> at any time but parts of our site will not function correctly without them.
+-		By continuing to use this site you consent to the use of cookies on your device as described in our <a href="https://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">cookie policy</a> unless you have disabled them. You can change your <a href="https://help.ft.com/help/legal-privacy/cookies/how-to-mange-cookies/">cookie settings</a> at any time but parts of our site will not function correctly without them.
 -	</p>
 -	<div class="o-cookie-message__close-btn-container">
 -		<button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">

--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -62,7 +62,7 @@ To support a core experience without JavaScript, add the full `o-cookie-message`
 				</div>
 				<p id="o-cookie-message-description">
 					We use
-					<a href="http://help.ft.com/help/legal-privacy/cookies/"
+					<a href="https://help.ft.com/help/legal-privacy/cookies/"
 						class="o-cookie-message__link"
 						target="_blank"
 						rel="noopener">cookies</a>

--- a/components/o-cookie-message/demos/src/custom-html-full.mustache
+++ b/components/o-cookie-message/demos/src/custom-html-full.mustache
@@ -7,7 +7,7 @@
 					<h2 id="demo-label-element-id">Cookies on the FT</h2>
 				</div>
 				<p>
-					We use <a href="http://help.ft.com/help/legal-privacy/cookies/"
+					We use <a href="https://help.ft.com/help/legal-privacy/cookies/"
 						class="o-cookie-message__link"
 						target="_blank"
 						rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -96,7 +96,7 @@ class CookieMessage {
 	<h2 id="${labelId}">Cookies on the FT</h2>
 </div>
 <p id="${descriptionId}">
-	We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.
+	We use <a href="https://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.
 </p>`;
 
 		const child = this.cookieMessageElement.firstElementChild;

--- a/components/o-cookie-message/src/tsx/cookie-message.tsx
+++ b/components/o-cookie-message/src/tsx/cookie-message.tsx
@@ -60,7 +60,7 @@ export function CookieMessage({
 									<>
 										We use{' '}
 										<a
-											href="http://help.ft.com/help/legal-privacy/cookies/"
+											href="https://help.ft.com/help/legal-privacy/cookies/"
 											className="o-cookie-message__link"
 											target="_blank"
 											rel="noopener">

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -42,7 +42,7 @@ export const html = {
 				<h2 id="o-cookie-message-label">Cookies on the FT</h2>
 			</div>
 			<p id="o-cookie-message-description">
-				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a>
+				We use <a href="https://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
 				content and ads, providing social media features and to analyse how our Sites are used.
 			</p>
@@ -71,7 +71,7 @@ export const html = {
 				<h2 id="o-cookie-message-label">Cookies on the FT</h2>
 			</div>
 			<p id="o-cookie-message-description">
-				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a>
+				We use <a href="https://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
 				content and ads, providing social media features and to analyse how our Sites are used.
 			</p>

--- a/components/o-footer-services/MIGRATION.md
+++ b/components/o-footer-services/MIGRATION.md
@@ -82,10 +82,10 @@ All previous variations of the footer have been discontinued. To illustrate the 
 +		<div class="o-footer-services__container">
 +			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 +				<div class="o-footer-services__links">
-+					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-+					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-+					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-+					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
++					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
++					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
++					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
++					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 +					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 +				</div>
 +				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/MIGRATION.md
+++ b/components/o-footer-services/MIGRATION.md
@@ -86,6 +86,7 @@ All previous variations of the footer have been discontinued. To illustrate the 
 +					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 +					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 +					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
++					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 +				</div>
 +				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 +			</div>

--- a/components/o-footer-services/README.md
+++ b/components/o-footer-services/README.md
@@ -30,9 +30,9 @@ A footer requires the following markup:
 	<div class="o-footer-services__container">
 		<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 			<div class="o-footer-services__links">
-			<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-			<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-			<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+			<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+			<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+			<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 			<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 		</div>
 		<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/README.md
+++ b/components/o-footer-services/README.md
@@ -33,7 +33,7 @@ A footer requires the following markup:
 			<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
 			<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 			<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-			<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+			<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 		</div>
 		<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 	</div>

--- a/components/o-footer-services/demos/src/footer-content-only.mustache
+++ b/components/o-footer-services/demos/src/footer-content-only.mustache
@@ -12,6 +12,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer-content-only.mustache
+++ b/components/o-footer-services/demos/src/footer-content-only.mustache
@@ -8,10 +8,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-legal.mustache
+++ b/components/o-footer-services/demos/src/footer-legal.mustache
@@ -7,6 +7,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer-legal.mustache
+++ b/components/o-footer-services/demos/src/footer-legal.mustache
@@ -3,10 +3,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-links.mustache
+++ b/components/o-footer-services/demos/src/footer-links.mustache
@@ -9,10 +9,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-links.mustache
+++ b/components/o-footer-services/demos/src/footer-links.mustache
@@ -13,6 +13,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer-logo-content.mustache
+++ b/components/o-footer-services/demos/src/footer-logo-content.mustache
@@ -9,10 +9,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-logo-content.mustache
+++ b/components/o-footer-services/demos/src/footer-logo-content.mustache
@@ -13,6 +13,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer-logo.mustache
+++ b/components/o-footer-services/demos/src/footer-logo.mustache
@@ -12,6 +12,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer-logo.mustache
+++ b/components/o-footer-services/demos/src/footer-logo.mustache
@@ -8,10 +8,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-no-content.mustache
+++ b/components/o-footer-services/demos/src/footer-no-content.mustache
@@ -10,10 +10,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer-no-content.mustache
+++ b/components/o-footer-services/demos/src/footer-no-content.mustache
@@ -14,6 +14,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer-services/demos/src/footer.mustache
+++ b/components/o-footer-services/demos/src/footer.mustache
@@ -11,10 +11,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>

--- a/components/o-footer-services/demos/src/footer.mustache
+++ b/components/o-footer-services/demos/src/footer.mustache
@@ -15,6 +15,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-footer/demos/src/simple-footer.mustache
+++ b/components/o-footer/demos/src/simple-footer.mustache
@@ -5,7 +5,7 @@
 
 		<div>
 			<ul class="o-footer__legal-links">
-				<li><a href="http://help.ft.com/help/legal-privacy/terms-conditions/">Terms &amp; Conditions</a></li><li><a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a></li><li><a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a></li><li><a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a></li>
+				<li><a href="https://help.ft.com/help/legal-privacy/terms-conditions/">Terms &amp; Conditions</a></li><li><a href="https://help.ft.com/help/legal-privacy/privacy/">Privacy</a></li><li><a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a></li><li><a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a></li>
 			</ul>
 		</div>
 		<div class="o-footer__copyright">

--- a/components/o-header/stories/storybook-data/anon.ts
+++ b/components/o-header/stories/storybook-data/anon.ts
@@ -5,7 +5,7 @@ const data: TNavMenu = {
 	items: [
 		{
 			label: 'Help Centre',
-			url: 'http://help.ft.com',
+			url: 'https://help.ft.com',
 			submenu: null,
 		},
 		{

--- a/components/o-header/stories/storybook-data/user.ts
+++ b/components/o-header/stories/storybook-data/user.ts
@@ -2,7 +2,7 @@ import {TNavMenu} from '../../src/tsx/Props';
 const data: TNavMenu = {
 	label: 'User',
 	items: [
-		{label: 'Help Centre', url: 'http://help.ft.com', submenu: null},
+		{label: 'Help Centre', url: 'https://help.ft.com', submenu: null},
 		{
 			label: 'Settings & Account',
 			url: 'https://www.ft.com/myaccount',

--- a/components/o-layout/demos/src/shared/footer.mustache
+++ b/components/o-layout/demos/src/shared/footer.mustache
@@ -15,6 +15,7 @@
 					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
 					<a href="http://help.ft.com/help/legal-privacy/privacy/" class="o-footer-services__bulletted-link">Privacy</a>
 					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 			</div>

--- a/components/o-layout/demos/src/shared/footer.mustache
+++ b/components/o-layout/demos/src/shared/footer.mustache
@@ -11,10 +11,10 @@
 		<div class="o-footer-services__container">
 			<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
 				<div class="o-footer-services__links">
-					<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
-					<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
-					<a href="http://help.ft.com/help/legal-privacy/privacy/" class="o-footer-services__bulletted-link">Privacy</a>
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
+					<a href="https://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+					<a href="https://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+					<a href="https://help.ft.com/help/legal-privacy/privacy/" class="o-footer-services__bulletted-link">Privacy</a>
+					<a href="https://help.ft.com/help/legal-privacy/terms-conditions">Terms & Conditions</a>
 					<a href="https://help.ft.com/legal-privacy/copyright-policy/">Slavery Statement & Policies</a>
 				</div>
 				<p><span>&copy; THE FINANCIAL TIMES LTD 2020.</span> FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>


### PR DESCRIPTION
Closes: https://github.com/Financial-Times/origami/issues/785