### PR TITLE
fix: o-header tsx, use correct drawer markup

### DIFF
--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -13,7 +13,8 @@ export function Drawer({
 		<div
 			className="o-header__drawer"
 			id="o-header-drawer"
-			role="navigation"
+			role="dialog"
+			aria-modal="true"
 			aria-label="Drawer menu"
 			data-o-header-drawer
 			data-o-header-drawer--no-js

--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,7 +4978,7 @@
 		},
 		"components/o-colors": {
 			"name": "@financial-times/o-colors",
-			"version": "6.4.3",
+			"version": "6.4.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-autoinit": "^3.1.0",
@@ -5188,7 +5188,7 @@
 		},
 		"components/o-ft-affiliate-ribbon": {
 			"name": "@financial-times/o-ft-affiliate-ribbon",
-			"version": "5.1.2",
+			"version": "5.2.0",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5213,7 +5213,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "10.1.2",
+			"version": "11.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5748,7 +5748,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "5.7.0",
+			"version": "5.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/n-map-content-to-topper": "^3.2.0"
@@ -5796,7 +5796,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.4",
+			"version": "7.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
Adds correct role to drawer to o-header tsx, as with demos. See abf34447eb7b2d51fe8ceb3c3cf02435635b43d5