### PR TITLE
Major o-topper release: remove JS including `n-map-content-to-topper` 

### DIFF
--- a/components/o-topper/MIGRATION.md
+++ b/components/o-topper/MIGRATION.md
@@ -1,5 +1,15 @@
 # Migration guide
+## Migrating from v5 to v6
 
+`o-topper` no longer includes JavaScript to select the correct topper for JSON-formatted FT articles and flags. This helper was deeply tied to the FT.com content store, and included hardcoded UUIDs and business logic beyond the scope of Origami. Origami components focus on providing reusable user interfaces – without business logic assumptions which could limit their use outside specific groups or use-cases.
+
+To migrate, replace `o-topper` JavaScript with [`n-map-content-to-topper`](https://github.com/Financial-Times/n-map-content-to-topper).
+
+```diff
+-import { mapContentToTopper } from '@financial-times/o-topper';
++import mapContentToTopper from '@financial-times/n-map-content-to-topper';
+const topper = mapContentToTopper(ftArticle, flags);
+```
 ## Migrating from v4 to v5
 
 The velvet topper (previously used to indicate life and arts) has been removed.

--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -4,7 +4,6 @@ This component is used for styling the topper sections of an article.
 - [Usage](#usage)
 - [Markup](#markup)
 - [Sass](#sass)
-- [JavaScript](#javascript)
 - [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -149,28 +148,14 @@ To include o-topper styles granularly specify which elements, themes, and colour
 	)
 ));
 ```
-
-## JavaScript
-
-### Mapping Content to Topper
-
-This component exports a JavaScript helper from [`n-map-content-to-topper`](https://github.com/Financial-Times/n-map-content-to-topper). Use this helper to select the correct topper for an article given a JSON-formatteed FT article and flags.
-
-**Note:** This helper is deeply tied to the FT.com content store, and includes hardcoded UUIDs and business logic.
-
-```js
-import { mapContentToTopper } from '@financial-times/o-topper';
-
-const topper = mapContentToTopper(ftArticle, flags);
-```
-
 ## Migration
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 5 | N/A  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-⚠ maintained | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.1  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+✨ active | 6 | N/A  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+⚠ maintained | 5 | N/A  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+╳ deprecated | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+╳ deprecated | 3 | 3.1  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 ╳ deprecated | 2 | 2.7  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 ╳ deprecated | 1 | 1.2  | - |
 

--- a/components/o-topper/main.js
+++ b/components/o-topper/main.js
@@ -1,3 +1,0 @@
-import mapContentToTopper from '@financial-times/n-map-content-to-topper';
-
-export default mapContentToTopper;

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -13,7 +13,6 @@
   },
   "license": "MIT",
   "type": "module",
-  "browser": "main.js",
   "scripts": {
     "start": "npx serve ./demos/local",
     "build": "bash ../../scripts/component/build.bash",
@@ -34,9 +33,6 @@
     "@financial-times/o-fonts": "^5.2.0",
     "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-typography": "^7.2.0"
-  },
-  "dependencies": {
-    "@financial-times/n-map-content-to-topper": "^3.2.0"
   },
   "engines": {
     "npm": "^7 || ^8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4959,7 +4959,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.7.4",
+			"version": "7.7.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5163,7 +5163,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.5.0",
+			"version": "9.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5754,9 +5754,6 @@
 			"name": "@financial-times/o-topper",
 			"version": "5.7.4",
 			"license": "MIT",
-			"dependencies": {
-				"@financial-times/n-map-content-to-topper": "^3.2.0"
-			},
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
@@ -8661,14 +8658,6 @@
 		"node_modules/@financial-times/math": {
 			"resolved": "libraries/math",
 			"link": true
-		},
-		"node_modules/@financial-times/n-map-content-to-topper": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-3.2.0.tgz",
-			"integrity": "sha512-dcK+X3/KgtktYkwtw3/TM4r7H3vewiRXSvnZ68PXamAJJy0pblYdePqNHVsHtVi2Gu5S5A6G74GiUaHN//mJrA==",
-			"engines": {
-				"node": "16.x"
-			}
 		},
 		"node_modules/@financial-times/n-notification": {
 			"resolved": "components/n-notification",
@@ -55644,11 +55633,6 @@
 				}
 			}
 		},
-		"@financial-times/n-map-content-to-topper": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-3.2.0.tgz",
-			"integrity": "sha512-dcK+X3/KgtktYkwtw3/TM4r7H3vewiRXSvnZ68PXamAJJy0pblYdePqNHVsHtVi2Gu5S5A6G74GiUaHN//mJrA=="
-		},
 		"@financial-times/n-notification": {
 			"version": "file:components/n-notification",
 			"requires": {
@@ -56040,7 +56024,6 @@
 		"@financial-times/o-topper": {
 			"version": "file:components/o-topper",
 			"requires": {
-				"@financial-times/n-map-content-to-topper": "^3.2.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7.2.0"


### PR DESCRIPTION
`o-topper` no longer includes JavaScript to select the correct topper for JSON-formatted FT articles and flags. This helper was deeply tied to the FT.com content store, and included hardcoded UUIDs and business logic beyond the scope of Origami. Origami components focus on providing reusable user interfaces – without business logic assumptions which could limit their use outside specific groups or use-cases.

Not to mention, `n-map-content-to-topper` does not set its version number in `package.json` causing Origami contributors to have to `npm i` regularly for some reason – e.g. when checking out a new branch. Super annoying and time consuming.

**Review but do not merge yet:** Let's wait for [this topper change to be released](https://github.com/Financial-Times/origami/pull/1008), so we don't block the feature release behind a major release which (may) involve co-ordination between multiple teams.