### PR TITLE
feat!: introduce FT editorial time formatting

### DIFF
--- a/components/o-date/package.json
+++ b/components/o-date/package.json
@@ -27,7 +27,7 @@
     "watch": "bash ../../scripts/component/watch.bash"
   },
   "dependencies": {
-    "@financial-times/ft-date-format": "^2.1.0"
+    "@financial-times/ft-date-format": "^3.0.0"
   },
   "volta": {
     "node": "14.16.1",

--- a/components/o-date/test/date.test.js
+++ b/components/o-date/test/date.test.js
@@ -123,6 +123,7 @@ describe('o-date', () => {
 			proclaim.strictEqual(oDate.format(date, 'm mm'), '7 07');
 			proclaim.strictEqual(oDate.format(date, 'a'), 'am');
 			proclaim.strictEqual(oDate.format(date, 'This is \\a co\\mmon string mm'), 'This is a common string 07');
+			proclaim.strictEqual(oDate.format(date, 't'), '6:07am')
 		});
 
 		it('returns an unpadded 12hour clock value for `h` format', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5048,7 +5048,7 @@
 			"version": "5.4.0",
 			"license": "MIT",
 			"dependencies": {
-				"@financial-times/ft-date-format": "^2.1.0"
+				"@financial-times/ft-date-format": "^3.0.0"
 			},
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5752,7 +5752,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "5.7.4",
+			"version": "6.0.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -8638,9 +8638,9 @@
 			"link": true
 		},
 		"node_modules/@financial-times/ft-date-format": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/ft-date-format/-/ft-date-format-2.1.0.tgz",
-			"integrity": "sha512-nVDEVgQTHU5vBQVC1zNb7erXDvOsugcPfTsm2L+nB0dSeIsGjKy+FMEUYpd05PQsw4c5H/IvownQuGLHhwolbw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@financial-times/ft-date-format/-/ft-date-format-3.0.0.tgz",
+			"integrity": "sha512-C0kR50JTZJlFRWNf3YrYEmJOr0JPe6kUupySHCFEBGaMSUNwt74HEvSJ9IJHLpvEEat1qjbFSjelswVN8PLY/w==",
 			"engines": {
 				"npm": "^7 || ^8"
 			}
@@ -55378,9 +55378,9 @@
 			"requires": {}
 		},
 		"@financial-times/ft-date-format": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/ft-date-format/-/ft-date-format-2.1.0.tgz",
-			"integrity": "sha512-nVDEVgQTHU5vBQVC1zNb7erXDvOsugcPfTsm2L+nB0dSeIsGjKy+FMEUYpd05PQsw4c5H/IvownQuGLHhwolbw=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@financial-times/ft-date-format/-/ft-date-format-3.0.0.tgz",
+			"integrity": "sha512-C0kR50JTZJlFRWNf3YrYEmJOr0JPe6kUupySHCFEBGaMSUNwt74HEvSJ9IJHLpvEEat1qjbFSjelswVN8PLY/w=="
 		},
 		"@financial-times/fticons": {
 			"version": "1.23.1",
@@ -55727,7 +55727,7 @@
 		"@financial-times/o-date": {
 			"version": "file:components/o-date",
 			"requires": {
-				"@financial-times/ft-date-format": "^2.1.0"
+				"@financial-times/ft-date-format": "^3.0.0"
 			}
 		},
 		"@financial-times/o-editorial-layout": {


### PR DESCRIPTION
Upgrades ft-date-format to enable use of FT editorial time style.

`t` can be used to format a time to match the style in FT's Style Guide.
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/7166831/225279472-dd2690ab-d4a6-4473-8a9c-404efb11a8c1.png">
