### PR TITLE
fix: styling changes to deep landscape

### DIFF
--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -90,7 +90,7 @@
 		grid-template-rows: 66vw 1fr;
 
 		.o-topper__content {
-			grid-column: 1;
+			grid-column: 1 span/2;
 			margin: auto;
 		}
 		.o-topper__image{

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -54,7 +54,7 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-			padding:20px;
+			padding:20px 20px 0 20px;
 		}
 	}
 

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -12,21 +12,12 @@
 		display:inline-block;
 		grid-row: 1;
 		box-sizing: border-box;
-		align-self: center;
+		align-self: end;
 		background: transparent;
-		position: absolute;
-		left: 10px;
-		bottom: 72px;
+	  	margin: 0 0 48px 12px;
 	}
-  	.o-topper__topic {
-	  	color: black !important;
-	}
-  	.n-myft-follow-button {
-		color: black !important;
-		border: 1px solid black !important;
-		&::before {
-		  	background-image:url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:plus?format=svg&source=next-article&tint=%23000000%2C%23FFFFFF)
-		}
+	.o-topper--deep-landscape .o-topper__topic {
+	  color: black;
 	}
 	.o-topper__headline {
 		&::after {
@@ -91,7 +82,6 @@
 
 		.o-topper__content {
 			grid-column: 1 span/2;
-			margin: auto;
 		}
 		.o-topper__image{
 			height:66vw;

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -54,7 +54,7 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-			padding:20px 20px 0 20px;
+		  	margin: 0 0 36px 12px
 		}
 	}
 
@@ -72,6 +72,9 @@
 	@include oGridRespondTo(L) {
 		grid-template-rows: 66vw 1fr;
 
+		.o-topper__content {
+		  grid-column: 1;
+		}
 		.o-topper__image{
 			height:66vw;
 		}

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -14,6 +14,24 @@
 		box-sizing: border-box;
 		align-self: center;
 		background: transparent;
+		position: absolute;
+		left: 10px;
+		bottom: 72px;
+	}
+  	.o-topper__topic {
+	  	color: black !important;
+	}
+  	.n-myft-follow-button {
+		color: black !important;
+		border: 1px solid black !important;
+		&::before {
+		  	background-image:url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:plus?format=svg&source=next-article&tint=%23000000%2C%23FFFFFF)
+		}
+	}
+	.o-topper__headline {
+		&::after {
+		  	content: none;
+		}
 	}
 
 	@each $color-name in $colors {
@@ -43,7 +61,7 @@
 		}
 	}
 
-	
+
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
@@ -52,7 +70,7 @@
 			padding:20px;
 		}
 	}
-	
+
 	@include oGridRespondTo($from:S , $until:M) {
 		.o-topper__content {
 			width:75%;

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -16,9 +16,6 @@
 		background: transparent;
 	  	margin: 0 0 48px 12px;
 	}
-	.o-topper--deep-landscape .o-topper__topic {
-	  color: black;
-	}
 	.o-topper__headline {
 		&::after {
 		  	content: none;

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -75,7 +75,7 @@
 
 		.o-topper__content {
 		  	grid-column: 1;
-		  	margin: 0 0 72px 0;
+		  	margin: 0 0 72px;
 		}
 		.o-topper__image{
 			height:66vw;

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -15,7 +15,7 @@
 		box-sizing: border-box;
 		align-self: end;
 		background: transparent;
-	  	margin: 0 0 48px 12px;
+	  	margin: 0 0 72px 10%;
 	}
 	.o-topper__headline {
 		&::after {
@@ -54,7 +54,8 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-		  	margin: 0 0 36px 12px
+		  	margin: 0;
+		  	padding: 20px;
 		}
 	}
 
@@ -73,7 +74,8 @@
 		grid-template-rows: 66vw 1fr;
 
 		.o-topper__content {
-		  grid-column: 1;
+		  	grid-column: 1;
+		  	margin: 0 0 72px 0;
 		}
 		.o-topper__image{
 			height:66vw;

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -11,6 +11,7 @@
 	.o-topper__content {
 		display:inline-block;
 		grid-row: 1;
+	  	grid-column: 1 / span 2;
 		box-sizing: border-box;
 		align-self: end;
 		background: transparent;
@@ -53,8 +54,6 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-			align-self: end;
-			grid-column: 1 / span 2;
 			padding:20px;
 		}
 	}
@@ -62,24 +61,17 @@
 	@include oGridRespondTo($from:S , $until:M) {
 		.o-topper__content {
 			width:75%;
-			grid-column: 1/span 2;
-			margin: auto auto auto 10%;
 		}
 	}
 	@include oGridRespondTo($from:M , $until:L) {
 		.o-topper__content {
 			width:50%;
-			grid-column: 1/span 2;
-			margin: auto auto auto 10%;
 		}
 	}
 
 	@include oGridRespondTo(L) {
 		grid-template-rows: 66vw 1fr;
 
-		.o-topper__content {
-			grid-column: 1 span/2;
-		}
 		.o-topper__image{
 			height:66vw;
 		}


### PR DESCRIPTION
Makes multiple styling changes to deep landscape:
- Moves the text down to the bottom of the image with padding
- Changes the link text to black in the header tags
- Removes the line between the heading

See: https://financialtimes.atlassian.net/browse/CI-1517