### PR TITLE
fix: o-topper, image hero meta contrast

### DIFF
--- a/components/o-teaser/src/scss/themes/_hero.scss
+++ b/components/o-teaser/src/scss/themes/_hero.scss
@@ -120,8 +120,19 @@
 			pointer-events: auto;
 		}
 
+		.o-teaser__tag-suffix {
+			color: inherit;
+		}
+
 		.o-teaser__meta:after {
 			border-bottom-color: oColorsByName('white');
+		}
+
+
+		.o-teaser__tag:hover,
+		.o-teaser__tag:focus {
+			color: inherit;
+			outline-color: inherit;
 		}
 	}
 }


### PR DESCRIPTION
closes: https://github.com/Financial-Times/origami/issues/918