### PR TITLE
[CI-1411] o-topper: update n-map-content-to-topper to 3.2.0

### DIFF
--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -36,7 +36,7 @@
     "@financial-times/o-typography": "^7.2.0"
   },
   "dependencies": {
-    "@financial-times/n-map-content-to-topper": "^2.2.2"
+    "@financial-times/n-map-content-to-topper": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"


### PR DESCRIPTION
[ticket](https://financialtimes.atlassian.net/browse/CI-1411)