### PR TITLE
backstage: locally watch for any component / library change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4833,7 +4833,7 @@
     },
     "components/ft-concept-button": {
       "name": "@financial-times/ft-concept-button",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "engines": {
         "npm": "^7 || ^8"
@@ -5020,7 +5020,7 @@
     },
     "components/o-cookie-message": {
       "name": "@financial-times/o-cookie-message",
-      "version": "6.4.3",
+      "version": "6.5.0",
       "license": "MIT",
       "dependencies": {
         "superstore-sync": "^2.1.1"
@@ -5161,7 +5161,7 @@
     },
     "components/o-forms": {
       "name": "@financial-times/o-forms",
-      "version": "9.4.1",
+      "version": "9.4.2",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-buttons": "^7.2.0",
@@ -5273,7 +5273,7 @@
     },
     "components/o-labels": {
       "name": "@financial-times/o-labels",
-      "version": "6.4.1",
+      "version": "6.5.1",
       "license": "MIT",
       "devDependencies": {
         "@financial-times/o-fonts": "^5.2.0",

--- a/scripts/component/watch.bash
+++ b/scripts/component/watch.bash
@@ -23,6 +23,6 @@ die() {
 trap die INT
 
 # we use rg --files, it will not rebuild for any .gitignore'd files
-rg --files | entr npm run build &
+rg ../../components ../../libraries --files | entr npm run build &
 
 serve demos/local/


### PR DESCRIPTION
Rebuild watched components when any component / library changes. E.g. `npm run watch -w components/o-forms` will rebuild when o-normalise is updated.