### PR TITLE
feat: o-forms, allow submit events to be intercepted

### DIFF
--- a/components/o-forms/README.md
+++ b/components/o-forms/README.md
@@ -788,19 +788,42 @@ The main `o-forms` JavaScript has been written to identify and run on a `<form>`
 </form>
 ```
 
-By default, `o-forms` is initialised _without_ native browser validation, and with an error summary for invalid elements when the form is submitted. In order to use the default behaviour, you'll need to do the following:
+By default, `o-forms` is initialised with validation logic. It will generate an error summary for invalid elements when the form is submitted:
 ```js
 import oForms from '@financial-times/o-forms';
 oForms.init()
 ```
-The default behaviour can be changed by configuring the options object:
+
+The default behaviour of `o-forms` can be changed by configuring the options object. For example, set `preventSubmit: true` to prevent the user from submitting the form. You may then run your own logic before submitting the form by listening for the `oForms.submit` event.
+```js
+oForms.init(null, {
+	preventSubmit: true
+})
+
+window.addEventListener('oForms.submit', (e) => {
+	console.log(`A user would like to submit a form, it is ${e.detail.valid ? 'valid' : 'invalid'}.`);
+	if(e.detail.valid) {
+		e.detail.instance.form.submit();
+	}
+});
+```
+
+The error summary may also be prevented by setting `errorSummary: false`. Though we do not recommend this as an error summary can be helpful for users to discover and navigate a form with errors – this is particularly true for users of some assistive technologies.
+```js
+oForms.init(null, {
+	errorSummary: false
+})
+```
+
+In order to use default browser validation set `useBrowserValidation: true`:
 ```js
 oForms.init(null, {
 	useBrowserValidation: true,
 	errorSummary: false
 })
 ```
-You can also set these values to the data attributes `data-o-forms-use-browser-validation` and `data-o-forms-error-summary` on the `<form>` element if you are not initialising the `oForms` instance in your product.
+
+You can also set these values to the data attributes e.g. `data-o-forms-prevent-submit`, `data-o-forms-use-browser-validation`, and `data-o-forms-error-summary` on the `<form>` element.
 
 ### Individual Inputs
 

--- a/components/o-forms/src/js/forms.js
+++ b/components/o-forms/src/js/forms.js
@@ -3,14 +3,29 @@ import State from './state.js';
 import ErrorSummary from './error-summary.js';
 
 class Forms {
+
+	/**
+ 	* @typedef {Object} FormsOptions - An options object for configuring the form.
+	* @property {boolean} [errorSummary=true] - Display an error summary at the top of the form as part of `o-forms` validation.
+ 	* @property {boolean} [preventSubmit=false] - Prevent form submission after `o-froms` validation – see the `oForms.submit` event to manually submit the form after validation. This does not apply when `useBrowserValidation` is true.
+	* @property {boolean} [useBrowserValidation=false] - Do not use `o-forms` validation, rely on the browser's built-in validation instead.
+ 	*/
+
+	/**
+ 	* @typedef {Event} FormsSubmitEvent - An event emitted when the form is submitted by the userand `o-forms` has completed validation.
+	* @property {object} detail - The event detail.
+	* @property {object} detail.instance  - The instance of `o-forms`.
+	* @property {boolean} detail.valid  - The validity of the `o-forms` instance.
+ 	*/
+
 	/**
 	 * Class constructor.
 	 *
-	 * @param {HTMLElement} [formElement] - The form element in the DOM
-	 * @param {object} [options={}] - An options object for configuring the form
+	 * @param {HTMLFormElement} [formElement] - The form element in the DOM
+	 * @param {FormsOptions} [options={}] - An options object for configuring the form
 	 */
 	constructor(formElement, options) {
-		if (formElement.nodeName !== 'FORM') {
+		if (!formElement || formElement.nodeName !== 'FORM') {
 			throw new Error(`[data-o-component="o-forms"] must be set on a form element. It is currently set on a '${formElement.nodeName.toLowerCase()}'.`);
 		}
 
@@ -20,12 +35,22 @@ class Forms {
 
 		this.opts = Object.assign({
 			useBrowserValidation: false,
+			preventSubmit: false,
 			errorSummary: true
 		}, options || Forms.getDataAttributes(formElement));
 
+		if(this.opts.useBrowserValidation && this.opts.preventSubmit) {
+			throw new Error('The o-forms `preventSubmit` option only applies when the `useBrowserValidation` option is `false`.');
+		}
+
 		if (!this.opts.useBrowserValidation) {
-			this.form.setAttribute('novalidate', true);
+			this.form.setAttribute('novalidate', '');
 			this.form.addEventListener('submit', this);
+			this.form.addEventListener('oForms.submit', (e) => {
+				if(e.detail.valid && !this.opts.preventSubmit) {
+					this.form.submit();
+				}
+			});
 		} else {
 			this.form.removeAttribute('novalidate');
 			this.submits = this.form.querySelectorAll('[type=submit]');
@@ -101,8 +126,10 @@ class Forms {
 		if (event.type === 'submit') {
 			event.preventDefault();
 			const checkedElements = this.validateFormInputs();
+			const formInvalid = checkedElements.some(input => input.valid === false);
 
-			if (checkedElements.some(input => input.valid === false)) {
+			if (formInvalid) {
+				// Display error summary.
 				if (this.opts.errorSummary) {
 					if (this.summary) {
 						const newSummary = new ErrorSummary(checkedElements, this.opts.errorSummaryMessage);
@@ -116,11 +143,20 @@ class Forms {
 						firstErrorAnchor.focus();
 					}
 				}
-
-				return;
 			}
 
-			event.target.submit();
+			/**
+			 * @type {FormsSubmitEvent}
+			 **/
+			const oFormsSubmitEvent = new CustomEvent('oForms.submit', {
+				detail: {
+					instance: this,
+					valid: !formInvalid
+				},
+				cancelable: true,
+				bubbles: true
+			});
+			this.form.dispatchEvent(oFormsSubmitEvent);
 		}
 	}
 

--- a/components/o-forms/src/js/forms.js
+++ b/components/o-forms/src/js/forms.js
@@ -5,18 +5,18 @@ import ErrorSummary from './error-summary.js';
 class Forms {
 
 	/**
- 	* @typedef {Object} FormsOptions - An options object for configuring the form.
-	* @property {boolean} [errorSummary=true] - Display an error summary at the top of the form as part of `o-forms` validation.
- 	* @property {boolean} [preventSubmit=false] - Prevent form submission after `o-froms` validation – see the `oForms.submit` event to manually submit the form after validation. This does not apply when `useBrowserValidation` is true.
-	* @property {boolean} [useBrowserValidation=false] - Do not use `o-forms` validation, rely on the browser's built-in validation instead.
- 	*/
+	 * @typedef {Object} FormsOptions - An options object for configuring the form.
+	 * @property {boolean} [errorSummary=true] - Display an error summary at the top of the form as part of `o-forms` validation.
+	 * @property {boolean} [preventSubmit=false] - Prevent form submission after `o-froms` validation – see the `oForms.submit` event to manually submit the form after validation. This does not apply when `useBrowserValidation` is true.
+	 * @property {boolean} [useBrowserValidation=false] - Do not use `o-forms` validation, rely on the browser's built-in validation instead.
+	 */
 
 	/**
- 	* @typedef {Event} FormsSubmitEvent - An event emitted when the form is submitted by the userand `o-forms` has completed validation.
-	* @property {object} detail - The event detail.
-	* @property {object} detail.instance  - The instance of `o-forms`.
-	* @property {boolean} detail.valid  - The validity of the `o-forms` instance.
- 	*/
+	 * @typedef {Event} FormsSubmitEvent - An event emitted when the form is submitted by the userand `o-forms` has completed validation.
+	 * @property {object} detail - The event detail.
+	 * @property {object} detail.instance  - The instance of `o-forms`.
+	 * @property {boolean} detail.valid  - The validity of the `o-forms` instance.
+	 */
 
 	/**
 	 * Class constructor.
@@ -147,7 +147,7 @@ class Forms {
 
 			/**
 			 * @type {FormsSubmitEvent}
-			 **/
+			 */
 			const oFormsSubmitEvent = new CustomEvent('oForms.submit', {
 				detail: {
 					instance: this,

--- a/components/o-forms/test/forms.test.js
+++ b/components/o-forms/test/forms.test.js
@@ -239,7 +239,6 @@ describe('Forms', () => {
 
 	context('on `submit` of a valid form', () => {
 		let submit;
-		let summary;
 		let formSubmitSpy;
 
 		beforeEach(() => {

--- a/components/o-forms/test/forms.test.js
+++ b/components/o-forms/test/forms.test.js
@@ -3,7 +3,10 @@
 import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon-esm.js';
 
-import formFixture from './helpers/fixtures.js';
+import {
+	invalidForm as invalidFormFixture,
+	validForm as validFormFixture
+} from './helpers/fixtures.js';
 import Forms from './../main.js';
 
 describe('Forms', () => {
@@ -16,15 +19,17 @@ describe('Forms', () => {
 		parentClass = (element, modifier) => element.closest('.o-forms-input').classList.contains(`o-forms-input--${modifier}`);
 	});
 
-	context('on `submit`', () => {
+	context('on `submit` of an invalid form', () => {
 		let submit;
 		let summary;
-		let formSpy;
+		let formAddEventListenerSpy;
+		let formSubmitSpy;
 
 		beforeEach(() => {
-			document.body.innerHTML = formFixture;
+			document.body.innerHTML = invalidFormFixture;
 			formEl = document.forms[0];
-			formSpy = sinon.spy(formEl, 'addEventListener');
+			formAddEventListenerSpy = sinon.spy(formEl, 'addEventListener');
+			formSubmitSpy = sinon.spy(formEl, 'submit');
 
 			dateFields = formEl.elements['date'];
 			requiredTextField = formEl.elements['required'];
@@ -35,23 +40,67 @@ describe('Forms', () => {
 			document.body.innerHTML = null;
 		});
 
-		it('`opts.useBrowserValidation = true` relays form validation to browser on all invalid form inputs', () => {
-			new Forms(formEl, { useBrowserValidation: true });
-			submit.click();
+		context('`opts.useBrowserValidation = true`', () => {
+			it('relays form validation to browser on all invalid form inputs', () => {
+				new Forms(formEl, { useBrowserValidation: true });
+				submit.click();
 
-			proclaim.isTrue(formSpy.withArgs('submit').notCalled);
-			proclaim.isTrue(parentClass(dateFields[0], 'invalid'));
-			proclaim.isTrue(parentClass(requiredTextField, 'invalid'));
+				proclaim.isTrue(formAddEventListenerSpy.withArgs('submit').notCalled);
+				proclaim.isTrue(parentClass(dateFields[0], 'invalid'));
+				proclaim.isTrue(parentClass(requiredTextField, 'invalid'));
+			});
+
+			it('throws an error when the `preventSubmit` option is also true', () => {
+				proclaim.throws(() => {
+					new Forms(formEl, {
+						useBrowserValidation: true,
+						preventSubmit: true
+					});
+				}, Error)
+			});
 		});
 
-		it('`opts.useBrowserValidation = false` manually validates form inputs', () => {
-			new Forms(formEl);
-			submit.click();
+		context('`opts.useBrowserValidation = false`', () => {
+			it('`uses o-forms form validation', () => {
+				new Forms(formEl, {
+					useBrowserValidation: false
+				});
+				submit.click();
 
-			proclaim.isTrue(formSpy.withArgs('submit').calledOnce);
-			proclaim.isTrue(parentClass(dateFields[0], 'invalid'));
-			proclaim.isTrue(parentClass(requiredTextField, 'invalid'));
+				proclaim.isTrue(formAddEventListenerSpy.withArgs('submit').calledOnce);
+				proclaim.isTrue(parentClass(dateFields[0], 'invalid'));
+				proclaim.isTrue(parentClass(requiredTextField, 'invalid'));
+			});
+
+			context('`opts.preventSubmit = true`', () => {
+				it('prevents form submission after `o-forms` has validated the form', () => {
+					new Forms(formEl, {
+						useBrowserValidation: false,
+						preventSubmit: true
+					});
+					submit.click();
+
+					proclaim.isTrue(formSubmitSpy.notCalled);
+					proclaim.isTrue(parentClass(dateFields[0], 'invalid'));
+					proclaim.isTrue(parentClass(requiredTextField, 'invalid'));
+				});
+
+				it('fires `oForms.submit`', (done) => {
+					const oFormsInstance = new Forms(formEl, {
+						useBrowserValidation: false,
+						preventSubmit: true
+					});
+					formEl.addEventListener('oForms.submit', (e) => {
+						proclaim.equal(e.detail.instance, oFormsInstance);
+						proclaim.equal(e.detail.valid, false);
+						done();
+					});
+					submit.click();
+				});
+			});
 		});
+
+
 
 		context('`opts.errorSummary = true`', () => {
 			let listItems;
@@ -146,14 +195,14 @@ describe('Forms', () => {
 			const secondFormEl = document.getElementById('second-initialised-form');
 			// initialise the first form
 			const form = new Forms(formEl);
-			const formSpy = sinon.spy(form, 'validateFormInputs');
+			const formAddEventListenerSpy = sinon.spy(form, 'validateFormInputs');
 			// initialise the second form
 			const secondForm = new Forms(secondFormEl);
 			const secondFormSpy = sinon.spy(secondForm, 'validateFormInputs');
 			// submit the first form
 			submit.click();
 			// the first form is validated, the second is not
-			proclaim.isTrue(formSpy.called, 'The first form was submitted but not validated.');
+			proclaim.isTrue(formAddEventListenerSpy.called, 'The first form was submitted but not validated.');
 			proclaim.isTrue(secondFormSpy.notCalled, 'The second form was not submitted but was validated.');
 		});
 
@@ -180,11 +229,50 @@ describe('Forms', () => {
 			const secondFormSubmitEl = secondFormEl.querySelector('[type="submit"]');
 			// initialise the first form only
 			const form = new Forms(formEl);
-			const formSpy = sinon.spy(form, 'validateFormInputs');
+			const formAddEventListenerSpy = sinon.spy(form, 'validateFormInputs');
 			// submit the second form
 			secondFormSubmitEl.click();
 			// the first form is not validated
-			proclaim.isTrue(formSpy.notCalled, 'The first form was validated even though it was not submitted.');
+			proclaim.isTrue(formAddEventListenerSpy.notCalled, 'The first form was validated even though it was not submitted.');
+		});
+	});
+
+	context('on `submit` of a valid form', () => {
+		let submit;
+		let summary;
+		let formSubmitSpy;
+
+		beforeEach(() => {
+			document.body.innerHTML = validFormFixture;
+			formEl = document.forms[0];
+			formSubmitSpy = sinon.spy(formEl, 'submit');
+
+			dateFields = formEl.elements['date'];
+			requiredTextField = formEl.elements['required'];
+			submit = formEl.elements[formEl.elements.length - 1];
+		});
+
+		afterEach(() => {
+			document.body.innerHTML = null;
+		});
+
+		context('`opts.useBrowserValidation = false`', () => {
+			context('`opts.preventSubmit = true`', () => {
+				it('prevents form submission after `o-forms` has validated the form', (done) => {
+					new Forms(formEl, {
+						useBrowserValidation: false,
+						preventSubmit: true
+					});
+
+					formEl.addEventListener('oForms.submit', (e) => {
+						proclaim.isTrue(e.detail.valid);
+						proclaim.isTrue(formSubmitSpy.notCalled);
+						done();
+					});
+
+					submit.click();
+				});
+			});
 		});
 	});
 
@@ -192,7 +280,7 @@ describe('Forms', () => {
 		let form;
 
 		before(() => {
-			document.body.innerHTML = formFixture;
+			document.body.innerHTML = invalidFormFixture;
 			formEl = document.forms[0];
 			form = new Forms(formEl);
 		});
@@ -234,7 +322,7 @@ describe('Forms', () => {
 		let radioInputs;
 
 		before(() => {
-			document.body.innerHTML = formFixture;
+			document.body.innerHTML = invalidFormFixture;
 			formEl = document.forms[0];
 			name = 'radioBox';
 			radioInputs = formEl.elements[name];
@@ -266,9 +354,9 @@ describe('Forms', () => {
 
 	context('.destroy()', () => {
 		let form;
-		let formSpy;
+		let formAddEventListenerSpy;
 		beforeEach(() => {
-			document.body.innerHTML = formFixture;
+			document.body.innerHTML = invalidFormFixture;
 			formEl = document.forms[0];
 			form = new Forms(formEl);
 		});
@@ -288,11 +376,11 @@ describe('Forms', () => {
 		});
 
 		it('removes all event listeners', () => {
-			formSpy = sinon.spy(formEl, 'removeEventListener');
+			formAddEventListenerSpy = sinon.spy(formEl, 'removeEventListener');
 
 			form.destroy();
 
-			proclaim.isTrue(formSpy.calledOnce);
+			proclaim.isTrue(formAddEventListenerSpy.calledOnce);
 		});
 	});
 });

--- a/components/o-forms/test/helpers/fixtures.js
+++ b/components/o-forms/test/helpers/fixtures.js
@@ -1,4 +1,23 @@
-export default `
+const validForm = `
+<form action="" data-o-component="o-forms">
+
+	<span class="o-forms-field o-forms-field--optional">
+		<span class="o-forms-title">
+			<label for="optional" class="o-forms-title__main">Optional text input</label>
+		</span>
+
+		<span class="o-forms-input o-forms-input--text">
+			<input id="optional" type="text" name="optional" value="">
+		</span>
+	</span>
+
+	<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
+
+	<input class="o-buttons o-buttons--secondary" type="submit">
+</form>
+`;
+
+const invalidForm = `
 <form action="" data-o-component="o-forms">
 
 	<div class="o-forms-field" role="group" aria-labelledby="date-group-title">
@@ -66,3 +85,9 @@ export default `
 	<input class="o-buttons o-buttons--secondary" type="submit">
 </form>
 `;
+
+
+export { validForm, invalidForm};
+
+
+export default invalidForm;


### PR DESCRIPTION
By default o-forms listens to submit events. It validates a form and, if it is valid, will then call submit on the form element. This means projects which use o-forms cannot prevent a valid form from submitting.

This may be desirable to add extra steps prior to submission. For example to load a captcha (~apparently this should happen on submit?~ which we want to run when the form is filled out correctly) or to display a final confirmation.

To achieve this option:

This PR introduces the `oForms.submit` event. This is fired by o-forms when its submit event handler has finished form validation, just before submitting the form. A user may listen for this event and prevent propagation to stop the form from submitting. As this would rely on the project's event listener running first, however, the there is now also an option (`preventSubmit`) to ensure the form is not submitted by `o-forms`.

E.g:
```js
import oForms from '@financial-times/o-forms';

// Initialise a form. Note `oForms.init()` could also be used.
const formElement = document.forms[0];
new oForms(formElement, {
	preventSubmit: true
});

// Listen to the form submit event to handle submission manually.
formElement.addEventListener('oForms.submit', (e) => {
	console.log(`A user would like to submit a form, it is ${e.detail.valid ? 'valid' : 'invalid'}.`);
	if(e.detail.valid) {
		e.detail.instance.form.submit();
	}
});
```