### PR TITLE
feat: add scrollContainer option on o-comments

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -78,6 +78,7 @@ class Stream {
 				if(this.options.addClass){
 					containerClassName.push(this.options.addClass);
 				}
+				const customScrollContainer = document.querySelector(this.options.scrollContainer);
 				scriptElement.onload = () => {
 					this.embed = Coral.createStreamEmbed(
 						{
@@ -88,6 +89,7 @@ class Stream {
 							autoRender: true,
 							bodyClassName: 'o-comments-coral-talk-container',
 							containerClassName,
+							customScrollContainer,
 							events: (events) => {
 								events.onAny((name, data) => {
 									this.publishEvent({name, data});


### PR DESCRIPTION
Why?
We have an issue on the app that provoques bad rendering on comments when they are more than 12 . With this option we can fix it and stablished what will be the parent scroll container of the comments which in some cases like in the app now or if they would be in a modal element ,would be needed to work properly 
What ?
We add an option data-o-comments-scroll-container to de component that contains a selector to get the element which is going to be the custom scroll container