### PR TITLE
fix: run percy on push to main

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -12,9 +12,9 @@ on:
   push:
     branches: main
     paths:
-      - "/package.json"
-      - "/package-lock.json"
-      - "/components/**"
+      - "package.json"
+      - "package-lock.json"
+      - "components/**"
 
 jobs:
   percy-components-ft-concept-button:

--- a/templates/percy-workflow.yml
+++ b/templates/percy-workflow.yml
@@ -13,9 +13,9 @@ on:
   push:
     branches: main
     paths:
-      - "/package.json"
-      - "/package-lock.json"
-      - "/components/**"
+      - "package.json"
+      - "package-lock.json"
+      - "components/**"
 
 jobs:
   <%#projects%>


### PR DESCRIPTION
percy still is not running on push to main – because we are using an absolute path? 
relates to: ca1990720c17c0d9e110591d076a7973c3b5d34b