### PR TITLE
fix: o-colors, reduce warnings

### DIFF
--- a/components/o-colors/main.scss
+++ b/components/o-colors/main.scss
@@ -41,6 +41,7 @@
 	'usecase-custom-properties': true,
 	'usecase-classes': true,
 )) {
+	$_o-colors-mixin-output: true !global;
 	$palette-properties: map-get($opts, 'palette-custom-properties');
 	$usecase-properties: map-get($opts, 'usecase-custom-properties');
 	$usecase-classes: map-get($opts, 'usecase-classes');
@@ -93,6 +94,7 @@
 			}
 		}
 	}
+	$_o-colors-mixin-output: false !global;
 }
 
 // If noisy, output helper classes for use cases and palette colors

--- a/components/o-colors/src/scss/_functions.scss
+++ b/components/o-colors/src/scss/_functions.scss
@@ -10,7 +10,7 @@
 	// Error when the color name is not found.
 	// Get the namespaced color name.
 	@if (not _oColorsNameExists($color-name)) {
-		@return _oColorsError('The color "#{inspect($color-name)}" does not exist.');
+		@return _oColorsError('The color #{inspect($color-name)} does not exist.');
 	}
 
 	// Get color details.
@@ -21,7 +21,7 @@
 	// Output any deprecation notice.
 	$deprecated: map-get($meta, 'deprecated');
 	$already-warned: index($_o-colors-deprecation-warnings-output, $color-name) != null;
-	@if $deprecated and not $already-warned {
+	@if not $_o-colors-mixin-output and $deprecated and not $already-warned {
 		$deprecation-message: 'The color "#{$color-name}" is deprecated for your brand\'s palette, and will be removed in the next major.';
 		// Append any custom deprecation message.
 		$deprecation-message: if(type-of($deprecated) != 'string', $deprecation-message, $deprecation-message + ' ' + $deprecated);
@@ -66,7 +66,7 @@
 	$opts: if($config, map-get($config, 'opts'), ());
 	$deprecated: if(type-of($opts) == 'map', map-get($opts, 'deprecated'), null);
 	$deprecated-key: 'usecase-#{$usecase}-#{$property}';
-	@if(not index($_o-colors-deprecation-warnings-output, $deprecated-key)) {
+	@if(not $_o-colors-mixin-output and not index($_o-colors-deprecation-warnings-output, $deprecated-key)) {
 		@if (type-of($deprecated) == 'string') {
 			@warn 'Color usecase "#{inspect($usecase)}" is deprecated ' +
 				'(property "#{inspect($property)}" was requested): #{inspect($deprecated)}';

--- a/components/o-colors/src/scss/_variables.scss
+++ b/components/o-colors/src/scss/_variables.scss
@@ -64,3 +64,12 @@ $_o-colors-deprecation-warnings-output: ();
 /// @access private
 /// @type Bool
 $_o-colors-test-environment: false !default;
+
+/// Is the current execution context the oColors primary mixin?
+/// This can be helpful to know internally to provide alternate
+/// behaviour, e.g. reduce warning noise if a user is outputting
+/// all available styles – including deprecated styles – without
+/// necessarily using them directly.
+/// @access private
+/// @type Bool
+$_o-colors-mixin-output: false !default;


### PR DESCRIPTION
o-colors includes a map of colour names to hex values. It includes meta data for each colour, such as whether it is deprecated or not.

When a user requests a deprecated colour we output a warning to help them migrate.

A user can also request a deprecated colour without meaning to by requesting all o-colors styles with the `oColors` primary mixin. Even if they aren't using the deprecated colour they then get a warning. We have 3 options:
1. Continue to hound users about something they're not doing, untill they staty ignoring warnings.
2. Insist users are very specifc about which parts of o-colors they would like to include, force them to list each colour and colour usecase they use (not a very lovely user experience, not possible to enforce without a major release and  Build Service changes).
3. Take a balanced approach and only warn a user of colour deprecations via Sass when they explicity request a colour or colour usecase – i.e. don't output colour deprecation notices from the `oColors` mixin.

This commit takes options 3.