### PR TITLE
Convert unitless values into percentages in oColorsMix

### DIFF
--- a/components/o-colors/src/scss/_functions.scss
+++ b/components/o-colors/src/scss/_functions.scss
@@ -194,6 +194,10 @@
 		@return _oColorsError("'#{inspect($color)}' is not a valid mixing color.");
 	}
 
+	@if (unitless($percentage)) {
+		@return mix($mixer, $base, $percentage * 1%);
+	}
+
 	@return mix($mixer, $base, $percentage);
 }
 


### PR DESCRIPTION
## Description
This PR ensures that `oColorsMix` calls the sass-native `mix` function with the required % unit for its `$weight` argument.

## Context
`sass@^1.52.3` raises warnings for any calls to `mix` made with a unitless value. In a project like ft-app this results in the terminal becoming flooded with aggressive red messages.
