### PR TITLE
fix: revert "remove blinking animation from live label"

### DIFF
--- a/components/o-labels/src/scss/_mixins.scss
+++ b/components/o-labels/src/scss/_mixins.scss
@@ -217,6 +217,40 @@
 		@extend %_o-labels-indicator-live-color;
 	}
 	@extend %_o-labels-timestamp-typography;
+
+	@if($status == 'live') {
+		& > %_o-labels-indicator__status:before {
+			animation: _o-labels-live-pulse 1.2s ease-in-out infinite;
+			// Prevent animation of the live label if the reader has indicated
+			// that they prefer reduced motion. This may be conservative but
+			// as the live indicator is presented alongside content (including
+			// the front page at the time of writing) we do not want to risk
+			// severely distracting some readers.
+			// https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html
+			@media (prefers-reduced-motion) {
+				animation: none;
+			}
+		}
+
+		// output keyframes once when live status is output
+		@if($status == 'live' and $_o-labels-indicator-live-pulse-output: false) {
+			$_o-labels-indicator-live-pulse-output: true !global;
+			@keyframes _o-labels-live-pulse {
+				0% {
+					opacity: 1;
+				}
+				30% {
+					opacity: 0.4;
+				}
+				70% {
+					opacity: 0.4;
+				}
+				100% {
+					opacity: 1;
+				}
+			}
+		}
+	}
 }
 
 

--- a/components/o-labels/src/scss/_variables.scss
+++ b/components/o-labels/src/scss/_variables.scss
@@ -64,3 +64,9 @@ $_o-labels-indicator-status: (
 	'new',
 	'updated'
 );
+
+/// Whether or not the animation keyframes for the live indicator
+/// label has already been output.
+/// @type Boolean
+/// @access private
+$_o-labels-indicator-live-pulse-output: false !default;


### PR DESCRIPTION
This reverts commit 431aa6df44bcea50771841eb540a2cf3db51c299.

The powers that be have decided not to remove the blinking animation from the live label after all, instead we will update our accessibility statement regarding a means of disabling the blinking.

Relates to: https://financialtimes.atlassian.net/browse/CON-2112