### PR TITLE
feat: Add support for a "badged" variant of live and close labels.

### DIFF
--- a/components/o-labels/README.md
+++ b/components/o-labels/README.md
@@ -63,7 +63,6 @@ This table outlines the possible standard label states. Custom states may also b
 ### Indicator Label
 
 The indicator label is used to show story status with new, updated, and live variants. The indicator label only supports the core brand but [internal brand support is under consideration](https://github.com/Financial-Times/o-labels/issues/58).
-
 #### Indicator Label Status
 
 This table outlines the possible indicator label statuses:
@@ -75,6 +74,22 @@ This table outlines the possible indicator label statuses:
 | new                  | Indicate a story is new.                                      | core        |
 | updated              | Indicate a story has been updated.                            | core        |
 
+E.g. for a live label:
+
+```html
+<span class="o-labels-indicator o-labels-indicator--live">
+  <span class="o-labels-indicator__status">live</span>
+</span>
+```
+
+The live and closed labels also support a more prominent badge variant:
+```html
+<span
+  class="o-labels-indicator o-labels-indicator--live o-labels-indicator--inverse o-labels-indicator--badge"
+>
+  <span class="o-labels-indicator__status">live</span>
+</span>
+```
 ### Timestamp Label
 
 The timestamp label is used to show article status in place of an indicator label when the article is not new, updated, or live. The timestamp label only supports the core brand.

--- a/components/o-labels/demos/src/indicators-badge.mustache
+++ b/components/o-labels/demos/src/indicators-badge.mustache
@@ -1,0 +1,13 @@
+<span class="o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>

--- a/components/o-labels/main.scss
+++ b/components/o-labels/main.scss
@@ -115,7 +115,7 @@
 			padding: oSpacingByName('s1') oSpacingByName('s2');
 			font-weight: oFontsWeight('bold');
 			color: oColorsByName('white');
-			border-radius: div(2,16) * 1rem;
+			border-radius: div(2, 16) * 1rem;
 			&.o-labels-indicator--live {
 				background: oColorsByName('crimson');
 			}

--- a/components/o-labels/main.scss
+++ b/components/o-labels/main.scss
@@ -1,3 +1,4 @@
+@import '@financial-times/math';
 @import '@financial-times/o-spacing/main';
 @import '@financial-times/o-brand/main';
 @import "@financial-times/o-colors/main";
@@ -107,6 +108,27 @@
 		@if $indicator-label-inverse {
 			.o-labels-indicator--inverse {
 				@extend %_o-labels-timestamp--inverse;
+			}
+		}
+
+		.o-labels-indicator.o-labels-indicator--badge {
+			padding: oSpacingByName('s1') oSpacingByName('s2');
+			font-weight: oFontsWeight('bold');
+			color: oColorsByName('white');
+			border-radius: div(2,16) * 1rem;
+			&.o-labels-indicator--live {
+				background: oColorsByName('crimson');
+			}
+
+			&.o-labels-indicator--closed {
+				background: oColorsByName('black-60');
+			}
+		}
+
+		.o-labels-indicator.o-labels-indicator--badge.o-labels-indicator--inverse {
+			&.o-labels-indicator--live,
+			&.o-labels-indicator--closed {
+				background: transparent;
 			}
 		}
 	}

--- a/components/o-labels/origami.json
+++ b/components/o-labels/origami.json
@@ -107,6 +107,20 @@
 			"template": "/demos/src/indicators.mustache"
 		},
 		{
+			"name": "indicators-badge",
+			"title": "Badge Indicators",
+			"description": "",
+			"data": {
+				"modifiers": [
+					"badge"
+				]
+			},
+			"brands": [
+				"core"
+			],
+			"template": "/demos/src/indicators-badge.mustache"
+		},
+		{
 			"name": "indicators-sizes",
 			"title": "Indicator Sizes",
 			"description": "All indicator labels adapt to the set font size. This demo shows using custom CSS to set the font size of indicator labels.",

--- a/components/o-labels/src/scss/_mixins.scss
+++ b/components/o-labels/src/scss/_mixins.scss
@@ -252,3 +252,10 @@
 		}
 	}
 }
+
+
+@mixin _oLabelIndicatorBadge ($color) {
+	background: oColorsByName($color);
+	padding: oSpacingByName('s1') oSpacingByName('s2');
+	font-weight: oFontsWeight('bold');
+}

--- a/components/o-labels/src/tsx/label.tsx
+++ b/components/o-labels/src/tsx/label.tsx
@@ -74,6 +74,7 @@ export function LifeCycleLabel(props: LifeCycleLabelProps): JSX.Element {
 
 export interface IndicatorLabelProps {
 	indicator: 'live' | 'closed' | 'new' | 'updated';
+	badge?: boolean;
 	status?: string;
 	inverse?: boolean;
 	timestamp?: JSX.Element | JSX.Element[];
@@ -84,10 +85,14 @@ export function IndicatorLabel({
 	status,
 	inverse,
 	timestamp,
+	badge,
 }: IndicatorLabelProps): JSX.Element {
 	const classNames = ['o-labels-indicator', `o-labels-indicator--${indicator}`];
 	if (inverse) {
 		classNames.push('o-labels-indicator--inverse');
+	}
+	if(badge) {
+		classNames.push('o-labels-indicator--badge');
 	}
 	return (
 		<span className={classNames.join(' ')}>

--- a/components/o-labels/stories/core/indicators.stories.tsx
+++ b/components/o-labels/stories/core/indicators.stories.tsx
@@ -48,6 +48,7 @@ export const LiveIndicatorLabel: IndicatorStory =
 LiveIndicatorLabel.args = {
 	indicator: 'live',
 	status: 'live',
+	badge: false,
 };
 
 LiveIndicatorLabel.argTypes = {
@@ -63,6 +64,7 @@ export const ClosedIndicatorLabel: IndicatorStory =
 ClosedIndicatorLabel.args = {
 	indicator: 'closed',
 	status: 'closed',
+	badge: false,
 };
 ClosedIndicatorLabel.argTypes = {
 	dateTime: {
@@ -77,8 +79,17 @@ export const NewIndicatorLabel: IndicatorStory =
 NewIndicatorLabel.args = {
 	indicator: 'new',
 	status: 'new',
+	badge: false,
 	dateTime: Date.now(),
 };
+
+NewIndicatorLabel.argTypes = {
+	badge: {
+		table: {
+			disable: true
+		}
+	}
+}
 
 export const UpdatedIndicatorLabel: IndicatorStory =
 	Template.bind({});
@@ -87,3 +98,11 @@ UpdatedIndicatorLabel.args = {
 	status: 'updated',
 	dateTime: Date.now(),
 };
+
+UpdatedIndicatorLabel.argTypes = {
+	badge: {
+		table: {
+			disable: true
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5043,7 +5043,7 @@
     },
     "components/o-date": {
       "name": "@financial-times/o-date",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "MIT",
       "dependencies": {
         "@financial-times/ft-date-format": "^2.1.0"
@@ -5091,7 +5091,7 @@
     },
     "components/o-expander": {
       "name": "@financial-times/o-expander",
-      "version": "6.2.3",
+      "version": "6.2.4",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-normalise": "^3.2.0"
@@ -5101,6 +5101,7 @@
       },
       "peerDependencies": {
         "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.2.0",
         "@financial-times/o-viewport": "^5.0.0"
       }
     },
@@ -5160,7 +5161,7 @@
     },
     "components/o-forms": {
       "name": "@financial-times/o-forms",
-      "version": "9.4.0",
+      "version": "9.4.1",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-buttons": "^7.2.0",
@@ -5272,7 +5273,7 @@
     },
     "components/o-labels": {
       "name": "@financial-times/o-labels",
-      "version": "6.3.0",
+      "version": "6.4.1",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-fonts": "^5.2.0",
@@ -5356,7 +5357,7 @@
     },
     "components/o-message": {
       "name": "@financial-times/o-message",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-fonts": "^5",


### PR DESCRIPTION
This style is already duplicated in the homepage and live blogs app. The Spark team would also like to use this style in the live blogs preview page.

<img width="771" alt="Screenshot 2022-10-18 at 13 23 59" src="https://user-images.githubusercontent.com/10405691/196428645-34d91ed5-53c1-417d-8fdb-ec97b121bfb0.png">
<img width="771" alt="Screenshot 2022-10-18 at 13 23 52" src="https://user-images.githubusercontent.com/10405691/196428651-7a0f21e3-4193-41c2-ade3-e22c88583e9b.png">


on the homepage:
<img width="771" alt="Screenshot 2022-10-18 at 13 24 17" src="https://user-images.githubusercontent.com/10405691/196428634-6689bf06-df11-4eec-80a6-a0e8def88782.png">
on the live stream page:
<img width="771" alt="Screenshot 2022-10-18 at 13 24 12" src="https://user-images.githubusercontent.com/10405691/196428641-642741b8-df7b-40ff-9c68-4343e8b2ad3a.png">