### PR TITLE
backstage: trap focus in overlay using role=dialog and aria-modal=true

### DIFF
--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -65,16 +65,36 @@ const isVisible = function (element) {
 	return Boolean(element.offsetHeight);
 };
 
-const focusTrap = function (event ) {
+const filterFocusableElements = function (element) {
+	const elementVisible = isVisible(element);
+	// Inputs for radio and checkboxes are visually hidden,
+	// so check the label visibility of inputs too when determining
+	// whether to trap focus.
+	const elementLabelVisible =
+		element.labels && [].slice.call(element.labels).some(l => isVisible(l));
+	// When tabbing, the checked radio input of a group is focused, not each radio input.
+	const elementIsUncheckedRadio =
+		element.type === 'radio' && element.checked !== true;
+	return (
+		!element.disabled &&
+		!elementIsUncheckedRadio &&
+		(elementVisible || elementLabelVisible)
+	);
+}
+
+const focusTrap = function (event) {
 	const tabKeyCode = 9;
-		if (this.overlayFocusableElements.length && event.keyCode === tabKeyCode) {
+	const overlayFocusableElements = [].slice
+	.call(this.wrapper.querySelectorAll(focusable))
+	.filter(element => filterFocusableElements(element));
+	if (overlayFocusableElements.length && event.keyCode === tabKeyCode) {
 		const lastElement =
-			this.overlayFocusableElements[this.overlayFocusableElements.length - 1];
+			overlayFocusableElements[overlayFocusableElements.length - 1];
 		// Loop focus back to the first element if focus has reached the focusable element
 		if (event.target === lastElement) {
-			this.overlayFocusableElements[0].focus();
+			overlayFocusableElements[0].focus();
 			event.preventDefault();
-		} else if (event.shiftKey && event.target === this.overlayFocusableElements[0]) {
+		} else if (event.shiftKey && event.target === overlayFocusableElements[0]) {
 			// loop to the bottom when shift+tabbing.
 			lastElement.focus();
 			event.preventDefault();
@@ -326,27 +346,9 @@ class Overlay {
 	}
 
 	_trapFocus() {
-		this.overlayFocusableElements = [].slice
-			.call(
-				this.wrapper.querySelectorAll(focusable)
-			)
-			.filter(element => {
-				const elementVisible = isVisible(element);
-				// Inputs for radio and checkboxes are visually hidden,
-				// so check the label visibility of inputs too when determining
-				// whether to trap focus.
-				const elementLabelVisible =
-					element.labels && [].slice.call(element.labels).some(l => isVisible(l));
-				// When tabbing, the checked radio input of a group is focused, not each radio input.
-				const elementIsUncheckedRadio =
-					element.type === 'radio' && element.checked !== true;
-				return (
-					!element.disabled &&
-					!elementIsUncheckedRadio &&
-					(elementVisible || elementLabelVisible)
-				);
-		});
-		this.overlayFocusableElements[0].focus();
+		const allFocusableNodes = Array.from(this.wrapper.querySelectorAll(focusable))
+			.filter(element => filterFocusableElements(element))
+			allFocusableNodes[0].focus();
 		// Trap the focus inside the overlay so keyboard navigation doesn't escape the overlay
 		document.addEventListener('keydown', focusTrap.bind(this));
 	}

--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -65,37 +65,16 @@ const isVisible = function (element) {
 	return Boolean(element.offsetHeight);
 };
 
-const focusTrap = function (event) {
+const focusTrap = function (event ) {
 	const tabKeyCode = 9;
-	const overlayFocusableElements = [].slice
-		.call(
-			this.wrapper.querySelectorAll(focusable)
-		)
-		.filter(element => {
-			const elementVisible = isVisible(element);
-			// Inputs for radio and checkboxes are visually hidden,
-			// so check the label visibility of inputs too when determining
-			// whether to trap focus.
-			const elementLabelVisible =
-				element.labels && [].slice.call(element.labels).some(l => isVisible(l));
-			// When tabbing, the checked radio input of a group is focused, not each radio input.
-			const elementIsUncheckedRadio =
-				element.type === 'radio' && element.checked !== true;
-			return (
-				!element.disabled &&
-				!elementIsUncheckedRadio &&
-				(elementVisible || elementLabelVisible)
-			);
-		});
-
-	if (overlayFocusableElements.length && event.keyCode === tabKeyCode) {
+		if (this.overlayFocusableElements.length && event.keyCode === tabKeyCode) {
 		const lastElement =
-			overlayFocusableElements[overlayFocusableElements.length - 1];
+			this.overlayFocusableElements[this.overlayFocusableElements.length - 1];
 		// Loop focus back to the first element if focus has reached the focusable element
 		if (event.target === lastElement) {
-			overlayFocusableElements[0].focus();
+			this.overlayFocusableElements[0].focus();
 			event.preventDefault();
-		} else if (event.shiftKey && event.target === overlayFocusableElements[0]) {
+		} else if (event.shiftKey && event.target === this.overlayFocusableElements[0]) {
 			// loop to the bottom when shift+tabbing.
 			lastElement.focus();
 			event.preventDefault();
@@ -347,6 +326,27 @@ class Overlay {
 	}
 
 	_trapFocus() {
+		this.overlayFocusableElements = [].slice
+			.call(
+				this.wrapper.querySelectorAll(focusable)
+			)
+			.filter(element => {
+				const elementVisible = isVisible(element);
+				// Inputs for radio and checkboxes are visually hidden,
+				// so check the label visibility of inputs too when determining
+				// whether to trap focus.
+				const elementLabelVisible =
+					element.labels && [].slice.call(element.labels).some(l => isVisible(l));
+				// When tabbing, the checked radio input of a group is focused, not each radio input.
+				const elementIsUncheckedRadio =
+					element.type === 'radio' && element.checked !== true;
+				return (
+					!element.disabled &&
+					!elementIsUncheckedRadio &&
+					(elementVisible || elementLabelVisible)
+				);
+		});
+		this.overlayFocusableElements[0].focus();
 		// Trap the focus inside the overlay so keyboard navigation doesn't escape the overlay
 		document.addEventListener('keydown', focusTrap.bind(this));
 	}
@@ -419,7 +419,7 @@ class Overlay {
 		}
 
 		// Renders content after overlay has been added so css is applied before that
-		// Thay way if an element has autofocus, the window won't scroll to the bottom
+		// This way if an element has autofocus, the window won't scroll to the bottom
 		// in Safari as the overlay is already in position
 		window.requestAnimationFrame(
 			function () {
@@ -457,7 +457,6 @@ class Overlay {
 					action: 'show',
 					overlay_id: this.id,
 				});
-
 				this._trapFocus();
 			}.bind(this)
 		);

--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -270,6 +270,7 @@ class Overlay {
 		}
 
 		wrapperEl.setAttribute('role', 'dialog');
+		wrapperEl.setAttribute('aria-modal', 'true');
 		if (this.opts.zindex) {
 			wrapperEl.style.zIndex = this.opts.zindex;
 		}
@@ -356,6 +357,7 @@ class Overlay {
 	 * @fires oOverlay#ready
 	 */
 	show() {
+		this.wrapper.style.display = 'block';
 		if (this.opts.modal) {
 			this.wrapper.classList.add('o-overlay--modal');
 			const shadow = document.createElement('div');
@@ -511,6 +513,7 @@ class Overlay {
 		if (this.opts.layer) {
 			this.broadcast('layerClose');
 		}
+		this.wrapper.style.display = 'none';
 
 		return false;
 	}

--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -348,7 +348,9 @@ class Overlay {
 	_trapFocus() {
 		const allFocusableNodes = Array.from(this.wrapper.querySelectorAll(focusable))
 			.filter(element => filterFocusableElements(element))
-			allFocusableNodes[0].focus();
+			if (allFocusableNodes.length) {
+				allFocusableNodes[0].focus();
+			}
 		// Trap the focus inside the overlay so keyboard navigation doesn't escape the overlay
 		document.addEventListener('keydown', focusTrap.bind(this));
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5748,7 +5748,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "5.6.2",
+			"version": "5.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/n-map-content-to-topper": "^3.2.0"
@@ -55632,7 +55632,7 @@
 			"requires": {
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-audio": {
@@ -55653,7 +55653,7 @@
 			"requires": {
 				"@financial-times/accessible-autocomplete": "^2.1.2",
 				"@financial-times/o-forms": "^9.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-utils": "^2.1.0"
 			}
 		},
@@ -55664,14 +55664,14 @@
 			"version": "file:components/o-banner",
 			"requires": {
 				"@financial-times/o-fonts": "^5",
-				"@financial-times/o-normalise": "^3"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-big-number": {
 			"version": "file:components/o-big-number",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-brand": {
@@ -55681,7 +55681,7 @@
 			"version": "file:components/o-buttons",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-colors": {
@@ -55691,7 +55691,7 @@
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-forms": "^9.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-overlay": "^4.2.1",
 				"@financial-times/o-syntax-highlight": "^4.2.0",
 				"@financial-times/o-tabs": "^8.0.0"
@@ -55708,7 +55708,7 @@
 			"version": "file:components/o-cookie-message",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"superstore-sync": "^2.1.1"
 			}
 		},
@@ -55723,13 +55723,13 @@
 			"requires": {
 				"@financial-times/o-colors": "^6.4.0",
 				"@financial-times/o-grid": "^6.1.1",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-editorial-typography": {
 			"version": "file:components/o-editorial-typography",
 			"requires": {
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-errors": {
@@ -55741,7 +55741,7 @@
 		"@financial-times/o-expander": {
 			"version": "file:components/o-expander",
 			"requires": {
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-fonts": {
@@ -55752,14 +55752,14 @@
 			"version": "file:components/o-footer",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-footer-services": {
 			"version": "file:components/o-footer-services",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-forms": {
@@ -55767,7 +55767,7 @@
 			"requires": {
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-ft-affiliate-ribbon": {
@@ -55783,14 +55783,14 @@
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-grid": "^6.1.1",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-header-services": {
 			"version": "file:components/o-header-services",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-icons": {
@@ -55801,7 +55801,7 @@
 			"version": "file:components/o-labels",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-layout": {
@@ -55811,7 +55811,7 @@
 				"@financial-times/o-footer-services": "^4.2.0",
 				"@financial-times/o-forms": "^9.2.0",
 				"@financial-times/o-header-services": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-syntax-highlight": "^4.2.0",
 				"@financial-times/o-table": "^9.2.0",
 				"@financial-times/o-tabs": "^6.2.0"
@@ -55836,14 +55836,14 @@
 			"version": "file:components/o-message",
 			"requires": {
 				"@financial-times/o-fonts": "^5",
-				"@financial-times/o-normalise": "^3"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-meter": {
 			"version": "file:components/o-meter",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.2.0"
 			}
 		},
@@ -55859,7 +55859,7 @@
 			"requires": {
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"focusable": "^2.3.0",
 				"ftdomdelegate": "^4.0.0"
 			},
@@ -55875,14 +55875,14 @@
 			"version": "file:components/o-quote",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-share": {
 			"version": "file:components/o-share",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"ftdomdelegate": "^4.0.6"
 			},
 			"dependencies": {
@@ -55897,14 +55897,14 @@
 			"version": "file:components/o-social-follow",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-spacing": {
 			"version": "file:components/o-spacing",
 			"requires": {
 				"@financial-times/o-colors": "^6.4.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.2.0"
 			}
 		},
@@ -55913,7 +55913,7 @@
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-icons": "^7.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-subs-card": {
@@ -55922,7 +55922,7 @@
 				"@financial-times/o-colors": "^6.4.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-grid": "^6.1.1",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-syntax-highlight": {
@@ -55937,7 +55937,7 @@
 				"@financial-times/o-buttons": "^7",
 				"@financial-times/o-fonts": "^5",
 				"@financial-times/o-forms": "^9",
-				"@financial-times/o-normalise": "^3",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7",
 				"ftdomdelegate": "^4.0.6"
 			},
@@ -55953,14 +55953,14 @@
 			"version": "file:components/o-tabs",
 			"requires": {
 				"@financial-times/o-fonts": "^5",
-				"@financial-times/o-normalise": "^3"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-teaser": {
 			"version": "file:components/o-teaser",
 			"requires": {
 				"@financial-times/o-date": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"date-fns": "^1.29.0",
 				"dateformat": "^3.0.3",
 				"dompurify": "^2.3.9",
@@ -55984,7 +55984,7 @@
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-grid": "^6.1.1",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-toggle": {
@@ -55992,7 +55992,7 @@
 			"requires": {
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.2.0"
 			}
 		},
@@ -56002,7 +56002,7 @@
 				"@financial-times/o-buttons": "^7",
 				"@financial-times/o-colors": "^6",
 				"@financial-times/o-fonts": "^5",
-				"@financial-times/o-normalise": "^3",
+				"@financial-times/o-normalise": "^3.3.0",
 				"ftdomdelegate": "^4.0.6"
 			},
 			"dependencies": {
@@ -56018,7 +56018,7 @@
 			"requires": {
 				"@financial-times/n-map-content-to-topper": "^3.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.2.0"
 			}
 		},
@@ -56037,7 +56037,7 @@
 			"version": "file:components/o-typography",
 			"requires": {
 				"@financial-times/o-grid": "^6.1.1",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"fontfaceobserver": "^2.0.9"
 			}
 		},
@@ -56048,7 +56048,7 @@
 			"version": "file:components/o-video",
 			"requires": {
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-normalise": "^3.2.0"
+				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-viewport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4835,7 +4835,7 @@
 		},
 		"components/ft-concept-button": {
 			"name": "@financial-times/ft-concept-button",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -4857,7 +4857,7 @@
 		},
 		"components/n-notification": {
 			"name": "@financial-times/n-notification",
-			"version": "8.2.2",
+			"version": "8.2.3",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4892,7 +4892,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.7.1",
+			"version": "1.7.2",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^2.1.2"
@@ -4920,7 +4920,7 @@
 		},
 		"components/o-banner": {
 			"name": "@financial-times/o-banner",
-			"version": "4.4.7",
+			"version": "4.4.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -4942,7 +4942,7 @@
 		},
 		"components/o-big-number": {
 			"name": "@financial-times/o-big-number",
-			"version": "3.1.1",
+			"version": "3.1.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4959,7 +4959,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.7.2",
+			"version": "7.7.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4978,7 +4978,7 @@
 		},
 		"components/o-colors": {
 			"name": "@financial-times/o-colors",
-			"version": "6.4.2",
+			"version": "6.4.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-autoinit": "^3.1.0",
@@ -5000,7 +5000,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "9.0.1",
+			"version": "9.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.2.0",
@@ -5022,7 +5022,7 @@
 		},
 		"components/o-cookie-message": {
 			"name": "@financial-times/o-cookie-message",
-			"version": "6.5.0",
+			"version": "6.5.1",
 			"license": "MIT",
 			"dependencies": {
 				"superstore-sync": "^2.1.1"
@@ -5056,7 +5056,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.4.0",
@@ -5076,7 +5076,7 @@
 		},
 		"components/o-editorial-typography": {
 			"name": "@financial-times/o-editorial-typography",
-			"version": "2.3.2",
+			"version": "2.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5093,7 +5093,7 @@
 		},
 		"components/o-expander": {
 			"name": "@financial-times/o-expander",
-			"version": "6.2.4",
+			"version": "6.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5120,7 +5120,7 @@
 		},
 		"components/o-footer": {
 			"name": "@financial-times/o-footer",
-			"version": "9.2.4",
+			"version": "9.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5145,7 +5145,7 @@
 		},
 		"components/o-footer-services": {
 			"name": "@financial-times/o-footer-services",
-			"version": "4.2.4",
+			"version": "4.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5163,7 +5163,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.4.6",
+			"version": "9.4.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.2.0",
@@ -5188,7 +5188,7 @@
 		},
 		"components/o-ft-affiliate-ribbon": {
 			"name": "@financial-times/o-ft-affiliate-ribbon",
-			"version": "5.1.1",
+			"version": "5.1.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5213,7 +5213,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "10.1.1",
+			"version": "10.1.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5239,7 +5239,7 @@
 		},
 		"components/o-header-services": {
 			"name": "@financial-times/o-header-services",
-			"version": "5.3.1",
+			"version": "5.3.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5275,7 +5275,7 @@
 		},
 		"components/o-labels": {
 			"name": "@financial-times/o-labels",
-			"version": "6.5.2",
+			"version": "6.5.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5294,7 +5294,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.2.4",
+			"version": "5.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.2.0",
@@ -5359,7 +5359,7 @@
 		},
 		"components/o-message": {
 			"name": "@financial-times/o-message",
-			"version": "5.4.0",
+			"version": "5.4.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5381,7 +5381,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.0",
+			"version": "3.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5415,7 +5415,7 @@
 		},
 		"components/o-overlay": {
 			"name": "@financial-times/o-overlay",
-			"version": "4.2.4",
+			"version": "4.2.5",
 			"license": "MIT",
 			"dependencies": {
 				"focusable": "^2.3.0",
@@ -5447,7 +5447,7 @@
 		},
 		"components/o-quote": {
 			"name": "@financial-times/o-quote",
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5466,7 +5466,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "8.3.1",
+			"version": "8.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5495,7 +5495,7 @@
 		},
 		"components/o-social-follow": {
 			"name": "@financial-times/o-social-follow",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5516,7 +5516,7 @@
 		},
 		"components/o-spacing": {
 			"name": "@financial-times/o-spacing",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.4.0",
@@ -5532,7 +5532,7 @@
 		},
 		"components/o-stepped-progress": {
 			"name": "@financial-times/o-stepped-progress",
-			"version": "4.0.4",
+			"version": "4.0.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5553,7 +5553,7 @@
 		},
 		"components/o-subs-card": {
 			"name": "@financial-times/o-subs-card",
-			"version": "6.2.2",
+			"version": "6.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.4.0",
@@ -5591,7 +5591,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.2.6",
+			"version": "9.2.7",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5625,7 +5625,7 @@
 		},
 		"components/o-tabs": {
 			"name": "@financial-times/o-tabs",
-			"version": "8.1.1",
+			"version": "8.1.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5642,7 +5642,7 @@
 		},
 		"components/o-teaser": {
 			"name": "@financial-times/o-teaser",
-			"version": "6.2.3",
+			"version": "6.2.4",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^1.29.0",
@@ -5669,7 +5669,7 @@
 		},
 		"components/o-teaser-collection": {
 			"name": "@financial-times/o-teaser-collection",
-			"version": "4.2.1",
+			"version": "4.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5702,7 +5702,7 @@
 		},
 		"components/o-toggle": {
 			"name": "@financial-times/o-toggle",
-			"version": "3.2.3",
+			"version": "3.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.2.0",
@@ -5716,7 +5716,7 @@
 		},
 		"components/o-tooltip": {
 			"name": "@financial-times/o-tooltip",
-			"version": "5.2.4",
+			"version": "5.2.5",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5748,7 +5748,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "5.6.3",
+			"version": "5.6.4",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/n-map-content-to-topper": "^3.2.0"
@@ -5772,7 +5772,7 @@
 		},
 		"components/o-typography": {
 			"name": "@financial-times/o-typography",
-			"version": "7.3.2",
+			"version": "7.3.3",
 			"license": "MIT",
 			"dependencies": {
 				"fontfaceobserver": "^2.0.9"
@@ -5796,7 +5796,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.3",
+			"version": "7.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
This issue was discovered while resolving #902. In both cases, we use JS to trap the focus and we listen if the tab key is pressed. For voiceOver the user usually will use `ctrl-option-[left/right] Arrow` and focus would leave the modal. To fix this we followed [web standard recommendations](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/). 

One to note is that once the overlay modal is open it is not automatically focused. 