### PR TITLE
Update CODEOWNERS for Storytelling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 * @Financial-Times/origami-core 
 
 # Storytelling components
-components/o-audio/ @Financial-Times/content-innovation
-components/o-comments/ @Financial-Times/content-innovation
-components/o-video/ @Financial-Times/content-innovation
+components/o-audio/ @Financial-Times/storytelling
+components/o-comments/ @Financial-Times/storytelling
+components/o-video/ @Financial-Times/storytelling
 
 # Acquisition components
 components/o-subs-card/ @Financial-Times/acquisition


### PR DESCRIPTION
As part of the Storytelling Team name change ([ticket](https://financialtimes.atlassian.net/browse/CI-1318)), The Github team name is updated to storytelling and [all the projects](https://biz-ops.in.ft.com/GithubTeam/Financial-Times%2Fcontent-innovation#general) with CODEOWNERS must to be updated.