### PR TITLE
feat: publish o-tracking support for nested JSON-like property values…

### DIFF
--- a/libraries/o-tracking/README.md
+++ b/libraries/o-tracking/README.md
@@ -299,7 +299,7 @@ For example, when the below anchor element is clicked, it will add extra event f
 
 **Nested properties**
 
-If you need to add nested property to the context of the events using the `data-trackable-context-*` custom attribute, you just need to specify the string representation of the value in a JSON-like format.
+To add a nested property to the context of events using the `data-trackable-context-*` custom attribute, specify the string representation of the value in a JSON-like format.
 
 For example, when the below anchor element is clicked:
 


### PR DESCRIPTION
… via data-trackable-context-*

Relates to: https://github.com/Financial-Times/origami/pull/883

The `feat` [conventional commit](https://github.com/Financial-Times/origami/pull/883) was missing from previous commits, this new commit will triggar a release. o-tracking documentation has been updated to facilitate this – avoids trivialisation, filler, etc https://origami.ft.com/documentation/principles/tone-and-language/