### PR TITLE
fix: o-share, show icons with windows high contrast mode enabled

### DIFF
--- a/components/o-share/src/scss/_mixins.scss
+++ b/components/o-share/src/scss/_mixins.scss
@@ -24,6 +24,13 @@
 
 		.o-share__icon--#{$icon-name}:before {
 			background-image: url($service-url + $query + "&format=svg&tint=#{$color-encoded}");
+			@media screen and (-ms-high-contrast: active) {
+				background-image: url($service-url + $query + "&format=svg&tint=%23ffffff,%23ffffff");
+			}
+
+			@media screen and (-ms-high-contrast: black-on-white) {
+				background-image: url($service-url + $query + "&format=svg&tint=%23000000,%23000000");
+			}
 		}
 
 		.o-share__icon--#{$icon-name}:hover,


### PR DESCRIPTION
Show icons with windows high contrast mode enabled.

`forced-colors` is the standard alternative but is quite new and not widely adopted.
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors We would need to update the way we colour icons (perhaps using masks and background colours) to use the text colour set by forced-colors. https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#system_colors