### PR TITLE
feat: o-labels, support custom labels with tsx templates

### DIFF
--- a/components/o-labels/src/tsx/label.tsx
+++ b/components/o-labels/src/tsx/label.tsx
@@ -1,6 +1,7 @@
 export interface BaseLabelProps {
 	size?: 'small' | 'big';
 	children: string;
+	state?: string;
 }
 export interface SupportLabelProps extends BaseLabelProps {
 	state:


### PR DESCRIPTION
It was not possible to use templates with custom labels. To support this we can allow any state on the BaseLabel tsx component.

```scss
@include oLabelsAddState('some-example', (
    'background-color': oColorsByName('claret')
));
```

```jsx
<BaseLabel state="some-example" size="big">my custom label</BaseLabel>
```