### PR TITLE
fix: show credit element on browser with permanent scroll

### DIFF
--- a/components/o-topper/src/scss/_elements.scss
+++ b/components/o-topper/src/scss/_elements.scss
@@ -50,7 +50,7 @@
 	margin-left: 50%;
 	left: -50vw;
 	box-sizing: border-box;
-	padding: 5px;
+	padding: 5px 10px;
 	transform: translate(0, -100%);
 }
 


### PR DESCRIPTION
credit element is a little bit sliced when is running on browsers with permanent scroll bar. 
In this Pr we move a little bit to the left the element so they are able to see it completely

BEFORE
![image](https://user-images.githubusercontent.com/102036944/203780237-304dbe9a-3612-4319-8fa8-93260d0cb290.png)

AFTER
![image](https://user-images.githubusercontent.com/102036944/203780630-c2b22d61-c60e-4533-b116-08fc206af351.png)

