### PR TITLE
fix: o-banner, relative space close button position

### DIFF
--- a/components/o-banner/demos/src/demo.scss
+++ b/components/o-banner/demos/src/demo.scss
@@ -1,4 +1,3 @@
-
 @import '../../main';
 @include oBanner();
 @import '@financial-times/o-fonts/main';

--- a/components/o-banner/src/scss/_mixins.scss
+++ b/components/o-banner/src/scss/_mixins.scss
@@ -209,7 +209,7 @@
 	cursor: pointer;
 	outline: inherit;
 	// end: undo button styles
-	$close-button-position: round(div(($_o-banner-spacing - $_o-banner-close-button-size), 2));
+	$close-button-position: calc((#{$_o-banner-spacing} - #{$_o-banner-close-button-size}) / 2);
 	display: block;
 	position: absolute;
 	right: $close-button-position;

--- a/components/o-banner/src/scss/_variables.scss
+++ b/components/o-banner/src/scss/_variables.scss
@@ -2,6 +2,6 @@
 $o-banner-is-silent: true !default;
 
 $_o-banner-spacing: oSpacingByIncrement(10) !default;
-$_o-banner-close-button-size: 26 !default;
+$_o-banner-close-button-size: 26px !default;
 $_o-banner-themes: ('marketing', 'product');
 $_o-banner-layouts: ('small', 'compact');


### PR DESCRIPTION
When `$o-spacing-relative-units:true` o-banner would output a large negative position for the close button due to... bad math in Sass. Instead we can use the `calc` function.