### PR TITLE
ADSDEV-1204 Cookie Banner DAC_Reflow_06

### DIFF
--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -72,18 +72,20 @@ class CookieMessage {
 		const wrapContent = content => `
 <div class="o-cookie-message__outer">
 	<div class="o-cookie-message__inner">
-		<div class="o-cookie-message__content">
-				${content}
-		</div>
-		<div class="o-cookie-message__actions">
-			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
+		<div class="o-cookie-message__content-outer">
+			<div class="o-cookie-message__content">
+					${content}
 			</div>
+			<div class="o-cookie-message__actions">
+				<div class="o-cookie-message__action o-cookie-message__action--secondary">
+					<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
+				</div>
 
-			<div class="o-cookie-message__action">
-				<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
-					Accept &amp; continue
-				</a>
+				<div class="o-cookie-message__action">
+					<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
+						Accept &amp; continue
+					</a>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -63,15 +63,8 @@
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
-	}
-
-	@media (max-width: 320px) {
-		.o-cookie-message__inner {
-			padding-top: oSpacingByIncrement(1);
-			padding-bottom: oSpacingByIncrement(1);
-			padding-left: oSpacingByIncrement(2);
-			padding-right: oSpacingByIncrement(2);
-		}
+		max-height: 50vh;
+    overflow: scroll;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -63,6 +63,9 @@
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
+	}
+
+	.o-cookie-message__content-outer {
 		max-height: 50vh;
 		overflow: scroll;
 	}

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -31,6 +31,9 @@
 			width: div(map-get($o-grid-layouts, XL), 2.5); // width is 40% grid
 			left: calc((100vw - #{map-get($o-grid-layouts, XL)}) / 2); // ((viewport - grid width) / 2)
 		}
+
+		max-height: 50vh;
+		overflow: scroll;
 	}
 
 	.o-cookie-message--active {
@@ -63,8 +66,6 @@
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
-		max-height: 50vh;
-		overflow: scroll;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -64,7 +64,7 @@
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
 		max-height: 50vh;
-    overflow: scroll;
+		overflow: scroll;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -67,7 +67,7 @@
 
 	.o-cookie-message__content-outer {
 		max-height: 50vh;
-		overflow: scroll;
+		overflow: auto;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -45,9 +45,6 @@
 		@include oVisualEffectsShadowContent('high');
 		background: oColorsByName('white');
 		color: oColorsByName('black');
-
-		max-height: 50vh;
-		overflow: scroll;
 	}
 
 	.o-cookie-message__inner {
@@ -66,6 +63,8 @@
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
+		max-height: 50vh;
+		overflow: scroll;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -31,9 +31,6 @@
 			width: div(map-get($o-grid-layouts, XL), 2.5); // width is 40% grid
 			left: calc((100vw - #{map-get($o-grid-layouts, XL)}) / 2); // ((viewport - grid width) / 2)
 		}
-
-		max-height: 50vh;
-		overflow: scroll;
 	}
 
 	.o-cookie-message--active {
@@ -48,6 +45,9 @@
 		@include oVisualEffectsShadowContent('high');
 		background: oColorsByName('white');
 		color: oColorsByName('black');
+
+		max-height: 50vh;
+		overflow: scroll;
 	}
 
 	.o-cookie-message__inner {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -65,6 +65,15 @@
 		max-width: none;
 	}
 
+	@media (max-width: 320px) {
+		.o-cookie-message__inner {
+			padding-top: oSpacingByIncrement(1);
+			padding-bottom: oSpacingByIncrement(1);
+			padding-left: oSpacingByIncrement(2);
+			padding-right: oSpacingByIncrement(2);
+		}
+	}
+
 	.o-cookie-message__content {
 		padding: 0;
 

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -36,6 +36,8 @@ export const html = {
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
+			<div class="o-cookie-message__content-outer">
+
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
@@ -58,6 +60,7 @@ export const html = {
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
 				</div>
+			</div>
 			</div>
 		</div>
 	</div>`,
@@ -65,6 +68,8 @@ export const html = {
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
+			<div class="o-cookie-message__content-outer">
+
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
@@ -87,6 +92,7 @@ export const html = {
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
 				</div>
+			</div>
 			</div>
 		</div>
 	</div>`


### PR DESCRIPTION
This PR is to improve reflow accessability of the cookie banner in `o-cookie-message` by reducing the size of padding when viewport size is 320px.

JIRA ticket: https://financialtimes.atlassian.net/browse/ADSDEV-1204