### PR TITLE
feat: add accesible mode that shows img html element instead of backg…

### DIFF
--- a/components/o-share/src/js/share.js
+++ b/components/o-share/src/js/share.js
@@ -130,6 +130,16 @@ function Share(rootEl, config) {
 			aElement.appendChild(spanElement);
 			liElement.appendChild(aElement);
 			ulElement.appendChild(liElement);
+			if(config.accessible){
+				if (document.readyState === "complete" || document.readyState === "loaded") {
+					addAccesibleIcons(aElement);
+				}
+				else{
+					document.addEventListener('DOMContentLoaded',() => {
+						addAccesibleIcons(aElement);
+					});
+				}
+			}
 		}
 		oShare.rootEl.appendChild(ulElement);
 	}
@@ -179,6 +189,7 @@ function Share(rootEl, config) {
 				config.titleExtra = rootEl.getAttribute('data-o-share-titleExtra') || '';
 				config.summary = rootEl.getAttribute('data-o-share-summary') || '';
 				config.relatedTwitterAccounts = rootEl.getAttribute('data-o-share-relatedTwitterAccounts') || '';
+				config.accessible = rootEl.getAttribute('data-o-share-accesible') !== null;
 			}
 			render();
 		}
@@ -186,6 +197,32 @@ function Share(rootEl, config) {
 		dispatchCustomEvent('ready', {
 			share: oShare
 		});
+	}
+	/**
+	 * Returns the image url from an html element pseudoelement ::before which has set a background-image
+	 *
+	 * @param element
+	 * @returns
+	 */
+	function getImageIconUrl(element){
+		const style = window.getComputedStyle(element, '::before');
+		const imageUrl = /url\s*\("(.*)"\)/.exec(style.getPropertyValue('background-image'))[1];
+		return imageUrl;
+	}
+
+	/**
+	 * add an image html element and hides background-image from an icon element
+	 *
+	 * @param {*} aElement
+	 */
+	function addAccesibleIcons(aElement){
+		if(aElement && !aElement.classList.contains('o-share-accesible')){
+			const accesibleImgIcon = document.createElement("img");
+			const urlIcon = getImageIconUrl(aElement);
+			accesibleImgIcon.src = urlIcon;
+			aElement.appendChild(accesibleImgIcon);
+			aElement.classList.add('o-share-accesible');
+		}
 	}
 
 	init();

--- a/components/o-share/src/scss/_mixins.scss
+++ b/components/o-share/src/scss/_mixins.scss
@@ -88,6 +88,14 @@
 		background-size: $size $size;
 	}
 
+	.o-share-accesible {
+		width: $size - ($o-share-border-size * 2);
+		height: $size - ($o-share-border-size * 2);
+		&:before {
+			display: none;
+		}
+	}
+
 	// If there is not a margin use a negative margin
 	// to make icons borders overlap.
 	@if not $margin {

--- a/components/o-share/src/tsx/share.tsx
+++ b/components/o-share/src/tsx/share.tsx
@@ -20,6 +20,7 @@ type ShareProps = {
 	small?: boolean;
 	vertical?: boolean;
 	inverse?: boolean;
+	accesible?:boolean;
 };
 
 export function Share({
@@ -32,13 +33,16 @@ export function Share({
 	small,
 	vertical,
 	inverse,
+	accesible,
 }: ShareProps) {
 	let className = '';
+	let additionalProperties = {};
 	if (small) className = ' o-share--small';
 	if (vertical) className = ' o-share--vertical';
 	if (inverse) className += ' o-share--inverse';
+	if (accesible) additionalProperties['data-o-share--accesible'] = true
 	return (
-		<div data-o-component="o-share" className={`o-share${className}`}>
+		<div data-o-component="o-share" className={`o-share${className}`} {...additionalProperties} >
 			<ul>
 				{socialNetworks.map((socialNetwork, i) => (
 					<li className="o-share__action" key={i + socialNetwork}>

--- a/components/o-share/stories/share.stories.tsx
+++ b/components/o-share/stories/share.stories.tsx
@@ -27,6 +27,7 @@ export default {
 		small: false,
 		inverse: false,
 		vertical: false,
+		accesible: false
 	},
 } as ComponentMeta<typeof Share>;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5161,7 +5161,7 @@
     },
     "components/o-forms": {
       "name": "@financial-times/o-forms",
-      "version": "9.4.1",
+      "version": "9.4.2",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-buttons": "^7.2.0",
@@ -5273,7 +5273,7 @@
     },
     "components/o-labels": {
       "name": "@financial-times/o-labels",
-      "version": "6.4.1",
+      "version": "6.5.0",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
I have add an accesible new feature that adds img html elements instead of using a pseudo html element ::before to add the  background image fro the icons.
This is done dynamically after DomContentLoaded event is fired. This is not the best approach but there's a lot of scss logic that we will need to move to javascript in case we want to calculate the url of the icons from javascript. So for the moment maybe this could be the best approach.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1373)