### PR TITLE
feat: add element image-caption replacing  image-credit behaviour and modify image-credit 

### DIFF
--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -53,6 +53,7 @@ Toppers support a wide array of [elements](#supported-elements) and can be custo
 | `.o-topper__picture`        | A `<picture>` tag visual element.                                                                  |
 | `.o-topper__image`          | An `<img>` tag visual element, usually used as fallback for a `<picture>`.                         |
 | `.o-topper__image-credit`   | Element showing credit/copyright for the `__picture` or `__image`. Should be a `<figcaption>` tag. |
+| `.o-topper__image-caption`   | Element showing caption and credit/copyright together for the `__picture` or `__image`. Should be a `<figcaption>` tag. |
 
 ### Themes
 

--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -131,6 +131,7 @@ To include o-topper styles granularly specify which elements, themes, and colour
 		'read-next',
 		'image',
 		'image-credit',
+		'image-caption'
 	),
 	'colors': (
 		'white', // .o-topper--color-white

--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -52,7 +52,7 @@ Toppers support a wide array of [elements](#supported-elements) and can be custo
 | `.o-topper__visual`         | Wrapper for the visual elements `__picture` and `__image`. Should be a `<figure>` tag.             |
 | `.o-topper__picture`        | A `<picture>` tag visual element.                                                                  |
 | `.o-topper__image`          | An `<img>` tag visual element, usually used as fallback for a `<picture>`.                         |
-| `.o-topper__image-credit`   | Element showing credit/copyright for the `__picture` or `__image`. Should be a `<figcaption>` tag. |
+| `.o-topper__image-credit`   | Element showing credit/copyright for the `__picture` or `__image`, where no image caption is given. If an image caption is provided alongside credit/copyright information use `.o-topper__image-caption` instead. Should be a `<figcaption>` tag. |
 | `.o-topper__image-caption`   | Element showing caption and credit/copyright together for the `__picture` or `__image`. Should be a `<figcaption>` tag. |
 
 ### Themes

--- a/components/o-topper/demos/src/full-bleed-image-center.mustache
+++ b/components/o-topper/demos/src/full-bleed-image-center.mustache
@@ -18,6 +18,6 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0c368ecb-3d2d-4bf2-be88-2befb42c45f8.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/c41b7e70-fe88-4789-818e-3bacf0f65980.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-				<figcaption class="o-topper__image-credit">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo</figcaption>
+				<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo</figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-image-left.mustache
+++ b/components/o-topper/demos/src/full-bleed-image-left.mustache
@@ -18,6 +18,8 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0c368ecb-3d2d-4bf2-be88-2befb42c45f8.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/c41b7e70-fe88-4789-818e-3bacf0f65980.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-credit">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo</figcaption>
+		<figcaption class="o-topper__image-credit">@FT</figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo</figcaption>
+
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-image-left.mustache
+++ b/components/o-topper/demos/src/full-bleed-image-left.mustache
@@ -19,7 +19,5 @@
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/c41b7e70-fe88-4789-818e-3bacf0f65980.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
 		<figcaption class="o-topper__image-credit">@FT</figcaption>
-		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo</figcaption>
-
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
@@ -24,6 +24,5 @@
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
 		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
-		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
@@ -23,6 +23,7 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/402afdfa-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-credit">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo © Bloomberg</figcaption>
+		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-offset.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset.mustache
@@ -23,6 +23,6 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/402afdfa-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo © Bloomberg</figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-offset.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset.mustache
@@ -23,7 +23,6 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/402afdfa-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
 		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-offset.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset.mustache
@@ -23,6 +23,7 @@
 			<source media="(min-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/402afdfa-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440 1440w">
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/05fff02c-f78e-11e7-8715-e94187b3017e?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 		</picture>
-		<figcaption class="o-topper__image-credit">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo © Bloomberg</figcaption>
+		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/split-text-center.mustache
+++ b/components/o-topper/demos/src/split-text-center.mustache
@@ -26,5 +26,7 @@
 		</picture>
 
 		<figcaption class="o-topper__image-credit">© Ollanski</figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
+
 	</figure>
 </div>

--- a/components/o-topper/demos/src/split-text-center.mustache
+++ b/components/o-topper/demos/src/split-text-center.mustache
@@ -26,7 +26,5 @@
 		</picture>
 
 		<figcaption class="o-topper__image-credit">© Ollanski</figcaption>
-		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
-
 	</figure>
 </div>

--- a/components/o-topper/demos/src/split-text-left.mustache
+++ b/components/o-topper/demos/src/split-text-left.mustache
@@ -21,7 +21,6 @@
 
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/97a49d16-61e8-11e7-8814-0ac7eb84e5f1?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=800">
 		</picture>
-		<figcaption class="o-topper__image-credit">© KMG/SWNS.com</figcaption>
 		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
 
 	</figure>

--- a/components/o-topper/demos/src/split-text-left.mustache
+++ b/components/o-topper/demos/src/split-text-left.mustache
@@ -22,5 +22,7 @@
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http://prod-upp-image-read.ft.com/97a49d16-61e8-11e7-8814-0ac7eb84e5f1?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=800">
 		</picture>
 		<figcaption class="o-topper__image-credit">© KMG/SWNS.com</figcaption>
+		<figcaption class="o-topper__image-caption">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo </figcaption>
+
 	</figure>
 </div>

--- a/components/o-topper/src/scss/_elements.scss
+++ b/components/o-topper/src/scss/_elements.scss
@@ -41,6 +41,20 @@
 }
 
 @mixin _oTopperImageCredit {
+	@include oTypographySans(-2);
+	color: oColorsByName('white');
+	position: absolute;
+	text-shadow: 1px 1px 1px oColorsByName('slate');
+	text-align: right;
+	width: 100vw;
+	margin-left: 50%;
+	left: -50vw;
+	box-sizing: border-box;
+	padding: 5px;
+	transform: translate(0, -100%);
+}
+
+@mixin _oTopperImageCaption {
 	@include oTypographySans(-1);
 	padding: 10px 11px 0px;
 	@include oGridRespondTo(L) {

--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -221,6 +221,12 @@
 			@include _oTopperImageCredit;
 		}
 	}
+
+	@if index($elements, 'image-caption') {
+		.o-topper__image-caption {
+			@include _oTopperImageCaption;
+		}
+	}
 }
 
 @mixin _oTopperColors($colors) {
@@ -293,7 +299,7 @@
 		}
 	}
 	
-	.o-topper__image-credit {
+	.o-topper__image-caption {
 		color: oColorsMix($foreground, $color-name, 73);
 	}
 

--- a/components/o-topper/src/scss/_variables.scss
+++ b/components/o-topper/src/scss/_variables.scss
@@ -63,7 +63,8 @@ $_o-topper-elements: (
 	'topic',
 	'read-next',
 	'image',
-	'image-credit'
+	'image-credit',
+	'image-caption'
 );
 
 /// @access private

--- a/components/o-topper/src/scss/themes/_full-bleed-image.scss
+++ b/components/o-topper/src/scss/themes/_full-bleed-image.scss
@@ -65,7 +65,8 @@
 		}
 	}
 
-	.o-topper__image-credit {
+	.o-topper__image-caption {
+		background-color: transparent;
 		color: oColorsByName("black-70");
 		margin-bottom: -20px;
 	}

--- a/components/o-topper/src/scss/themes/_full-bleed-offset.scss
+++ b/components/o-topper/src/scss/themes/_full-bleed-offset.scss
@@ -2,7 +2,7 @@
 
 @mixin _oTopperThemeFullBleedOffset {
 	&.o-topper--right-rail {
-		.o-topper__image-credit {
+		.o-topper__image-caption {
 			@if not $o-topper-snappy {
 				@include oGridRespondTo(L) {
 					width: calc(100vw - 720px);
@@ -110,7 +110,7 @@
 		display: flex;
 	}
 
-	.o-topper__image-credit {
+	.o-topper__image-caption {
 		text-align: left;
 		@include oGridRespondTo(L) { 
 			box-sizing: border-box;

--- a/components/o-topper/src/scss/themes/_split-text.scss
+++ b/components/o-topper/src/scss/themes/_split-text.scss
@@ -92,8 +92,16 @@
 			}
 		}
 	}
-
 	.o-topper__image-credit {
+		top: 350px;
+		@include oGridRespondTo(M) {
+			top: 480px;
+		}
+		@include oGridRespondTo(L) {
+			top: 600px;
+		}
+	}
+	.o-topper__image-caption {
 		color: oColorsByName("black-70");
 		position: relative;
 		width: 100%;

--- a/tools/a11y/index.js
+++ b/tools/a11y/index.js
@@ -12,7 +12,7 @@ const AxeBuilder = AxeBuilderPlaywright.default;
 const cwd = process.cwd()
 
 const builtDemoHtmlFiles = await glob(path.join(cwd, '/demos/local/*.html'), {onlyFiles: true})
-
+const elementsToExclude = [".o-topper > figure > figcaption.o-topper__image-credit"];
 const axeRulesToIgnore = [
 // ignoring the href="#" error
 // pa11y demos are for pa11y only and may include multiple versions
@@ -45,7 +45,7 @@ for (const file of builtDemoHtmlFiles) {
 	// of the tooltip and during the animation - the contrast of the text is insufficient.
 	await setTimeout(1000);
 
-	const results = await new AxeBuilder({ page }).disableRules(axeRulesToIgnore).analyze();
+	const results = await new AxeBuilder({ page }).exclude(elementsToExclude).disableRules(axeRulesToIgnore).analyze();
 	prettyPrintAxeReport({
         violations: results.violations,
         url: file,


### PR DESCRIPTION
add element image-caption replacing  image-credit behaviour and modify image-credit as it was before the las change , that is, set image-credit on top of the image on the bottom right corner with white color and shadow.
At the moment this is meant to be used on articles showing image-caption or image-credit but not showing both even thought we have prepared this for use both at the same time and individually. In the images below AFTER we show with both just for comparing purposes.

[ticket1](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1420)
[ticket2](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1421)
[ticket3](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1423)

**BEFORE**
![image](https://user-images.githubusercontent.com/102036944/203008373-e34c8631-973f-40dc-a38d-dd9315eb27b1.png)
![image](https://user-images.githubusercontent.com/102036944/203008295-673708e9-5e89-4c58-ad13-4889f30e41a3.png)
![image](https://user-images.githubusercontent.com/102036944/203008462-f3f53a05-56e7-409e-86be-7c14db2c4e68.png)


**AFTER**
![image](https://user-images.githubusercontent.com/102036944/203007307-aad0497c-9e8a-47e3-ab4b-dd4fdd1eaec2.png)
![image](https://user-images.githubusercontent.com/102036944/203007432-acbb0a9f-1196-405e-81b8-e12c83489efd.png)
![image](https://user-images.githubusercontent.com/102036944/203007568-26e84c5e-7378-4cee-b58e-b983e0a4957a.png)




