### PR TITLE
feat: Add link variant to ft-concept-button 

### DIFF
--- a/components/ft-concept-button/main.scss
+++ b/components/ft-concept-button/main.scss
@@ -1,8 +1,17 @@
 @import '@financial-times/o-typography/main';
 @import '@financial-times/o-normalise/main';
+@import '@financial-times/o-fonts/main';
 
 /// @access private
 $_ftConceptButtonThemes: (
+	link: (
+		background: oColorsByUsecase('link', 'text'),
+		text: oColorsByName('white'),
+		highlight: oColorsByUsecase('link-hover', 'text'),
+		pressed-highlight: rgba(oColorsByUsecase('link-hover', 'text'), 0.05),
+		disabled: rgba(oColorsByName('black'), 0.5),
+		focus-outline: oColorsByUsecase('focus', 'outline', $fallback: null),
+	),
 	standard: (
 		background: oColorsByName('claret'),
 		text: oColorsByName('white'),
@@ -34,7 +43,7 @@ $_ftConceptButtonThemes: (
 		pressed-highlight: rgba(oColorsByName('white'), 0.2),
 		disabled: rgba(oColorsByName('white'), 0.5),
 		focus-outline: oColorsByName('white'),
-	),
+	)
 );
 
 @function _ftConceptButtonGetThemeColor($key) {
@@ -159,10 +168,10 @@ $_ftConceptButtonThemes: (
 	@include oTypographySans($weight: 'semibold', $scale: -1);
 	border-radius: 100px;
 	box-sizing: content-box;
-	display: block;
+	display: inline-block;
 	outline-offset: 2px;
 	overflow: hidden;
-	padding: 5px 12px;
+	padding: oSpacingByName('s1') oSpacingByName('s2');
 	text-align: left;
 	text-overflow: ellipsis;
 	max-width: 15em;
@@ -178,8 +187,14 @@ $_ftConceptButtonThemes: (
 		'monochrome',
 	)
 ) {
+	.ft-concept-button__link,
 	.ft-concept-button__button {
 		@include _ftConceptButtonBase();
+	}
+
+	.ft-concept-button__link {
+		@include _ftConceptButtonTheme('link');
+		text-decoration: none;
 	}
 
 	.ft-concept-button__announcement {

--- a/components/ft-concept-button/src/tsx/concept-button.tsx
+++ b/components/ft-concept-button/src/tsx/concept-button.tsx
@@ -14,6 +14,16 @@ export interface ConceptButtonProps {
 	// for props that aren't appropriate in Origami
 	extraButtonProps: any;
 }
+export interface ConceptLinkProps {
+	// link text
+	label: string;
+	href: string;
+	// for attributes which aren't appropriate in Origami
+	attributes?: {
+		[attribute: string]: string | boolean;
+	};
+	onClick?: Function;
+}
 
 function ConceptButton({
 	label,
@@ -45,5 +55,25 @@ function ConceptButton({
 	);
 }
 
-export {ConceptButton};
+function ConceptLink({
+	label,
+	href,
+	attributes,
+	onClick
+}: ConceptLinkProps) {
+	return (
+		<div
+			className="ft-concept-button">
+			<a
+				className="ft-concept-button__link"
+				href={href}
+				{...attributes}
+				onClick={onClick ? event => onClick(event) : null}>
+				{label}
+			</a>
+		</div>
+	);
+}
+
+export {ConceptButton, ConceptLink};
 export default ConceptButton;

--- a/components/ft-concept-button/stories/concept-button.scss
+++ b/components/ft-concept-button/stories/concept-button.scss
@@ -1,2 +1,8 @@
+@import "@financial-times/o-fonts/main";
+@import "@financial-times/o-normalise/main";
+@include oFonts();
+@include oNormalise();
+
 @import '../main';
 @include ftConceptButton();
+

--- a/components/ft-concept-button/stories/concept-button.stories.tsx
+++ b/components/ft-concept-button/stories/concept-button.stories.tsx
@@ -8,9 +8,12 @@ export default {
 	title: 'Components/ft-concept-button',
 	component: ConceptButton,
 	decorators: [withDesign, withHtml],
-	// @todo Deprecate concept pill button?
-	// It looks like the concept pill has only ever
-	// been intended as a link to concepts.
+	// @deprecated The concept pill is a candidate for deprecation.
+	// They were only ever intended as use as links button use a 
+	// `button` element` in the template. The concept pill style
+	// is only used in one place via n-myft-ui, in a dubious way.
+	// We would prefer the teal style of `ft-concept-button_link`
+	// going forward.
 	excludeStories: [
 		'ConceptPill',
 		'OpinionPill',

--- a/components/ft-concept-button/stories/concept-button.stories.tsx
+++ b/components/ft-concept-button/stories/concept-button.stories.tsx
@@ -8,6 +8,15 @@ export default {
 	title: 'Components/ft-concept-button',
 	component: ConceptButton,
 	decorators: [withDesign, withHtml],
+	// @todo Deprecate concept pill button?
+	// It looks like the concept pill has only ever
+	// been intended as a link to concepts.
+	excludeStories: [
+		'ConceptPill',
+		'OpinionPill',
+		'InversePill',
+		'MonochromePill'
+	],
 	parameters: {
 		design: {
 			type: 'figma',

--- a/components/ft-concept-button/stories/concept-link.stories.tsx
+++ b/components/ft-concept-button/stories/concept-link.stories.tsx
@@ -1,0 +1,40 @@
+import {withDesign} from 'storybook-addon-designs';
+import {ConceptLink as ConceptLinkTemplate} from '../src/tsx/concept-button';
+import './concept-button.scss';
+import withHtml from 'origami-storybook-addon-html';
+
+export default {
+	title: 'Components/ft-concept-button',
+	component: ConceptLinkTemplate,
+	decorators: [withDesign, withHtml],
+	parameters: {
+		design: {
+			type: 'figma',
+			url: 'https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/FT-UI-Library?node-id=0%3A915',
+		},
+		html: {},
+	},
+	argTypes: {
+		attributes: {
+			control: false,
+			table: {disable: true},
+		},
+		onClick: {
+			control: false,
+			table: {disable: true},
+		},
+	},
+};
+
+const ConceptLinkStory = args => {
+	return (
+		<ConceptLinkTemplate {...args} />
+	);
+};
+
+export const ConceptPillLink = ConceptLinkStory.bind({});
+
+ConceptPillLink.args = {
+	label: 'Movies',
+	href: '#movies',
+};


### PR DESCRIPTION
1. Hide the current concept button styles from Origami because it is not used
and is a candidate for deprecation. That style seems to be only still used in
one place, via n-myft-ui, on the contact preferences page. In addition it is a
link, not a button, like the one here in Origami.
2. Add ft-concept-button__link to fulfil the same purpose as the above but
on the newsletter page. This will be the preferred style going forward. It's
teal to match the colour of our links.

<img width="1552" alt="Screenshot 2022-11-02 at 17 10 51" src="https://user-images.githubusercontent.com/10405691/199555888-edc853b7-44c0-4600-b0ba-dd9488567463.png">
