### PR TITLE
fix: ensure components depend on the latest o-normalise version

### DIFF
--- a/components/o-autocomplete/package.json
+++ b/components/o-autocomplete/package.json
@@ -36,7 +36,7 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.1",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-visual-effects": "^4.0.1"

--- a/components/o-buttons/package.json
+++ b/components/o-buttons/package.json
@@ -24,7 +24,7 @@
 		"@financial-times/o-brand": "^4.1.0",
 		"@financial-times/o-colors": "^6.0.1",
 		"@financial-times/o-icons": "^7.0.0",
-		"@financial-times/o-normalise": "^3.2.0",
+		"@financial-times/o-normalise": "^3.3.0",
 		"@financial-times/o-typography": "^7.0.1"
 	},
 	"devDependencies": {

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-viewport": "^5.0.0"
   },
   "devDependencies": {

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -31,7 +31,7 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-toggle": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -35,7 +35,7 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },

--- a/components/o-header-services/package.json
+++ b/components/o-header-services/package.json
@@ -30,7 +30,7 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-utils": "^2.0.0",

--- a/components/o-header-services/test/js/drop-down.test.js
+++ b/components/o-header-services/test/js/drop-down.test.js
@@ -12,7 +12,7 @@ describe('Dropdown', () => {
 	let navItems;
 	let sandbox;
 
-	beforeEach(() => {
+	beforeEach((done) => {
 		sandbox = document.createElement('div');
 		sandbox.innerHTML = fixtures.withPrimaryNav;
 		document.body.appendChild(sandbox);
@@ -20,6 +20,10 @@ describe('Dropdown', () => {
 		new HeaderServices(headerEl);
 		navItems = document.querySelectorAll('li[data-o-header-services-level="1"]');
 		click = (parent, element) => parent.querySelector(element).dispatchEvent(new Event('click'));
+		// A small delay between initialising the component and running tests
+		// ensures click events behave as expected, more investigation is needed
+		// to understand why.
+		setTimeout(done,  100);
 	});
 
 	afterEach(() => {

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -30,7 +30,7 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.1",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-toggle": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-utils": "^2.0.0",

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -29,7 +29,7 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-fonts": "^5.0.0",
     "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-quote": "^5.0.1",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -35,7 +35,7 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0",

--- a/components/o-share/package.json
+++ b/components/o-share/package.json
@@ -34,7 +34,7 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },

--- a/components/o-social-follow/package.json
+++ b/components/o-social-follow/package.json
@@ -32,7 +32,7 @@
     "@financial-times/o-brand": "^4.1.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -28,7 +28,7 @@
     "@financial-times/math": "^1.0.0",
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.2.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -28,7 +28,7 @@
     "@financial-times/o-grid": "^6.0.0",
     "@financial-times/o-icons": "^7.0.1",
     "@financial-times/o-labels": "^6.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1"
   },

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -41,7 +41,7 @@
     "@financial-times/o-fonts": "^5.0.0",
     "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-spacing": "^3.0.0"
   },
   "devDependencies": {

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -27,7 +27,7 @@
     "@financial-times/o-colors": "^6.0.1",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-loading": "^5.0.0",
-    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-viewport": "^5.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4912,7 +4912,7 @@
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.1",
 				"@financial-times/o-loading": "^5.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-visual-effects": "^4.0.1"
@@ -4972,13 +4972,13 @@
 				"@financial-times/o-brand": "^4.1.0",
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-icons": "^7.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
 		},
 		"components/o-colors": {
 			"name": "@financial-times/o-colors",
-			"version": "6.4.3",
+			"version": "6.4.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-autoinit": "^3.1.0",
@@ -5103,7 +5103,7 @@
 			},
 			"peerDependencies": {
 				"@financial-times/o-icons": "^7.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-viewport": "^5.0.0"
 			}
 		},
@@ -5136,7 +5136,7 @@
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.0",
 				"@financial-times/o-loading": "^5.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-toggle": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
@@ -5181,14 +5181,14 @@
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.0",
 				"@financial-times/o-loading": "^5.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
 		},
 		"components/o-ft-affiliate-ribbon": {
 			"name": "@financial-times/o-ft-affiliate-ribbon",
-			"version": "5.1.2",
+			"version": "5.2.0",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5213,7 +5213,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "10.1.2",
+			"version": "11.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5230,7 +5230,7 @@
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-grid": "^6.1.1",
 				"@financial-times/o-icons": "^7.0.1",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-toggle": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-utils": "^2.0.0",
@@ -5255,7 +5255,7 @@
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-utils": "^2.0.0",
@@ -5314,7 +5314,7 @@
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-fonts": "^5.0.0",
 				"@financial-times/o-grid": "^6.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-quote": "^5.0.1",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
@@ -5433,7 +5433,7 @@
 				"@financial-times/o-brand": "^4.1.0",
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-icons": "^7.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-viewport": "^5.0.0",
@@ -5466,7 +5466,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "8.3.2",
+			"version": "9.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5483,7 +5483,7 @@
 				"@financial-times/o-brand": "^4.1.0",
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-grid": "^6.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
@@ -5509,7 +5509,7 @@
 				"@financial-times/o-brand": "^4.1.0",
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-grid": "^6.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
@@ -5546,7 +5546,7 @@
 				"@financial-times/math": "^1.0.0",
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-icons": "^7.2.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
@@ -5662,7 +5662,7 @@
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.1",
 				"@financial-times/o-labels": "^6.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1"
 			}
@@ -5748,7 +5748,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "5.7.0",
+			"version": "5.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/n-map-content-to-topper": "^3.2.0"
@@ -5790,13 +5790,13 @@
 				"@financial-times/o-fonts": "^5.0.0",
 				"@financial-times/o-grid": "^6.1.1",
 				"@financial-times/o-icons": "^7.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.0.0"
 			}
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.4",
+			"version": "7.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5809,7 +5809,7 @@
 				"@financial-times/o-colors": "^6.0.1",
 				"@financial-times/o-icons": "^7.0.0",
 				"@financial-times/o-loading": "^5.0.0",
-				"@financial-times/o-normalise": "^3.2.0",
+				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-viewport": "^5.0.0"
 			}


### PR DESCRIPTION
Attempt 2 of f8d45ef723d178e33ee1b158c43ae9f745a97b19