### PR TITLE
feat: add option to set an additional class on shadow dom for o-comments

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -74,7 +74,10 @@ class Stream {
 					: 'https://ft.coral.coralproject.net';
 				const scriptElement = document.createElement('script');
 				scriptElement.src = `${rootUrl}/assets/js/embed.js?${cacheBuster}`;
-
+				const containerClassName = ['o-comments-coral-talk-container'];
+				if(this.options.addClass){
+					containerClassName.push(this.options.addClass);
+				}
 				scriptElement.onload = () => {
 					this.embed = Coral.createStreamEmbed(
 						{
@@ -84,7 +87,7 @@ class Stream {
 							rootURL: rootUrl,
 							autoRender: true,
 							bodyClassName: 'o-comments-coral-talk-container',
-							containerClassName: 'o-comments-coral-talk-container',
+							containerClassName,
 							events: (events) => {
 								events.onAny((name, data) => {
 									this.publishEvent({name, data});

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -26,6 +26,13 @@
 			line-height: 1.784rem;
         	}
 	}
+	#coral.o-comments-app {
+		--ft-magnify: 1.0666666667;
+		.coral-comment-content {
+            		font-size: 1rem;
+            		line-height: 1.45rem;
+        	}
+	}
 	.o-comments-coral-talk-container, #coral {
 		--font-family-primary: #{inspect(oTypographyGetFontFamily('sans'))};
 		--font-family-secondary: #{inspect(oTypographyGetFontFamily('sans'))};

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -26,7 +26,7 @@
 			line-height: 1.784rem;
         	}
 	}
-	#coral.o-comments-app {
+	#coral.o-comments-root-font-size-1 {
 		--ft-magnify: 1.0666666667;
 		.coral-comment-content {
             		font-size: 1rem;


### PR DESCRIPTION
**Why ?** 
On the app the rem font size is different than in ft.com so we need to set a variant for the app to keep the same style.
**What ?** 
We set a new data-attribute called  data-o-comments-add-class which adds an additional class to coral component. On the app  we set the value data-o-comments-add-class="o-comments-app" and then it will take the styles that we have created for this class in this PR.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?modal=detail&selectedIssue=CI-1460)