### PR TITLE
backstage: Run the Percy Github action on merge to main

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,4 +1,4 @@
-name: percy 
+name: percy
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -14,11 +14,7 @@ on:
     paths:
       - "/package.json"
       - "/package-lock.json"
-      - "/origami.json"
-      - "/main.js"
-      - "/main.scss"
-      - "/demos/**"
-      - "/src/**"
+      - "/components/**"
 
 jobs:
   percy-components-ft-concept-button:

--- a/templates/percy-workflow.yml
+++ b/templates/percy-workflow.yml
@@ -1,5 +1,5 @@
 {{=<% %>=}}
-name: percy <%& workspace %>
+name: percy
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -13,13 +13,9 @@ on:
   push:
     branches: main
     paths:
-      - "<%& workspace %>/package.json"
-      - "<%& workspace %>/package-lock.json"
-      - "<%& workspace %>/origami.json"
-      - "<%& workspace %>/main.js"
-      - "<%& workspace %>/main.scss"
-      - "<%& workspace %>/demos/**"
-      - "<%& workspace %>/src/**"
+      - "/package.json"
+      - "/package-lock.json"
+      - "/components/**"
 
 jobs:
   <%#projects%>


### PR DESCRIPTION
It doesn't look like we are running Percy on merge to main as the action will only run if certain files have been changed, it seems to be misconfigured – perhaps from before we moved to a mono-repo, when each component would have its own Percy action.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

![Screenshot 2022-10-12 at 17 44 58](https://user-images.githubusercontent.com/10405691/195401366-866cccdb-9c53-4a9c-8de3-556bbb7d4c30.png)

This may explain why Percy has not been showing visual diffs with the message:
> Multiple browsers were upgraded to the latest version in this build.
> Snapshots will show as "new snapshots" until the next build is
>created on the baseline branch.

![Screenshot 2022-10-12 at 17 44 42](https://user-images.githubusercontent.com/10405691/195401390-252308f4-dff8-4c30-aede-2a7016089e5b.png)

We haven't been updating screenshots of the baseline branch (main)!