### PR TITLE
Update video.js

### DIFF
--- a/components/o-video/src/js/video.js
+++ b/components/o-video/src/js/video.js
@@ -60,7 +60,7 @@ function shouldDispatch(video) {
 		23, 24, 25, 26, 27,
 		48, 49, 50, 51, 52,
 		73, 74, 75, 76, 77,
-		100
+		99,100
 	];
 
 	// Initialise dispatched progress store


### PR DESCRIPTION
track progress of video on 99%  since 100% is not sent (tested on chrome) and also make sense to advice that the user has seen almost all the video but maybe he just left the last seconds because he knows the video ends there.

[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?modal=detail&selectedIssue=CI-1464)