### PR TITLE
docs: Do not use Storybook `storyStoreV7` for now.

### DIFF
--- a/apps/storybook/config/main.js
+++ b/apps/storybook/config/main.js
@@ -173,5 +173,4 @@ module.exports.env = config => ({
 
 module.exports.features = {
 	buildStoriesJson: true,
-	storyStoreV7: true,
 }


### PR DESCRIPTION
This option has broken our production Storybook Build with error:

>Uncaught ReferenceError: regeneratorRuntime is not defined

I tried configuring `browserlist` in webpack in an attempt to:
1. remove polyfills for features like `async/await` by building for modern browsers
2. add polyfills for features like `async/await` by building for older browsers

No luck.

At this point, I'm not sure what is calling `regeneratorRuntime` or whether `regeneratorRuntime` is in a pre-compiled bundle or not.

How about we wait until `storyStoreV7` isn't an experimental feature and storybook v7 and related pugins are released:
https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#modern-browser-support