### PR TITLE
fix: o-footer, allow links to wrap rather than overflow with ellipses

### DIFF
--- a/components/o-footer/src/scss/_mixins.scss
+++ b/components/o-footer/src/scss/_mixins.scss
@@ -91,9 +91,6 @@
 
 	.o-footer__matrix-title,
 	.o-footer__matrix-link__copy {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
 		display: block;
 	}
 
@@ -168,8 +165,11 @@
 	}
 
 	.o-footer__matrix-link--more {
-		display: flex;
-
+		white-space: nowrap;
+		> .o-footer__matrix-link__copy {
+			display: inline;
+			white-space: normal;
+		}
 		&:after {
 			@include oIconsContent(
 				$icon-name: 'arrow-right',
@@ -178,7 +178,10 @@
 				$include-base-styles: true
 			);
 			content: '';
-			align-self: center;
+			// Undo in-built icon whitespace.
+			position: relative;
+			margin: calc(#{$_o-footer-icon-size}px / -4);
+			vertical-align: baseline;
 		}
 	}
 }


### PR DESCRIPTION
At some breakpoints links within o-footer are partially hidden when they overflow. This also means there are hidden footer links when zoomed or when a custom text spacing is applied – an accessibility issue.

Instead allow links to wrap, so no link copy is ever hidden.

close: https://github.com/Financial-Times/origami/issues/931

When this happens it is more difficult to skim links left to right, as links in each column may not be aligned. This isn't such an issue since links are categorised in columns. We may choose to undertake a broader change in the future to reduce this by:
1. Restoring the "More from the FT Group" link from its current position, in its own column, to sit on a new row spanning the footer's width.
2. Updating footer link columns to use just the space they need, rather than taking up a specific number of columns based on our grid system.
The above requires more input from the design team.