### PR TITLE
Migration guide and tsx templates

### DIFF
--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -1,6 +1,32 @@
 # Migration Guide
 
 ## Migrating from v10 to v11
+o-header v11 includes markup changes in drawer menu. v10 drawer menu used to render all list items under one tag:
+```html
+<nav>
+	<ul>
+	<!-- more list items without heading -->
+	</ul>
+</nav>
+```
+But drawer menu can display visually grouped items within the nav. so we updated markup to use semantically correct html. This approach also improves the accessibility of the drawer menu and users who use screen readers will get the same structure, information, and relationships between content as sighted users are provided with visual styling. v11 uses multiple `ul` tags inside nav tag and for heading we use `h2` tags which is used to describe list groupings for assistive technologies. v11 markup:
+
+```html
+<nav>
+	<h2 id="o-header-drawer-top-sections" id='top-sections'>Top sections</h2>
+	<ul aria-labelledby="top-sections">
+	    <!-- list items -->
+	</ul>
+	<h2 id="o-header-drawer-top-sections" id='ft-recommends'>FT recommends</h2>
+	<ul aria-labelledby="ft-recommends">
+	    <!-- list items -->
+	</ul>
+	<!-- more list items without heading -->
+	<ul>
+	<!-- more list items without heading -->
+	</ul>
+</nav>
+```
 ## Migrating from v9 to v10
 
 o-header v10 includes markup changes. Use demo markup to update your project. Changes to be aware of include:

--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -27,6 +27,9 @@ But drawer menu can display visually grouped items within the nav. so we updated
 	</ul>
 </nav>
 ```
+We also renamed css class `o-header__drawer-menu-item--divide` from to `o-header__drawer-menu-list--divide` and now it applies on `ul` inside our `nav` tag instead of applying it on separate list items.
+
+
 ## Migrating from v9 to v10
 
 o-header v10 includes markup changes. Use demo markup to update your project. Changes to be aware of include:

--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -18,7 +18,7 @@ Before:
 	<!-- more list items without heading -->
 	</ul>
 </nav>
-\```
+```
 
 After:
 ```html
@@ -36,7 +36,7 @@ After:
 	<!-- more list items without heading -->
 	</ul>
 </nav>
-\```
+```
 
 ### Markup drawer divider
 

--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -1,16 +1,26 @@
 # Migration Guide
 
 ## Migrating from v10 to v11
-o-header v11 includes markup changes in drawer menu. v10 drawer menu used to render all list items under one tag:
+o-header v11 includes markup changes in the drawer menu. Update your markup as described below or [use o-header's tsx template](https://github.com/Financial-Times/origami/tree/main/components/o-header/src/tsx).
+
+### Markup visual drawer headings
+
+Update your drawer markup to semantically represent visually grouped navigation items. This approach improves the experience for users of assistive technologies.
+
+1. Split the drawer `ul` into multiple lists.
+2. Add a `h2` tag to describe each list.
+3. Associate both elements with the `aria-labelledby` attribute.
+
+Before:
 ```html
 <nav>
 	<ul>
 	<!-- more list items without heading -->
 	</ul>
 </nav>
-```
-But drawer menu can display visually grouped items within the nav. so we updated markup to use semantically correct html. This approach also improves the accessibility of the drawer menu and users who use screen readers will get the same structure, information, and relationships between content as sighted users are provided with visual styling. v11 uses multiple `ul` tags inside nav tag and for heading we use `h2` tags which is used to describe list groupings for assistive technologies. v11 markup:
+\```
 
+After:
 ```html
 <nav>
 	<h2 id="o-header-drawer-top-sections" id='top-sections'>Top sections</h2>
@@ -26,10 +36,11 @@ But drawer menu can display visually grouped items within the nav. so we updated
 	<!-- more list items without heading -->
 	</ul>
 </nav>
-```
-We also renamed css class `o-header__drawer-menu-item--divide` from to `o-header__drawer-menu-list--divide` and now it applies on `ul` inside our `nav` tag instead of applying it on separate list items.
+\```
 
+### Markup drawer divider
 
+Remove the CSS class `o-header__drawer-menu-item--divide` from the last list item of a drawer menu and instead apply `o-header__drawer-menu-list--divide` to the menu list itself.
 ## Migrating from v9 to v10
 
 o-header v10 includes markup changes. Use demo markup to update your project. Changes to be aware of include:

--- a/components/o-header/demos/src/grid-demo.mustache
+++ b/components/o-header/demos/src/grid-demo.mustache
@@ -166,9 +166,9 @@
 			{{#heading}}
 			<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 			{{/heading}}
-			<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+			<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 						{{#items}}
-						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+						<li class="o-header__drawer-menu-item">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/header.json
+++ b/components/o-header/demos/src/header.json
@@ -440,12 +440,12 @@
                 ]
             },
             {
+								"divide": true,
                 "items": [
                     {
                         "name": "xx xx",
                         "href": "#",
                         "variation": "secondary",
-                        "divide": true,
                         "index": 0
                     },
                     {

--- a/components/o-header/demos/src/header.mustache
+++ b/components/o-header/demos/src/header.mustache
@@ -176,9 +176,9 @@
 			{{#heading}}
 			<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 			{{/heading}}
-			<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+			<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 						{{#items}}
-						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+						<li class="o-header__drawer-menu-item">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/mega-menu.json
+++ b/components/o-header/demos/src/mega-menu.json
@@ -824,12 +824,12 @@
                 ]
             },
             {
+								"divide": true,
                 "items": [
                     {
                         "name": "xx xx",
                         "href": "#",
                         "variation": "secondary",
-                        "divide": true,
                         "index": 0
                     },
                     {

--- a/components/o-header/demos/src/pa11y.mustache
+++ b/components/o-header/demos/src/pa11y.mustache
@@ -164,9 +164,9 @@
 			{{#heading}}
 			<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 			{{/heading}}
-			<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+			<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 						{{#items}}
-						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+						<li class="o-header__drawer-menu-item">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/simple-header.mustache
+++ b/components/o-header/demos/src/simple-header.mustache
@@ -93,9 +93,9 @@
 			{{#heading}}
 			<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 			{{/heading}}
-			<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+			<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 						{{#items}}
-						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+						<li class="o-header__drawer-menu-item">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/sticky-header.mustache
+++ b/components/o-header/demos/src/sticky-header.mustache
@@ -129,9 +129,9 @@
 				{{#heading}}
 				<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 				{{/heading}}
-				<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+				<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 							{{#items}}
-							<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+							<li class="o-header__drawer-menu-item">
 								{{#hasChildren}}
 									<div class="o-header__drawer-menu-toggle-wrapper">
 										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/subbrand.json
+++ b/components/o-header/demos/src/subbrand.json
@@ -426,12 +426,12 @@
                 ]
             },
             {
+								"divide": true,
                 "items": [
                     {
                         "name": "xx xx",
                         "href": "#",
                         "variation": "secondary",
-                        "divide": true,
                         "index": 0
                     },
                     {

--- a/components/o-header/demos/src/subbrand.mustache
+++ b/components/o-header/demos/src/subbrand.mustache
@@ -89,9 +89,9 @@
 			{{#heading}}
 			<h2 class="o-header__drawer-menu-item o-header__drawer-menu-item--heading" id="{{id}}">{{name}}</h2>
 			{{/heading}}
-			<ul class="o-header__drawer-menu-list" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
+			<ul class="o-header__drawer-menu-list {{#divide}}o-header__drawer-menu-list--divide{{/divide}}" {{#heading}}aria-labelledby="{{id}}"{{/heading}}>
 						{{#items}}
-						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
+						<li class="o-header__drawer-menu-item">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="{{name}}, current page" aria-current="page"{{/selected}}>{{name}}</a>

--- a/components/o-header/demos/src/subnav-right-align.json
+++ b/components/o-header/demos/src/subnav-right-align.json
@@ -440,12 +440,12 @@
                 ]
             },
             {
+								"divide": true,
                 "items": [
                     {
                         "name": "xx xx",
                         "href": "#",
                         "variation": "secondary",
-                        "divide": true,
                         "index": 0
                     },
                     {

--- a/components/o-header/demos/src/subnav.json
+++ b/components/o-header/demos/src/subnav.json
@@ -440,12 +440,12 @@
 				]
 			},
 			{
+				"divide": true,
 				"items": [
 					{
 						"name": "xx xx",
 						"href": "#",
 						"variation": "secondary",
-						"divide": true,
 						"index": 0
 					},
 					{

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -206,6 +206,10 @@
 		overflow: hidden;
 	}
 
+	.o-header__drawer-menu-list--divide {
+		border-top: 2px solid _oHeaderGet('drawer-menu-border');
+	}
+
 	.o-header__drawer-menu-list--child {
 		[data-o-header-drawer--no-js] & {
 			display: none;
@@ -234,9 +238,6 @@
 		margin-top: 1px;
 	}
 
-	.o-header__drawer-menu-item--divide {
-		border-top: 2px solid _oHeaderGet('drawer-menu-border');
-	}
 
 	.o-header__drawer-menu-item--heading {
 		margin-bottom: 0px;

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -38,7 +38,9 @@ function DrawerTools({current}: {current: TNavEdition}) {
 				className="o-header__drawer-tools-close"
 				aria-controls="o-header-drawer"
 				title="Close side navigation menu">
-				<span className="o-header__visually-hidden">Close side navigation menu</span>
+				<span className="o-header__visually-hidden">
+					Close side navigation menu
+				</span>
 			</button>
 			{current && (
 				<p className="o-header__drawer-current-edition">
@@ -115,31 +117,41 @@ function DrawerEditionSwitcher({
 function DrawerMenu({navItems}: {navItems: TNavMenuItem[]}) {
 	return (
 		<nav className="o-header__drawer-menu o-header__drawer-menu--primary">
-			<ul className="o-header__drawer-menu-list">
-				{navItems.map(({label, submenu}, i) => {
-					const menuItemClass = label ? 'heading' : 'divide';
-
-					const navigationItems = submenu?.items.map((item, j) => {
-						return (
-							<DrawerNavItem
-								navItem={item}
-								index={`${i}-${j}`}
-								hasHeading={!!label}
-								key={`submenu-${i}-${j}`}
-							/>
-						);
-					});
-					const menuItem = [
-						<li
-							className={`o-header__drawer-menu-item o-header__drawer-menu-item--${menuItemClass}`}
-							key={i}>
+			{navItems.map(({label, submenu}, i) => {
+				const hasDivider = !label;
+				const labelId = label
+					? label.replace(' ', '-').toLowerCase()
+					: undefined;
+				const navigationItems = submenu?.items.map((item, j) => {
+					return (
+						<DrawerNavItem
+							navItem={item}
+							index={`${i}-${j}`}
+							hasHeading={!!label}
+							key={`submenu-${i}-${j}`}
+						/>
+					);
+				});
+				const classNames = ['o-header__drawer-menu-list'];
+				hasDivider && classNames.push('o-header__drawer-menu-list--divide');
+				const menuItem = [
+					label && (
+						<h2
+							className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
+							id={labelId}
+							key={`heading-${i}`}>
 							{label}
-						</li>,
-						navigationItems,
-					];
-					return menuItem;
-				})}
-			</ul>
+						</h2>
+					),
+					<ul
+						className={classNames.join(' ')}
+						aria-labelledby={labelId}
+						key={`drawer-list-${i}`}>
+						{navigationItems}
+					</ul>,
+				];
+				return menuItem;
+			})}
 		</nav>
 	);
 }
@@ -249,16 +261,17 @@ function DrawerSubMenu({
 			<ul
 				className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
 				id={`o-header-drawer-child-${idSuffix}`}>
-				{submenu && submenu.map((item, i) => (
-					<li className="o-header__drawer-menu-item" key={item.url + i}>
-						<AnchorElement
-							url={item.url}
-							label={item.label}
-							selected={item.selected}
-							additionalClasses={childAnchorClass}
-						/>
-					</li>
-				))}
+				{submenu &&
+					submenu.map((item, i) => (
+						<li className="o-header__drawer-menu-item" key={item.url + i}>
+							<AnchorElement
+								url={item.url}
+								label={item.label}
+								selected={item.selected}
+								additionalClasses={childAnchorClass}
+							/>
+						</li>
+					))}
 			</ul>
 		</li>
 	);


### PR DESCRIPTION
This PR adds a migration guide and changes the class name for a divider in the drawer menu. Since we changed the markup of `o-header` we can apply the divider directly on `ul` tag instead of a list item itself. 