### PR TITLE
feat: Background Box support in deep landscape

### DIFF
--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -88,6 +88,13 @@ These colors affect the background of the `.o-topper__background` and `.o-topper
 .o-topper--color-matisse
 ```
 
+### Modifiers
+
+| Modifier                                | Use case                                                                                           |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------|
+| `.o-topper__content--background-box`    | Create a background box around the element `.o-topper__content`. The background colour of the box  |
+|                                         | will be defined based on the background of the topper                                              |
+
 ## Sass
 
 To include all o-topper CSS include `oTopper`:

--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -68,6 +68,7 @@ These themes affect the layout and visual style of all elements. See the [demos]
 .o-topper--split-text-left
 .o-topper--split-text-center
 .o-topper--deep-landscape
+.o-topper--deep-portrait
 ```
 
 ### Colors

--- a/components/o-topper/demos/src/deep-landscape-left.mustache
+++ b/components/o-topper/demos/src/deep-landscape-left.mustache
@@ -1,3 +1,6 @@
+<h2>
+Text Shadow + Slate background
+</h2>
 <div class="o-topper o-topper--deep-landscape o-topper--color-slate">
 	<div class="o-topper__content o-topper__content--text-shadow">
 		<div class="o-topper__tags">
@@ -19,6 +22,81 @@
 				<source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x">
 				<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
 			</picture>
-		<figcaption class="o-topper__image-caption">S @FT</figcaption>
+		<figcaption class="o-topper__image-credit">S @FT</figcaption>
+	</figure>
+</div>
+
+<h2>Box Shadow + Slate background</h2>
+
+<div class="o-topper o-topper--deep-landscape o-topper--color-slate">
+	<div class="o-topper__content o-topper__content--box-shadow">
+		<div class="o-topper__tags">
+			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
+		</div>
+		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
+			<span class="article-classifier__gap">Feeling the strain: stress and anxiety weigh on world’s workers</span>
+		</h1>
+		<div class="o-topper__standfirst">Henry Marsh and Stephen Westaby on ‘100 per cent mortality’, the embattled NHS and why self-deception is a clinical skill</div>
+	</div>
+
+	<div class="o-topper__background"></div>
+
+	<figure class="o-topper__visual">
+			<picture class="o-topper__picture">
+				<source media="(min-width: 491px) and (max-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=2 2x">
+				<source media="(max-width: 490px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=2 2x">
+				<source media="(min-width: 1221px) and (max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=2 2x">
+				<source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x">
+				<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
+			</picture>
+		<figcaption class="o-topper__image-credit">S @FT</figcaption>
+	</figure>
+</div>
+
+<h2>White background</h2>
+
+<div class="o-topper o-topper--deep-landscape o-topper--color-white">
+	<div class="o-topper__content">
+		<div class="o-topper__tags">
+			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
+		</div>
+		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
+			<span class="article-classifier__gap">Feeling the strain: stress and anxiety weigh on world’s workers</span>
+		</h1>
+		<div class="o-topper__standfirst">Henry Marsh and Stephen Westaby on ‘100 per cent mortality’, the embattled NHS and why self-deception is a clinical skill</div>
+	</div>
+
+	<div class="o-topper__background"></div>
+
+	<figure class="o-topper__visual">
+			<picture class="o-topper__picture"><source media="(min-width: 981px) and (max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/357e5a48-a1e5-47d6-9eed-2db9537f2c1f.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/357e5a48-a1e5-47d6-9eed-2db9537f2c1f.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=2 2x"><source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/357e5a48-a1e5-47d6-9eed-2db9537f2c1f.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/357e5a48-a1e5-47d6-9eed-2db9537f2c1f.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x"><source media="(max-width: 490px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f88eea18-54f1-4d59-9b7f-2672c42e3be5.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f88eea18-54f1-4d59-9b7f-2672c42e3be5.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=2 2x"><source media="(min-width: 491px) and (max-width: 980px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f88eea18-54f1-4d59-9b7f-2672c42e3be5.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=980&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f88eea18-54f1-4d59-9b7f-2672c42e3be5.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=980&amp;dpr=2 2x"><img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/357e5a48-a1e5-47d6-9eed-2db9537f2c1f.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440"></picture>
+		<figcaption class="o-topper__image-credit">S @FT</figcaption>
+	</figure>
+</div>
+
+<h2>Text Shadow + Box Shadow + White background</h2>
+
+<div class="o-topper o-topper--deep-landscape o-topper--color-white">
+	<div class="o-topper__content o-topper__content--text-shadow o-topper__content--box-shadow">
+		<div class="o-topper__tags">
+			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
+		</div>
+		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
+			<span class="article-classifier__gap">Feeling the strain: stress and anxiety weigh on world’s workers</span>
+		</h1>
+		<div class="o-topper__standfirst">Henry Marsh and Stephen Westaby on ‘100 per cent mortality’, the embattled NHS and why self-deception is a clinical skill</div>
+	</div>
+
+	<div class="o-topper__background"></div>
+
+	<figure class="o-topper__visual">
+			<picture class="o-topper__picture">
+				<source media="(min-width: 491px) and (max-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=2 2x">
+				<source media="(max-width: 490px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=2 2x">
+				<source media="(min-width: 1221px) and (max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=2 2x">
+				<source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x">
+				<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
+			</picture>
+		<figcaption class="o-topper__image-credit">S @FT</figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/deep-landscape-left.mustache
+++ b/components/o-topper/demos/src/deep-landscape-left.mustache
@@ -26,10 +26,10 @@ Text Shadow + Slate background
 	</figure>
 </div>
 
-<h2>Box Shadow + Slate background</h2>
+<h2>Background Box + Slate background</h2>
 
 <div class="o-topper o-topper--deep-landscape o-topper--color-slate">
-	<div class="o-topper__content o-topper__content--box-shadow">
+	<div class="o-topper__content o-topper__content--background-box">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
 		</div>
@@ -74,10 +74,10 @@ Text Shadow + Slate background
 	</figure>
 </div>
 
-<h2>Box Shadow + White background</h2>
+<h2>Background Box + White background</h2>
 
 <div class="o-topper o-topper--deep-landscape o-topper--color-white">
-	<div class="o-topper__content o-topper__content--text-shadow o-topper__content--box-shadow">
+	<div class="o-topper__content o-topper__content--text-shadow o-topper__content--background-box">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
 		</div>

--- a/components/o-topper/demos/src/deep-landscape-left.mustache
+++ b/components/o-topper/demos/src/deep-landscape-left.mustache
@@ -101,29 +101,3 @@ Text Shadow + Slate background
 	</figure>
 </div>
 
-<h2>Text Shadow + Box Shadow + Slate background</h2>
-
-<div class="o-topper o-topper--deep-landscape o-topper--color-slate">
-	<div class="o-topper__content o-topper__content--box-shadow o-topper__content--text-shadow">
-		<div class="o-topper__tags">
-			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
-		</div>
-		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
-			<span class="article-classifier__gap">Feeling the strain: stress and anxiety weigh on world’s workers</span>
-		</h1>
-		<div class="o-topper__standfirst">Henry Marsh and Stephen Westaby on ‘100 per cent mortality’, the embattled NHS and why self-deception is a clinical skill</div>
-	</div>
-
-	<div class="o-topper__background"></div>
-
-	<figure class="o-topper__visual">
-			<picture class="o-topper__picture">
-				<source media="(min-width: 491px) and (max-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=2 2x">
-				<source media="(max-width: 490px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=2 2x">
-				<source media="(min-width: 1221px) and (max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=2 2x">
-				<source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x">
-				<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
-			</picture>
-		<figcaption class="o-topper__image-credit">S @FT</figcaption>
-	</figure>
-</div>

--- a/components/o-topper/demos/src/deep-landscape-left.mustache
+++ b/components/o-topper/demos/src/deep-landscape-left.mustache
@@ -74,10 +74,37 @@ Text Shadow + Slate background
 	</figure>
 </div>
 
-<h2>Text Shadow + Box Shadow + White background</h2>
+<h2>Box Shadow + White background</h2>
 
 <div class="o-topper o-topper--deep-landscape o-topper--color-white">
 	<div class="o-topper__content o-topper__content--text-shadow o-topper__content--box-shadow">
+		<div class="o-topper__tags">
+			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
+		</div>
+		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
+			<span class="article-classifier__gap">Feeling the strain: stress and anxiety weigh on world’s workers</span>
+		</h1>
+		<div class="o-topper__standfirst">Henry Marsh and Stephen Westaby on ‘100 per cent mortality’, the embattled NHS and why self-deception is a clinical skill</div>
+	</div>
+
+	<div class="o-topper__background"></div>
+
+	<figure class="o-topper__visual">
+			<picture class="o-topper__picture">
+				<source media="(min-width: 491px) and (max-width: 1220px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/f7f44900-0eaf-4b3c-ba74-cd6f893ffd0b.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1220&amp;dpr=2 2x">
+				<source media="(max-width: 490px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/3408836a-5079-4a4c-9b19-ad54d18aa5d1.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=490&amp;dpr=2 2x">
+				<source media="(min-width: 1221px) and (max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440&amp;dpr=2 2x">
+				<source media="(min-width: 1441px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=1 1x, https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/dc1370be-2472-44af-89e3-3dde23ad2f34.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1920&amp;dpr=2 2x">
+				<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/6f323aa7-692e-4b0d-a3e2-ee1c708bdf72.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1440">
+			</picture>
+		<figcaption class="o-topper__image-credit">S @FT</figcaption>
+	</figure>
+</div>
+
+<h2>Text Shadow + Box Shadow + Slate background</h2>
+
+<div class="o-topper o-topper--deep-landscape o-topper--color-slate">
+	<div class="o-topper__content o-topper__content--box-shadow o-topper__content--text-shadow">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
 		</div>

--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -164,7 +164,7 @@
 		.o-topper__headline--large {
 			@include oEditorialTypographyHeadline();
 			position: relative; //so it appears above the full width background
-			margin-bottom: oSpacingByIncrement(7);
+			margin-bottom: oSpacingByIncrement(4);
 		}
 	}
 

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -32,11 +32,18 @@
 					text-shadow: 2px 3px 4px rgba(18,18,18,0.4);
 				}
 			}
-			.o-topper__content--box-shadow {
-					padding: oSpacingByName('s4');
-					margin-bottom: oSpacingByName('s6');
-					background-color: if($foreground == white, rgb(18,18,18,0.4), rgb(255,255,255,0.4));
-			}
+		}
+	}
+
+	$background-box-colors: (
+		'light',
+		'dark'
+	);
+	@each $background-box-color in $background-box-colors {
+		.o-topper__content.o-topper__content--background-box-#{$background-box-color} {
+			padding: oSpacingByName('s4');
+			margin-bottom: oSpacingByName('s6');
+			background-color: if($background-box-color == 'dark', rgb(18,18,18,0.4), rgb(255,255,255,0.4));
 		}
 	}
 

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -32,6 +32,11 @@
 					text-shadow: 2px 3px 4px rgba(18,18,18,0.4);
 				}
 			}
+			.o-topper__content--box-shadow {
+					padding: oSpacingByName('s4');
+					margin-bottom: oSpacingByName('s6');
+					background-color: if($foreground == white, rgb(18,18,18,0.4), rgb(255,255,255,0.4));
+			}
 		}
 	}
 

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -32,18 +32,11 @@
 					text-shadow: 2px 3px 4px rgba(18,18,18,0.4);
 				}
 			}
-		}
-	}
-
-	$background-box-colors: (
-		'light',
-		'dark'
-	);
-	@each $background-box-color in $background-box-colors {
-		.o-topper__content.o-topper__content--background-box-#{$background-box-color} {
-			padding: oSpacingByName('s4');
-			margin-bottom: oSpacingByName('s6');
-			background-color: if($background-box-color == 'dark', rgb(18,18,18,0.4), rgb(255,255,255,0.4));
+			.o-topper__content--background-box {
+				padding: oSpacingByName('s4');
+				margin-bottom: oSpacingByName('s6');
+				background-color: if($foreground == white, rgb(18,18,18,0.4), rgb(255,255,255,0.4));
+			}
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21825,13 +21825,19 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001300",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-			"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"version": "1.0.30001452",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
+			"integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			]
 		},
 		"node_modules/capture-exit": {
 			"version": "2.0.0",
@@ -66448,9 +66454,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001300",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-			"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
+			"version": "1.0.30001452",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
+			"integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",


### PR DESCRIPTION
We are introducing a Background Box variation for the deep landscape layout in toppers.
The  Background Box option is meant to improve readability when the text shadow is not good enough depending on the used background image chosen by Editorial. More information in the [ticket](https://financialtimes.atlassian.net/browse/CI-1543)

Desktop/Tablet (White and black permutations) 

![image](https://user-images.githubusercontent.com/752680/219619248-abfd4715-d729-4751-bdf0-d0f55192bca4.png)

![image](https://user-images.githubusercontent.com/752680/219619489-ed00d0fe-cf0d-425f-a87a-961ac04b1d4c.png)

Mobile (White and black permutations) 

![image](https://user-images.githubusercontent.com/752680/219619630-b27ff425-0499-4914-ac96-47ab3ecb34bb.png)
 
![image](https://user-images.githubusercontent.com/752680/219619699-cc2264cd-48a6-42ab-97d3-88dfcce71dd6.png)

In this PR:

* Add new background box modifier
* Fix the credit not appearing in the Deep Landscape demo
* Extending the existing demo to cover more permutation of the components
* Reducing to 16px the margin-bottom for all the headlines (Design request)