### PR TITLE
cookie message fixes

### DIFF
--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -77,7 +77,7 @@ To support a core experience without JavaScript, add the full `o-cookie-message`
 				</div>
 				<div class="o-cookie-message__action">
 					<a href="https://consent.ft.com/__consent/consent-record-cookie?redirect=#" class="o-cookie-message__button">
-						Accept &amp; continue
+						Accept cookies
 					</a>
 				</div>
 			</div>

--- a/components/o-cookie-message/demos/src/custom-html-full.mustache
+++ b/components/o-cookie-message/demos/src/custom-html-full.mustache
@@ -26,7 +26,7 @@
 				<div class="o-cookie-message__action">
 					<a href="https://consent.ft.com/__consent/consent-record-cookie?redirect=#"
 						class="o-cookie-message__button">
-						Accept &amp; continue
+						Accept cookies
 					</a>
 				</div>
 			</div>

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -82,7 +82,7 @@ class CookieMessage {
 
 			<div class="o-cookie-message__action">
 				<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
-					Accept &amp; continue
+					Accept cookies
 				</a>
 			</div>
 		</div>

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -72,20 +72,18 @@ class CookieMessage {
 		const wrapContent = content => `
 <div class="o-cookie-message__outer">
 	<div class="o-cookie-message__inner">
-		<div class="o-cookie-message__content-outer">
-			<div class="o-cookie-message__content">
-					${content}
+		<div class="o-cookie-message__content">
+				${content}
+		</div>
+		<div class="o-cookie-message__actions">
+			<div class="o-cookie-message__action o-cookie-message__action--secondary">
+				<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
 			</div>
-			<div class="o-cookie-message__actions">
-				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="${this.cookieInfo.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
-				</div>
 
-				<div class="o-cookie-message__action">
-					<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
-						Accept &amp; continue
-					</a>
-				</div>
+			<div class="o-cookie-message__action">
+				<a href="${this.cookieInfo.acceptUrlFallback}" class="o-cookie-message__button">
+					Accept &amp; continue
+				</a>
 			</div>
 		</div>
 	</div>

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -63,6 +63,8 @@
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
 		max-width: none;
+		max-height: 50vh;
+		overflow-y: auto;
 	}
 
 	.o-cookie-message__content {

--- a/components/o-cookie-message/src/scss/_mixins.scss
+++ b/components/o-cookie-message/src/scss/_mixins.scss
@@ -65,11 +65,6 @@
 		max-width: none;
 	}
 
-	.o-cookie-message__content-outer {
-		max-height: 50vh;
-		overflow: auto;
-	}
-
 	.o-cookie-message__content {
 		padding: 0;
 

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -84,7 +84,7 @@ export const html = {
 					</div>
 
 					<div class="o-cookie-message__action">
-						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
+						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept cookies</a>
 					</div>
 				</div>
 			</div>

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -36,8 +36,6 @@ export const html = {
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
-			<div class="o-cookie-message__content-outer">
-
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
@@ -60,7 +58,6 @@ export const html = {
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
 				</div>
-			</div>
 			</div>
 		</div>
 	</div>`,
@@ -68,8 +65,6 @@ export const html = {
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
-			<div class="o-cookie-message__content-outer">
-
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
@@ -92,7 +87,6 @@ export const html = {
 						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
 					</div>
 				</div>
-			</div>
 			</div>
 		</div>
 	</div>`

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -55,7 +55,7 @@ export const html = {
 					</div>
 
 					<div class="o-cookie-message__action">
-						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept &amp; continue</a>
+						<a href="https://consent.localhost/__consent/consent-record-cookie?redirect=http://example.com&amp;cookieDomain=.localhost" class="o-cookie-message__button">Accept cookies</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
- Reverses `o-cookie-message__content-outer` [markup addition](https://github.com/Financial-Times/origami/pull/861) before release. We can't add new markup without a major release, as it requires some users to update their markup – including ft.com projects. These don't rely on o-cookie-message JS to generate cookie message markup as they require a progressively enhanced fallback for when JavaScript has failed for whatever reason.
- Instead this PR adds overflow CSS to the existing `o-cookie-message__inner` element.
- The original addition of `o-cookie-message__content-outer` caused the separate [cookie message copy change PR](https://github.com/Financial-Times/origami/pull/858) to conflict. It was convenient to cherry pick that commit here.