### PR TITLE
fix: o-expander, advertise where content is added to screen reader users

### DIFF
--- a/components/o-expander/README.md
+++ b/components/o-expander/README.md
@@ -30,7 +30,10 @@ The  `o-expander` component has a content element `o-expander__content` (the DOM
 	<div class="o-expander__content">
 		<!-- Some content to expand and collapse. -->
 	</div>
-	<button class="o-expander__toggle">Toggle Content</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 ```
 
@@ -42,7 +45,10 @@ By default o-expander will collapse content on initialisation. To prevent this a
 +	<div class="o-expander__content o-expander__content--expanded">
 		<!-- Some content to expand and collapse. -->
 	</div>
-	<button class="o-expander__toggle">Toggle Content</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 ```
 
@@ -54,7 +60,10 @@ or
 +	<div class="o-expander__content" aria-hidden="false">
 		<!-- Some content to expand and collapse. -->
 	</div>
-	<button class="o-expander__toggle">Toggle Content</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 ```
 
@@ -69,7 +78,10 @@ By default the expander is based on height. Set the `max-height` of your collaps
 	<div class="o-expander__content">
 		<!-- Some content to expand and collapse. -->
 	</div>
-	<button class="o-expander__toggle">Toggle Content</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 ```
 
@@ -98,7 +110,10 @@ The expander may also be based on the number of items within `o-expander__conten
 			<li>item</li> //hidden when collapsed
 			<li>item</li> //hidden when collapsed
 		</ul>
-		<button class="o-expander__toggle">Toggle Content</button>
+		<button class="o-expander__toggle">
+			Toggle
+			<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		</button>
 	</div>
 ```
 
@@ -115,7 +130,10 @@ By default the item count assumes a list. To expand based on other children, suc
 			<p>item</p> //hidden when collapsed
 			<p>item</p> //hidden when collapsed
 		</div>
-		<button class="o-expander__toggle">Toggle Content</button>
+		<button class="o-expander__toggle">
+			Toggle
+			<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		</button>
 	</div>
 ```
 
@@ -130,7 +148,10 @@ The expander may also toggle the visibility of `o-expander__content` entirely. S
 		<div class="o-expander__content">
 			<!-- Some content to entirely hide/show. -->
 		</div>
-		<button class="o-expander__toggle">Toggle Content</button>
+		<button class="o-expander__toggle">
+			Toggle
+			<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		</button>
 	</div>
 ```
 
@@ -150,7 +171,10 @@ All expanders update toggle text when the expander is toggled. To customise defa
 		</div>
 		<!-- This toggle text will update when be "Show more of this please!" when the expander initialises. -->
 		<!-- And "Less of this please!" when the user expands the expander. -->
-		<button class="o-expander__toggle">Toggle</button>
+		<button class="o-expander__toggle">
+			Toggle
+			<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		</button>
 	</div>
 ```
 
@@ -163,7 +187,10 @@ Set `data-o-expander-toggle-state="aria"` to update the toggle aria attributes b
 			<!-- Some content to expand -->
 		</div>
 		<!-- This toggle text will not change. -->
-		<button class="o-expander__toggle">Toggle</button>
+		<button class="o-expander__toggle">
+			Toggle
+			<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		</button>
 	</div>
 ```
 

--- a/components/o-expander/demos/src/collapsing-height.mustache
+++ b/components/o-expander/demos/src/collapsing-height.mustache
@@ -2,5 +2,8 @@
 	<div class="o-expander__content">
 		In this "collapsing height" demo we have set a maximum height to the expander's content element with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
 	</div>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/demos/src/collapsing-hidden.mustache
+++ b/components/o-expander/demos/src/collapsing-hidden.mustache
@@ -2,5 +2,8 @@
 	<div class="o-expander__content">
 		In this "collapsing hidden" demo all content is hidden/shown on click.
 	</div>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/demos/src/collapsing-list.mustache
+++ b/components/o-expander/demos/src/collapsing-list.mustache
@@ -5,5 +5,8 @@
 		<li>item 3</li>
 		<li>item 4</li>
 	</ul>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/demos/src/collapsing-selector.mustache
+++ b/components/o-expander/demos/src/collapsing-selector.mustache
@@ -10,5 +10,8 @@
 			And finally we see a third paragraph.
 		</p>
 	</div>
-	<a href="#" class="o-expander__toggle">read more</a>
+	<a href="#" class="o-expander__toggle">
+		read more
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</a>
 </div>

--- a/components/o-expander/demos/src/hidden-content.mustache
+++ b/components/o-expander/demos/src/hidden-content.mustache
@@ -3,5 +3,8 @@
 	<div class="o-expander__content">
 		This content is completely visible/hidden with the toggle.
 	</div>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/demos/src/pa11y.mustache
+++ b/components/o-expander/demos/src/pa11y.mustache
@@ -2,7 +2,10 @@
 	<div class="o-expander__content">
 		In this "collapsing height" demo we have set a maximum height to the expander's content element with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
 	</div>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="2">
@@ -12,7 +15,10 @@
 		<li>item 3</li>
 		<li>item 4</li>
 	</ul>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 
 
@@ -28,7 +34,10 @@
 			And finally we see a third paragraph.
 		</p>
 	</div>
-	<a href="#" class="o-expander__toggle">read more</a>
+	<a href="#" class="o-expander__toggle">
+		read more
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</a>
 </div>
 
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="hidden">
@@ -36,7 +45,10 @@
 	<div class="o-expander__content">
 		This content is completely visible/hidden with the toggle.
 	</div>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>
 
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="2" data-o-expander-toggle-state="aria">
@@ -46,5 +58,8 @@
 		<li>Item 3</li>
 		<li>Item 4</li>
 	</ul>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/demos/src/toggle.mustache
+++ b/components/o-expander/demos/src/toggle.mustache
@@ -5,5 +5,8 @@
 		<li>Item 3</li>
 		<li>Item 4</li>
 	</ul>
-	<button class="o-expander__toggle">Toggle</button>
+	<button class="o-expander__toggle">
+		Toggle
+		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+	</button>
 </div>

--- a/components/o-expander/main.scss
+++ b/components/o-expander/main.scss
@@ -1,4 +1,5 @@
 @import "@financial-times/o-icons/main";
+@import "@financial-times/o-normalise/main";
 @import 'src/scss/variables';
 
 /// @outputs All o-expander CSS, including the expander content area and toggle.
@@ -68,6 +69,10 @@
 	.o-expander__toggle,
 	.o-expander--inactive .o-expander__toggle {
 		display: none;
+	}
+
+	.o-expander__visually-hidden {
+		@include oNormaliseVisuallyHidden;
 	}
 }
 

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -28,7 +28,8 @@
   },
   "peerDependencies": {
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-viewport": "^5.0.0"
+    "@financial-times/o-viewport": "^5.0.0",
+    "@financial-times/o-normalise": "^3.2.0"
   },
   "devDependencies": {
     "@financial-times/o-normalise": "^3.2.0"

--- a/components/o-expander/src/js/expander-utility.js
+++ b/components/o-expander/src/js/expander-utility.js
@@ -106,6 +106,7 @@ class ExpanderUtility {
 		// or "more" when collapsing to a height.
 		if (!this.options.collapsedToggleText) {
 			this.options.collapsedToggleText = this.options.shrinkTo === 'hidden' ? 'show' : 'more';
+			this.options.collapsedToggleText += ' <span class="o-expander__visually-hidden">(content will be shown above button)</span>';
 		}
 
 		// Elements.

--- a/components/o-expander/src/tsx/expander.tsx
+++ b/components/o-expander/src/tsx/expander.tsx
@@ -32,7 +32,10 @@ export function Expander({header = null, children, expanded}: ExpanderProps) {
 			data-o-expander-shrink-to="hidden">
 			{header}
 			<button className="o-expander__toggle">
-				{expanded ? 'hide' : 'show'}
+				{expanded ?
+					'hide' :
+					`show ${<span className="o-expander__visually-hidden">(content will be added above button)</span>}`
+				}
 			</button>
 			<div
 				className="o-expander__content"


### PR DESCRIPTION
Note: we do not enforce the new copy using JS as we cannot know where users
place their target relative to the content they reveal. This copy is only
needed when the target is placed below the revealed copy. In the future
we should consider redesigning this pattern for a more typical
disclosure pattern.

closes: https://github.com/Financial-Times/origami/issues/513