### PR TITLE
Add any icon support to o buttons TSX template

### DIFF
--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -20,7 +20,7 @@ export interface ButtonProps {
 		| "refresh"
 		| "cross"
 		| ""
-		| (string & Record<never, never>);
+		| (string & Record<never, never>); // Support IDE autocomplete whilst allowing any string https://github.com/microsoft/TypeScript/issues/29729#issuecomment-1331857805
 	iconOnly?: boolean;
 	attributes?: {
 		[attribute: string]: string | boolean;

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -19,7 +19,8 @@ export interface ButtonProps {
 		| "search"
 		| "refresh"
 		| "cross"
-		| string;
+		| ""
+		| (string & Record<never, never>);
 	iconOnly?: boolean;
 	attributes?: {
 		[attribute: string]: string | boolean;

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -1,25 +1,25 @@
 export interface ButtonProps {
 	label: string;
-	type: 'primary' | 'secondary' | 'ghost';
-	size?: 'big' | '';
-	theme?: 'inverse' | 'mono' | '';
+	type: "primary" | "secondary" | "ghost";
+	size?: "big" | "";
+	theme?: "inverse" | "mono" | "";
 	icon?:
-		| 'arrow-left'
-		| 'arrow-right'
-		| 'upload'
-		| 'tick'
-		| 'plus'
-		| 'warning'
-		| 'arrow-down'
-		| 'arrow-up'
-		| 'grid'
-		| 'list'
-		| 'edit'
-		| 'download'
-		| 'search'
-		| 'refresh'
-		| 'cross'
-		| '';
+		| "arrow-left"
+		| "arrow-right"
+		| "upload"
+		| "tick"
+		| "plus"
+		| "warning"
+		| "arrow-down"
+		| "arrow-up"
+		| "grid"
+		| "list"
+		| "edit"
+		| "download"
+		| "search"
+		| "refresh"
+		| "cross"
+		| string;
 	iconOnly?: boolean;
 	attributes?: {
 		[attribute: string]: string | boolean;
@@ -31,8 +31,8 @@ interface LinkButtonProps extends ButtonProps {
 	href: string;
 }
 
-function makeClassNames({type, size, theme, icon, iconOnly}) {
-	const classNames = ['o-buttons', `o-buttons--${type}`];
+function makeClassNames({ type, size, theme, icon, iconOnly }) {
+	const classNames = ["o-buttons", `o-buttons--${type}`];
 
 	if (size) {
 		classNames.push(`o-buttons--${size}`);
@@ -47,15 +47,15 @@ function makeClassNames({type, size, theme, icon, iconOnly}) {
 	}
 
 	if (iconOnly) {
-		classNames.push('o-buttons-icon--icon-only');
+		classNames.push("o-buttons-icon--icon-only");
 	}
-	return classNames.join(' ');
+	return classNames.join(" ");
 }
 
 export function Button({
 	label,
-	type = 'secondary',
-	size = '',
+	type = "secondary",
+	size = "",
 	theme,
 	icon,
 	iconOnly = false,
@@ -65,8 +65,9 @@ export function Button({
 	return (
 		<button
 			onClick={onClick ? event => onClick(event) : null}
-			className={makeClassNames({type, size, theme, icon, iconOnly})}
-			{...attributes}>
+			className={makeClassNames({ type, size, theme, icon, iconOnly })}
+			{...attributes}
+		>
 			{icon && iconOnly ? (
 				<span className="o-buttons-icon__label">{label}</span>
 			) : (
@@ -78,8 +79,8 @@ export function Button({
 
 export function LinkButton({
 	label,
-	type = 'secondary',
-	size = '',
+	type = "secondary",
+	size = "",
 	theme,
 	icon,
 	iconOnly = false,
@@ -91,8 +92,9 @@ export function LinkButton({
 		<a
 			href={href}
 			onClick={onClick ? event => onClick(event) : null}
-			className={makeClassNames({type, size, theme, icon, iconOnly})}
-			{...attributes}>
+			className={makeClassNames({ type, size, theme, icon, iconOnly })}
+			{...attributes}
+		>
 			{icon && iconOnly ? (
 				<span className="o-buttons-icon__label">{label}</span>
 			) : (

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -1,28 +1,50 @@
-import {withDesign} from 'storybook-addon-designs';
-import {Button, LinkButton} from '../src/tsx/button';
-import './button.scss';
-import withHtml from 'origami-storybook-addon-html';
+import { withDesign } from "storybook-addon-designs";
+import { Button, LinkButton } from "../src/tsx/button";
+import "./button.scss";
+import withHtml from "origami-storybook-addon-html";
 
 export default {
-	title: 'Components/o-buttons',
+	title: "Components/o-buttons",
 	component: Button,
 	decorators: [withDesign, withHtml],
 	args: {
 		onClick: {
 			table: {
-				disable: true
-			}
-		}
+				disable: true,
+			},
+		},
 	},
 	parameters: {
 		design: {
-			type: 'figma',
-			url: 'https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/FT-UI-Library?node-id=29%3A1131',
+			type: "figma",
+			url: "https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/FT-UI-Library?node-id=29%3A1131",
 		},
 		guidelines: {
-			notion: '448d914df4fd4bb68fdf5bc5e85c4b46',
+			notion: "448d914df4fd4bb68fdf5bc5e85c4b46",
 		},
 		html: {},
+	},
+	argTypes: {
+		icon: {
+			control: "select",
+			options: [
+				"arrow-left",
+				"arrow-right",
+				"upload",
+				"tick",
+				"plus",
+				"warning",
+				"arrow-down",
+				"arrow-up",
+				"grid",
+				"list",
+				"edit",
+				"download",
+				"search",
+				"refresh",
+				"cross",
+			],
+		},
 	},
 };
 
@@ -31,59 +53,59 @@ const LinkButtonStory = args => <LinkButton {...args} />;
 
 export const PrimaryButton = ButtonStory.bind({});
 PrimaryButton.args = {
-	label: 'Press button',
-	type: 'primary',
+	label: "Press button",
+	type: "primary",
 };
 
 export const SecondaryButton = ButtonStory.bind({});
 SecondaryButton.args = {
-	label: 'Press button',
-	type: 'secondary',
+	label: "Press button",
+	type: "secondary",
 };
 
 export const LinkAsButton = LinkButtonStory.bind({});
 LinkAsButton.args = {
-	label: 'Link button',
-	type: 'secondary',
-	href: '#',
+	label: "Link button",
+	type: "secondary",
+	href: "#",
 };
 
 export const BigButton = ButtonStory.bind({});
 BigButton.args = {
-	size: 'big',
-	label: 'Press button',
+	size: "big",
+	label: "Press button",
 };
 
 export const InverseButton = ButtonStory.bind({});
 InverseButton.args = {
-	label: 'Press button',
-	theme: 'inverse',
+	label: "Press button",
+	theme: "inverse",
 };
 InverseButton.parameters = {
-	origamiBackground: 'slate',
+	origamiBackground: "slate",
 };
 
 export const MonoButton = ButtonStory.bind({});
 MonoButton.args = {
-	label: 'Press button',
-	theme: 'mono',
+	label: "Press button",
+	theme: "mono",
 };
 
 export const GhostButton = ButtonStory.bind({});
 GhostButton.args = {
-	label: 'Press button',
-	type: 'ghost',
+	label: "Press button",
+	type: "ghost",
 };
 
 export const ButtonWithIcon = ButtonStory.bind({});
 ButtonWithIcon.args = {
-	label: 'Upload',
-	icon: 'upload',
+	label: "Upload",
+	icon: "",
 };
 
 export const IconOnlyButton = ButtonStory.bind({});
 IconOnlyButton.args = {
-	label: 'Next',
-	icon: 'arrow-right',
+	label: "Next",
+	icon: "arrow-right",
 	iconOnly: true,
 };

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -100,7 +100,7 @@ GhostButton.args = {
 export const ButtonWithIcon = ButtonStory.bind({});
 ButtonWithIcon.args = {
 	label: "Upload",
-	icon: "",
+	icon: "upload",
 };
 
 export const IconOnlyButton = ButtonStory.bind({});


### PR DESCRIPTION
This PR does not change the way o-buttons work.  It adds support for passing any string for the `icon` prop while still keeping the default icon sets as suggestions in IDE. This should improve TS users' experience with icons and also stop showing errors when custom icons are used.

There are a lot of eslint changes in the PR but the line that actually changed is line 23 in `button.tsx`