### PR TITLE
feat: modify caption from topper full-bleed-offset

### DIFF
--- a/components/o-topper/demos/src/full-bleed-offset.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset.mustache
@@ -23,6 +23,6 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/402afdfa-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
+		<figcaption class="o-topper__image-credit">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo © Bloomberg</figcaption>
 	</figure>
 </div>

--- a/components/o-topper/src/scss/_elements.scss
+++ b/components/o-topper/src/scss/_elements.scss
@@ -41,12 +41,8 @@
 }
 
 @mixin _oTopperImageCredit {
-	@include oTypographySans(-2);
-	color: oColorsByName('white');
-	position: absolute;
-	right: 12px;
-	bottom: 2px;
-	text-shadow: 1px 1px 1px oColorsByName('slate');
+	@include oTypographySans(-1);
+	padding: 3px 7px;
 }
 
 //IE9 support

--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -237,11 +237,10 @@
 	$foreground: oColorsGetTextColor($background, $opacity: 100);
 	$link-text-color: oColorsByUsecase('link', 'text');
 	$link-contrasts-with-background: oColorsGetContrastRatio($background, $link-text-color) > 4.5;
-
 	// include oTopperColor on a parent then extend this placeholder on a
 	// descendent to lend that descendent the color you specified in the mixin
 	.o-topper__background,
-	.o-topper__content {
+	.o-topper__content, .o-topper__image-credit {
 		background-color: $background;
 	}
 
@@ -292,6 +291,10 @@
 		&:hover {
 			color: oColorsMix($foreground, $color-name, 73);
 		}
+	}
+	
+	.o-topper__image-credit {
+		color:$foreground;
 	}
 
 	@if $color-name == 'paper' or $color-name == 'wheat' {

--- a/components/o-topper/src/scss/themes/_full-bleed-offset.scss
+++ b/components/o-topper/src/scss/themes/_full-bleed-offset.scss
@@ -3,10 +3,15 @@
 @mixin _oTopperThemeFullBleedOffset {
 	display: flex;
 	flex-direction: column;
-
+	
 	@include oGridRespondTo($until: L) {
 		margin: 0 auto;
 		padding: 0;
+
+		.o-topper__background {
+			position: absolute;
+			height:100%;
+		}
 	}
 
 	.o-topper__read-next {
@@ -40,8 +45,10 @@
 		.o-topper__visual {
 			grid-column: 1;
 			grid-row: 1 / span 3;
+			
 		}
 	}
+
 
 	//Add extra 20px columns to get the space outside the content well
 	@include oGridRespondTo(L) {
@@ -73,19 +80,27 @@
 	@supports (object-fit: cover) {
 		.o-topper__visual {
 			height: auto;
-			max-height: 480px;
 
 			@include oGridRespondTo(L) {
 				height: 600px;
-				max-height: 600px;
 			}
 		}
 	}
-
-	.o-topper__image-credit {
-		@include oGridRespondTo($from: M, $until: XL) {
-			bottom: auto;
-			top: 0;
-		}
+	@include oGridRespondTo( $from: M , $until: L ) {
+		display:flex;
 	}
+	.o-topper__image-credit {
+		text-align: right;
+		@include oGridRespondTo($from: L,$until: XL) { 
+			width: 28%;
+			float:right;
+		}
+		@include oGridRespondTo($from: XL) { 
+			width: 29%;
+			float:right;
+		}
+		
+	}
+
+	
 }


### PR DESCRIPTION
This PR modifies topper full-bleed offset in order to show the caption below the image.
Also this PR introduce serveral changes that will be used in the modification of the other topper captions.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1420)

BEFORE
<img width="317" alt="image" src="https://user-images.githubusercontent.com/102036944/199765807-c6b09ec5-1e2b-44fe-884e-84f230635706.png">
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/102036944/199766297-3ce7cce1-e456-4d4a-9b39-a24f2e151c3d.png">


AFTER
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1420
<img width="326" alt="image" src="https://user-images.githubusercontent.com/102036944/199765232-51bddaf2-ec9f-4c02-bfdf-08267d7a384e.png">
<img width="822" alt="image" src="https://user-images.githubusercontent.com/102036944/199765456-79b7fd0a-18d0-4ea0-b074-f8774b109e77.png">
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/102036944/199765565-68d1926a-4d18-479e-adc5-6a3c8b7d807a.png">


