### PR TITLE
fix: remove unnecesary margin deep-portrait

### DIFF
--- a/components/o-topper/src/scss/themes/_deep-portrait.scss
+++ b/components/o-topper/src/scss/themes/_deep-portrait.scss
@@ -90,7 +90,6 @@
 
 		.o-topper__image-caption {
 			margin-bottom: 0;
-			margin-top: 10px;
 			color: oColorsByName("black-70");
 		}
 	}


### PR DESCRIPTION
remove unnecessary margin from deep-portrait topper , to look the same as the rest of toppers