### PR TITLE
fix: set new margin bottom deep-landscape for desktop and tablet

### DIFF
--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -38,7 +38,6 @@
 			}
 			.o-topper__content--background-box {
 				padding: oSpacingByName('s4');
-				margin-bottom: oSpacingByName('s6');
 				background-color: if($foreground == white, rgb(18,18,18,0.4), rgb(255,255,255,0.4));
 			}
 		}
@@ -63,7 +62,7 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-		  	margin: 0;
+		  	margin: 0 0 24px;
 		  	padding: 20px;
 		}
 	}

--- a/components/o-topper/src/scss/themes/_deep-landscape.scss
+++ b/components/o-topper/src/scss/themes/_deep-landscape.scss
@@ -62,7 +62,7 @@
 	@include oGridRespondTo( $until:S) {
 		.o-topper__content {
 			width:100%;
-		  	margin: 0 0 24px;
+		  	margin: 0 0 oSpacingByName('s6');
 		  	padding: 20px;
 		}
 	}


### PR DESCRIPTION
fix margin bottom for box-shadow on deep-landscape to have 72px 
fix margin bottom on mobile on deep-landscape to have 24px
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?modal=detail&selectedIssue=CI-1601)
BEFORE
![image](https://user-images.githubusercontent.com/102036944/224676372-24dd4b52-84a4-4043-80d7-1a299e18f638.png)
![image](https://user-images.githubusercontent.com/102036944/224701971-d00b31c0-4f38-42f7-8342-837d171d6ece.png)

AFTER
![image](https://user-images.githubusercontent.com/102036944/224676199-cc32049b-e20c-4a7d-8c70-dedfa00e6002.png)
![image](https://user-images.githubusercontent.com/102036944/224701334-4678613c-f04d-40b8-af41-7f55d55c96e4.png)

