### PR TITLE
fix: o-typography, position visually hiddent anchor content relatively [OR-148]

### DIFF
--- a/components/o-typography/src/scss/use-cases/_general.scss
+++ b/components/o-typography/src/scss/use-cases/_general.scss
@@ -155,9 +155,17 @@
 			'we decided to remove the icon for external links.';
 	}
 
-	&[target="_blank"]:after {
-		@include oNormaliseVisuallyHidden();
-		content: '(opens a new window)';
+	&[target="_blank"] {
+		// Visually hidden content is positioned absolutely. Position relative on the anchor means the hidden
+		// content is positioned relative to the anchor element. This ensures it is clipped by the overflow
+		// property of an ancestor; otherwise the pseudo element which contains the hidden content will not
+		// be clipped by the overflow of any ancestor between it and its containing block.
+		// https://drafts.csswg.org/css2/#visufx
+		position: relative;
+		&:after {
+			@include oNormaliseVisuallyHidden();
+			content: '(opens a new window)';
+		}
 	}
 
 	// Output base styles shared by all links.

--- a/components/o-typography/test/scss/_mixins.test.scss
+++ b/components/o-typography/test/scss/_mixins.test.scss
@@ -543,6 +543,10 @@
 				text-decoration: none;
 				cursor: pointer;
 				border-bottom: 0.25ex solid;
+				&[target="_blank"] {
+					position: relative;
+				}
+
 				&[target="_blank"]:after {
 					position: absolute;
 					clip: rect(0 0 0 0);
@@ -586,6 +590,10 @@
 				), $include-base-styles: false);
 			}
 			@include expect {
+				&[target="_blank"] {
+					position: relative;
+				}
+
 				&[target="_blank"]:after {
 					position: absolute;
 					clip: rect(0 0 0 0);
@@ -622,6 +630,10 @@
 				), $include-base-styles: false);
 			}
 			@include expect {
+				&[target="_blank"] {
+					position: relative;
+				}
+
 				&[target="_blank"]:after {
 					position: absolute;
 					clip: rect(0 0 0 0);


### PR DESCRIPTION
Anchor elements which open in a new context (tab/window) have some hidden copy in a pseudo element to let screen reader users know. This is visually hidden with absolute positioning and clipping. This may cause an issue if it has an ancestor with hidden overflow between it and whatever element on the page is its containing block. To avoid this, we set `position: relative` on the anchor element to ensure it is always its containing block and so any ancestor with hidden overflow will clip it.

[CodePen Demo](https://codepen.io/ft-origami/pen/zYJJRgj?editors=1100)

Issue shows up in a large o-table with many rows, which contain links which open in a new context:
https://www.ft.com/ft1000-2023



https://user-images.githubusercontent.com/10405691/226403373-84bbc1d4-b12e-48a1-b209-8a9329a9473e.mp4



P.s. the reason we're not seeing the issue in Firefox is because Gecko and Webkit derived engines treat [clip](https://developer.mozilla.org/en-US/docs/Web/CSS/clip) differently. When clipped completely Firefox doesn't scroll to the visually hidden element. All tested browsers behave the same for `clip-path` however.