### PR TITLE
fix: remove background from figcaption on toppers

### DIFF
--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -240,8 +240,7 @@
 	// include oTopperColor on a parent then extend this placeholder on a
 	// descendent to lend that descendent the color you specified in the mixin
 	.o-topper__background,
-	.o-topper__content,
-	.o-topper__image-credit {
+	.o-topper__content {
 		background-color: $background;
 	}
 

--- a/components/o-topper/src/scss/themes/_full-bleed-image.scss
+++ b/components/o-topper/src/scss/themes/_full-bleed-image.scss
@@ -66,7 +66,6 @@
 	}
 
 	.o-topper__image-credit {
-		background-color: transparent;
 		color: oColorsByName("black-70");
 		margin-bottom: -20px;
 	}

--- a/components/o-topper/src/scss/themes/_split-text.scss
+++ b/components/o-topper/src/scss/themes/_split-text.scss
@@ -94,7 +94,6 @@
 	}
 
 	.o-topper__image-credit {
-		background-color: transparent;
 		color: oColorsByName("black-70");
 		position: relative;
 		width: 100%;


### PR DESCRIPTION
Background on toppers caption is not necessary and at some point was causing some visual issues with right-rail. 
With this PR we fix that.
