### PR TITLE
fix: storybook build / brand unique stories

### DIFF
--- a/apps/storybook/config/main.js
+++ b/apps/storybook/config/main.js
@@ -1,59 +1,59 @@
-const { readFile, access } = require('node:fs/promises');
-const {constants } = require('node:fs');
-const path = require('node:path');
-const process = require('node:process');
-const globby = require('globby');
+const {readFile, access} = require("node:fs/promises")
+const {constants} = require("node:fs")
+const path = require("node:path")
+const process = require("node:process")
+const globby = require("globby")
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND || "core";
+const brand = process.env.ORIGAMI_STORYBOOK_BRAND || "core"
 /**
  * Node.JS no longer has an fs.exists method.
  * Instead we use the fs.access method and check we can read the file.
  * fs.access will throw an error if the file does not exist.
  * @param {string} file file-system path to the file you are wanting to check exists or not
  * @returns {Promise.<boolean>} Whether the file exists
-*/
+ */
 async function fileExists(file) {
 	try {
-		await access(file, constants.R_OK);
-		return true;
+		await access(file, constants.R_OK)
+		return true
 	} catch (error) {
-		return false;
+		return false
 	}
 }
 
 function readIfExists(filePath) {
-	return fileExists(filePath)
-		.then(exists => {
-			if (exists) {
-				return readFile(filePath, 'utf-8');
-			} else {
-				return undefined;
-			}
-		});
+	return fileExists(filePath).then(exists => {
+		if (exists) {
+			return readFile(filePath, "utf-8")
+		} else {
+			return undefined
+		}
+	})
 }
 
 function requireIfExists(filePath) {
-	return readIfExists(filePath)
-		.then(file => {
-			return file ? JSON.parse(file) : undefined;
-		});
+	return readIfExists(filePath).then(file => {
+		return file ? JSON.parse(file) : undefined
+	})
 }
 
 function getOrigamiJson(cwd) {
-	cwd = cwd || process.cwd();
-	return requireIfExists(path.join(cwd, '/origami.json'));
+	cwd = cwd || process.cwd()
+	return requireIfExists(path.join(cwd, "/origami.json"))
 }
 
-
 function getComponentBrands(cwd) {
-	return getOrigamiJson(cwd)
-		.then(origamiJson => {
-			const hasBrandsDefined = origamiJson && origamiJson.brands && Array.isArray(origamiJson.brands) && origamiJson.brands.length > 0;
-			if (hasBrandsDefined) {
-				return origamiJson.brands;
-			}
-			return ['core', 'internal', 'whitelabel'];
-		});
+	return getOrigamiJson(cwd).then(origamiJson => {
+		const hasBrandsDefined =
+			origamiJson &&
+			origamiJson.brands &&
+			Array.isArray(origamiJson.brands) &&
+			origamiJson.brands.length > 0
+		if (hasBrandsDefined) {
+			return origamiJson.brands
+		}
+		return ["core", "internal", "whitelabel"]
+	})
 }
 
 module.exports.core = {
@@ -66,28 +66,36 @@ module.exports.core = {
 module.exports.stories = (async () => {
 	const storyPaths = [
 		"../stories/**/*.stories.mdx",
-		"../stories/**/*.stories.@(js|jsx|ts|tsx)"
-	];
+		"../stories/**/*.stories.@(js|jsx|ts|tsx)",
+	]
 
-	const componentDirectories = await globby(['../../components/**'], {
+	const componentDirectories = await globby(["../../components/**"], {
 		gitignore: false,
 		expandDirectories: false,
 		onlyDirectories: true,
 		deep: 1,
-	});
+	})
 
 	for (const componentDirectory of componentDirectories) {
-		const brands = await getComponentBrands(componentDirectory);
-		const storiesForBrand = brands.includes(brand) ? await globby([`${componentDirectory}/stories/**/*.stories.@(mdx|js|jsx|ts|tsx)`], {
-			gitignore: false,
-			expandDirectories: false,
-			deep: 1,
-		}) : [];
-		storyPaths.push(...storiesForBrand.map(storyPath => `../${storyPath}`));
+		const brands = await getComponentBrands(componentDirectory)
+		const storiesForBrand = brands.includes(brand)
+			? await globby(
+					[
+						`${componentDirectory}/stories/*.stories.@(mdx|js|jsx|ts|tsx)`,
+						`${componentDirectory}/stories/${brand}/*.stories.@(mdx|js|jsx|ts|tsx)`,
+					],
+					{
+						gitignore: false,
+						expandDirectories: false,
+						deep: 1,
+					}
+			  )
+			: []
+		storyPaths.push(...storiesForBrand.map(storyPath => `../${storyPath}`))
 	}
 
-	return storyPaths;
-})();
+	return storyPaths
+})()
 
 module.exports.addons = [
 	"@storybook/addon-essentials",
@@ -158,13 +166,12 @@ module.exports.webpackFinal = async function webpackFinal(config) {
 	return config
 }
 
-
-module.exports.env = (config) => ({
-    ...config,
-	ORIGAMI_STORYBOOK_BRAND: brand
+module.exports.env = config => ({
+	...config,
+	ORIGAMI_STORYBOOK_BRAND: brand,
 })
 
-
 module.exports.features = {
-	buildStoriesJson: true
+	buildStoriesJson: true,
+	storyStoreV7: true,
 }

--- a/components/o-labels/stories/core/content.stories.tsx
+++ b/components/o-labels/stories/core/content.stories.tsx
@@ -1,14 +1,12 @@
 
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {ContentLabel as ContentLabelTsx} from '../src/tsx/label';
-import './labels.scss';
+import {ContentLabel as ContentLabelTsx} from '../../src/tsx/label';
+import '../labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
     title: 'Components/o-labels',
     component: ContentLabelTsx,
-    includeStories: (brand === 'core' ? /.*/ : []),
     argTypes: {
         state: { defaultValue: 'content-premium' },
         size: {

--- a/components/o-labels/stories/core/indicators.stories.tsx
+++ b/components/o-labels/stories/core/indicators.stories.tsx
@@ -4,21 +4,13 @@ import type {Meta, Story} from '@storybook/react';
 import withHtml from 'origami-storybook-addon-html';
 import {useEffect} from 'react';
 import {withDesign} from 'storybook-addon-designs';
-import {IndicatorLabel as OIndicatorLabel, IndicatorLabelProps} from '../src/tsx/label';
-import './labels.scss';
-
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+import {IndicatorLabel as OIndicatorLabel, IndicatorLabelProps} from '../../src/tsx/label';
+import '../labels.scss';
 
 export default {
 	title: 'Components/o-labels',
 	component: OIndicatorLabel,
 	decorators: [withDesign, withHtml],
-	includeStories: (brand === 'core' ? [
-		'LiveIndicatorLabel',
-		'ClosedIndicatorLabel',
-		'NewIndicatorLabel',
-		'UpdatedIndicatorLabel'
-	] : []),
 	argTypes: {
 		inverse: {control: 'boolean', defaultValue: false},
 		dateTime: {control: 'date'},

--- a/components/o-labels/stories/core/life-cycle.stories.tsx
+++ b/components/o-labels/stories/core/life-cycle.stories.tsx
@@ -1,15 +1,18 @@
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {SupportLabel} from '../src/tsx/label';
-import './labels.scss';
+import {LifeCycleLabel as LifeCycleLabelTsx} from '../../src/tsx/label';
+import '../labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
 	title: 'Components/o-labels',
-	component: SupportLabel,
-    includeStories: (brand === 'internal' ? /.*/ : []),
+	component: LifeCycleLabelTsx,
 	argTypes: {
-		state: {defaultValue: 'support-active'},
+		state: {
+            defaultValue: 'lifecycle-beta',
+            table: {
+                disable: true
+            }
+        },
 		size: {
 			options: ['small', 'default', 'big'],
 			defaultValue: 'default'
@@ -27,10 +30,10 @@ const ComponentDescription = {
 
 export default ComponentDescription;
 
-export const SupportStatusLabel = args => {
-	const copy = args.text || args.state.replace('support-', '');
+export const LifeCycleLabel = args => {
+	const copy = args.text || args.state.replace('lifecycle-', '');
 	if(args.size === 'default') {
 		delete args.size;
 	}
-	return <SupportLabel {...args}>{copy}</SupportLabel>;
+	return <LifeCycleLabelTsx {...args}>{copy}</LifeCycleLabelTsx>;
 }

--- a/components/o-labels/stories/core/timestamps.stories.tsx
+++ b/components/o-labels/stories/core/timestamps.stories.tsx
@@ -4,15 +4,12 @@ import type {Meta, Story} from '@storybook/react';
 import withHtml from 'origami-storybook-addon-html';
 import {useEffect} from 'react';
 import {withDesign} from 'storybook-addon-designs';
-import {TimestampLabel as OTimestampLabel, TimestampLabelProps} from '../src/tsx/label';
-import './labels.scss';
-
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+import {TimestampLabel as OTimestampLabel, TimestampLabelProps} from '../../src/tsx/label';
+import '../labels.scss';
 
 export default {
 	title: 'Components/o-labels',
 	component: OTimestampLabel,
-	includeStories: (brand === 'core' ? ['TimestampLabel'] : []),
 	decorators: [withDesign, withHtml],
 	argTypes: {
 		inverse: {control: 'boolean', defaultValue: false},

--- a/components/o-labels/stories/internal/colour-pallet.stories.tsx
+++ b/components/o-labels/stories/internal/colour-pallet.stories.tsx
@@ -1,14 +1,12 @@
 
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {ColourLabel} from '../src/tsx/label';
+import {ColourLabel} from '../../src/tsx/label';
 import './labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
 	title: 'Components/o-labels',
 	component: ColourLabel,
-	includeStories: (brand === 'internal' ? /.*/ : []),
 	argTypes: {
 		state: { defaultValue: 'oxford' },
 		size: {

--- a/components/o-labels/stories/internal/content.stories.tsx
+++ b/components/o-labels/stories/internal/content.stories.tsx
@@ -1,0 +1,36 @@
+
+import withHtml from 'origami-storybook-addon-html';
+import {withDesign} from 'storybook-addon-designs';
+import {ContentLabel as ContentLabelTsx} from '../../src/tsx/label';
+import './labels.scss';
+
+const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+const ComponentDescription = {
+    title: 'Components/o-labels',
+    component: ContentLabelTsx,
+    argTypes: {
+        state: { defaultValue: 'content-premium' },
+        size: {
+            options: ['small', 'default', 'big'],
+            defaultValue: 'default'
+        },
+        text: {
+            name: 'text',
+            type: { name: 'string', required: false },
+            control: {
+                type: 'text'
+            }
+        }
+    },
+    decorators: [withDesign, withHtml]
+};
+
+export default ComponentDescription;
+
+export const ContentLabel = args => {
+    const copy = args.text || args.state.replace('content-', '');
+    if(args.size === 'default') {
+        delete args.size;
+    }
+    return <ContentLabelTsx {...args}>{copy}</ContentLabelTsx>;
+}

--- a/components/o-labels/stories/internal/service-tier.stories.tsx
+++ b/components/o-labels/stories/internal/service-tier.stories.tsx
@@ -1,20 +1,13 @@
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {LifeCycleLabel as LifeCycleLabelTsx} from '../src/tsx/label';
+import {ServiceLabel} from '../../src/tsx/label';
 import './labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
 	title: 'Components/o-labels',
-	component: LifeCycleLabelTsx,
-    includeStories: (brand === 'core' ? /.*/ : []),
+	component: ServiceLabel,
 	argTypes: {
-		state: {
-            defaultValue: 'lifecycle-beta',
-            table: {
-                disable: true
-            }
-        },
+		state: { defaultValue: 'tier-bronze' },
 		size: {
 			options: ['small', 'default', 'big'],
 			defaultValue: 'default'
@@ -32,10 +25,10 @@ const ComponentDescription = {
 
 export default ComponentDescription;
 
-export const LifeCycleLabel = args => {
-	const copy = args.text || args.state.replace('lifecycle-', '');
+export const ServiceTierLabel = args => {
+	const copy = args.text || args.state.replace('tier-', '');
 	if(args.size === 'default') {
 		delete args.size;
 	}
-	return <LifeCycleLabelTsx {...args}>{copy}</LifeCycleLabelTsx>;
+	return <ServiceLabel {...args}>{copy}</ServiceLabel>;
 }

--- a/components/o-labels/stories/internal/support.stories.tsx
+++ b/components/o-labels/stories/internal/support.stories.tsx
@@ -1,15 +1,13 @@
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {ServiceLabel} from '../src/tsx/label';
+import {SupportLabel} from '../../src/tsx/label';
 import './labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
 	title: 'Components/o-labels',
-	component: ServiceLabel,
-    includeStories: (brand === 'internal' ? /.*/ : []),
+	component: SupportLabel,
 	argTypes: {
-		state: { defaultValue: 'tier-bronze' },
+		state: {defaultValue: 'support-active'},
 		size: {
 			options: ['small', 'default', 'big'],
 			defaultValue: 'default'
@@ -27,10 +25,10 @@ const ComponentDescription = {
 
 export default ComponentDescription;
 
-export const ServiceTierLabel = args => {
-	const copy = args.text || args.state.replace('tier-', '');
+export const SupportStatusLabel = args => {
+	const copy = args.text || args.state.replace('support-', '');
 	if(args.size === 'default') {
 		delete args.size;
 	}
-	return <ServiceLabel {...args}>{copy}</ServiceLabel>;
+	return <SupportLabel {...args}>{copy}</SupportLabel>;
 }

--- a/components/o-message/stories/core/message-notice.stories.tsx
+++ b/components/o-message/stories/core/message-notice.stories.tsx
@@ -1,0 +1,27 @@
+import {NoticeMessage} from '../../src/tsx/message';
+import {
+	ComponentDescription,
+	NoticeInform,
+	NoticeInnerInform,
+	NoticeFeedback,
+	NoticeInnerFeedback
+} from '../shared/message-notice';
+import '../message.scss';
+
+export default {
+	title: 'Components/o-message',
+	component: NoticeMessage,
+	argTypes: {
+		state: {
+			options: ['inform', 'feedback'],
+		},
+	},
+	...ComponentDescription
+};
+
+export {
+	NoticeInform,
+	NoticeInnerInform,
+	NoticeFeedback,
+	NoticeInnerFeedback
+}

--- a/components/o-message/stories/internal/message-action.stories.tsx
+++ b/components/o-message/stories/internal/message-action.stories.tsx
@@ -2,13 +2,11 @@ import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
 import {ComponentStory, ComponentMeta} from '@storybook/react';
 import {useEffect} from 'react';
-import {ActionMessage} from '../src/tsx/message';
-import javascript from '../main';
+import {ActionMessage} from '../../src/tsx/message';
+import javascript from '../../main';
 import './message.scss';
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND || 'core';
-
-const actionProps = {
+export default {
 	title: 'Components/o-message',
 	component: ActionMessage,
 	decorators: [withDesign, withHtml],
@@ -35,10 +33,6 @@ const actionProps = {
 		},
 	},
 };
-
-
-const defaultProps = Brand !== 'core' ? actionProps : null;
-export default defaultProps as ComponentMeta<typeof ActionMessage>;
 
 const ActionStory = args => {
 	useEffect(() => {

--- a/components/o-message/stories/internal/message-notice.stories.tsx
+++ b/components/o-message/stories/internal/message-notice.stories.tsx
@@ -1,0 +1,35 @@
+import {NoticeMessage} from '../../src/tsx/message';
+import {
+	ComponentDescription,
+	NoticeInform,
+	NoticeInnerInform,
+	NoticeWarningLight,
+	NoticeInnerWarningLight,
+	NoticeWarning,
+	NoticeInnerWarning,
+	NoticeFeedback,
+	NoticeInnerFeedback,
+} from '../shared/message-notice';
+import '../message.scss';
+
+export default {
+	title: 'Components/o-message',
+	component: NoticeMessage,
+	argTypes: {
+		state: {
+			options: ['inform', 'feedback', 'warning', 'warning-light'],
+		},
+	},
+	...ComponentDescription
+};
+
+export {
+	NoticeInform,
+	NoticeInnerInform,
+	NoticeWarningLight,
+	NoticeInnerWarningLight,
+	NoticeWarning,
+	NoticeInnerWarning,
+	NoticeFeedback,
+	NoticeInnerFeedback,
+}

--- a/components/o-message/stories/message-alert.stories.tsx
+++ b/components/o-message/stories/message-alert.stories.tsx
@@ -6,8 +6,6 @@ import {AlertMessage} from '../src/tsx/message';
 import javascript from '../main';
 import './message.scss';
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND || 'core';
-
 export default {
 	title: 'Components/o-message',
 	component: AlertMessage,

--- a/components/o-message/stories/shared/message-notice.tsx
+++ b/components/o-message/stories/shared/message-notice.tsx
@@ -1,60 +1,14 @@
 import withHtml from 'origami-storybook-addon-html';
 import {withDesign} from 'storybook-addon-designs';
-import {ComponentStory, ComponentMeta} from '@storybook/react';
+import {ComponentStory} from '@storybook/react';
 import {useEffect} from 'react';
-import {NoticeMessage} from '../src/tsx/message';
-import javascript from '../main';
-import './message.scss';
+import {NoticeMessage} from '../../src/tsx/message';
+import javascript from '../../main';
+import '../message.scss';
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND || 'core';
-
-const argTypes = brand => {
-	const argTypes = {
-		state: {
-			options: ['inform', 'feedback', 'warning', 'warning-light'],
-		},
-	};
-	if (brand === 'core') {
-		argTypes.state.options = ['inform', 'feedback'];
-	}
-
-	if (brand === 'whitelabel') {
-		argTypes.state.options = ['inform'];
-	}
-	return argTypes;
-};
-
-const determineStoriesToIncludeByBrand = brand => {
-	let NoticeStories = [
-		'NoticeInform',
-		'NoticeInnerInform',
-		'NoticeWarningLight',
-		'NoticeInnerWarningLight',
-		'NoticeWarning',
-		'NoticeInnerWarning',
-		'NoticeFeedback',
-		'NoticeInnerFeedback',
-	];
-	switch (brand) {
-		case 'whitelabel':
-			return ['NoticeInform', 'NoticeInnerInform'];
-		case 'core':
-			return [
-				'NoticeInform',
-				'NoticeInnerInform',
-				'NoticeFeedback',
-				'NoticeInnerFeedback',
-			];
-		default:
-			break;
-	}
-	return NoticeStories;
-};
-
-const noticeProps = {
+export const ComponentDescription = {
 	title: 'Components/o-message',
 	component: NoticeMessage,
-	includeStories: determineStoriesToIncludeByBrand(Brand),
 	decorators: [withDesign, withHtml],
 	parameters: {},
 	args: {
@@ -71,10 +25,7 @@ const noticeProps = {
 			openInNewWindow: false,
 		},
 	},
-	argTypes: argTypes(Brand),
 };
-
-export default noticeProps as ComponentMeta<typeof NoticeMessage>;
 
 const innerDecorator = Story => (
 	<div className='demo-inner-message'>{Story()}</div>

--- a/components/o-message/stories/whitelabel/message-notice.stories.tsx
+++ b/components/o-message/stories/whitelabel/message-notice.stories.tsx
@@ -1,0 +1,23 @@
+import {NoticeMessage} from '../../src/tsx/message';
+import {
+	ComponentDescription,
+	NoticeInform,
+	NoticeInnerInform
+} from '../shared/message-notice';
+import '../message.scss';
+
+export default {
+	title: 'Components/o-message',
+	component: NoticeMessage,
+	argTypes: {
+		state: {
+			options: ['inform'],
+		},
+	},
+	...ComponentDescription
+};
+
+export {
+	NoticeInform,
+	NoticeInnerInform
+}


### PR DESCRIPTION
Looks like our Storybook setup is a little borked. We used a dynamic includeStories property to include different stories depending on which brand we’re building the StoryBook for, It works fine locally but the prod build errors because Storybook uses static analysis during the prod build to determine which stories to include/exclude – it doesn’t execute the code, just looks for an array or regex. Looks like someone reported the same issue / expectations as us back in Jul.

Is only an issue when `storyStoreV7` or `buildStoriesJson` is enabled in storybook config. `storyStoreV7` will be the default in the future. So instead of using a dynamic `includeStories` property let's include stories based on directory structure:

`stories/*.stories.tsx` - stories for all brands
`stories/[brand]/*.stories.tsx` - stories for a specific brand 
`stories/shared/.tsx` - exports stories for re-export to support muliple specific brands (no `.stories` extension)

Previous broken use of `includeStories`:
https://github.com/Financial-Times/origami/blob/b33ef6ee611a09eef5e3ec08c04a1fc744b54df0/components/o-labels/stories/content.stories.tsx#L11

Example error in CI:
https://github.com/Financial-Times/origami/actions/runs/3236117619/jobs/5301479773

Source of error (storybook uses static analysis):
https://github.com/storybookjs/storybook/blob/ea70649db9bce2ed4ad2b1eaa13a380fb8cc8e57/code/lib/csf-tools/src/CsfFile.ts#L25

Others had the same issue/expectation:
https://github.com/storybookjs/storybook/issues/18792