### PR TITLE
o-tracking/add trace to custom events

### DIFF
--- a/libraries/o-tracking/src/javascript/events/click.js
+++ b/libraries/o-tracking/src/javascript/events/click.js
@@ -1,9 +1,9 @@
 import Delegate from 'ftdomdelegate';
 import core from '../core.js';
-import {sanitise, assignIfUndefined, merge } from '../utils.js';
+import {assignIfUndefined, merge, sanitise} from '../utils.js';
 import {get as getSetting} from '../core/settings.js';
-import {getTrace} from '../../libs/get-trace.js';
-import { Queue } from '../core/queue.js';
+import tracing from '../../libs/tracing.js';
+import {Queue} from '../core/queue.js';
 
 let delegate;
 
@@ -37,7 +37,7 @@ const handleClickEvent = eventData => (clickEvent, clickElement) => {
 	//we don't want to track clicks to anonymous services like securedrop
 	if (clickElement.getAttribute("data-o-tracking-do-not-track") === "true") {return;}
 	const context = getEventProperties(clickEvent);
-	const { trace, customContext} = getTrace(clickElement);
+	const { trace, customContext} = tracing.getTrace(clickElement);
 	context.domPathTokens = trace;
 	context.url = window.document.location.href || null;
 	// source_id is a field that is currently being used in some data analytics

--- a/libraries/o-tracking/src/javascript/events/component-view.js
+++ b/libraries/o-tracking/src/javascript/events/component-view.js
@@ -1,5 +1,5 @@
 import core from '../core.js';
-import {getTrace} from '../../libs/get-trace.js';
+import tracing from '../../libs/tracing.js';
 import {assignIfUndefined, filterProperties} from '../utils.js';
 
 const TRACKING_ATTRIBUTES = [
@@ -11,7 +11,7 @@ const TRACKING_ATTRIBUTES = [
 
 const decorateEventData = (eventData, viewedEl, opts) => {
 
-	const { trace, customContext } = getTrace(viewedEl);
+	const { trace, customContext } = tracing.getTrace(viewedEl);
 	let context;
 
 	if (opts.getContextData) {

--- a/libraries/o-tracking/src/javascript/events/custom.js
+++ b/libraries/o-tracking/src/javascript/events/custom.js
@@ -1,9 +1,6 @@
 import core from '../core.js';
-import {
-	is,
-	broadcast,
-	merge,
-	addEvent} from '../utils.js';
+import tracing from "../../libs/tracing.js";
+import {addEvent, assignIfUndefined, broadcast, is, merge} from '../utils.js';
 
 /**
  * Default properties for events.
@@ -55,6 +52,14 @@ function event(trackingEvent, callback) {
 	// `event.target`
 	const element = trackingEvent.target || trackingEvent.srcElement;
 
+	if (element) {
+		const {trace, customContext} = tracing.getTrace(element);
+		config.context.domPathTokens = trace;
+		assignIfUndefined(customContext, config.context);
+	}
+
+	config.context.url = window.document.location.href || null;
+
 	if (isOrigamiComponent(element)) {
 		config.context.component_name = element.getAttribute('data-o-component');
 		config.context.component_id = config.context.component_id || getComponentId(element);
@@ -66,11 +71,11 @@ function event(trackingEvent, callback) {
 /**
  * Helper function that returns if an element is an Origami component
  *
- * @param  {Event} event - The event triggered.
- * @returns boolean - Returns the whether the HTML element if an Origami component.
+ * @param  {Element} element - The event triggered.
+ * @returns boolean - Returns true if the HTML element if an Origami component, else false.
  */
 function isOrigamiComponent(element) {
-	return element && element.getAttribute('data-o-component')
+	return element && element.getAttribute('data-o-component');
 }
 
 /**

--- a/libraries/o-tracking/src/javascript/events/custom.js
+++ b/libraries/o-tracking/src/javascript/events/custom.js
@@ -51,29 +51,26 @@ function event(trackingEvent, callback) {
 	delete config.context.category;
 	delete config.context.action;
 
-	const origamiElement = getOrigamiEventTarget(trackingEvent);
-	if (origamiElement) {
-		config.context.component_name = origamiElement.getAttribute('data-o-component');
-		config.context.component_id = config.context.component_id || getComponentId(origamiElement);
+	// IE backwards compatibility (get the actual target). If not IE, uses
+	// `event.target`
+	const element = trackingEvent.target || trackingEvent.srcElement;
+
+	if (isOrigamiComponent(element)) {
+		config.context.component_name = element.getAttribute('data-o-component');
+		config.context.component_id = config.context.component_id || getComponentId(element);
 	}
 
 	core.track(config, callback);
 }
 
 /**
- * Helper function that gets the target of an event if it's an Origami component
+ * Helper function that returns if an element is an Origami component
  *
  * @param  {Event} event - The event triggered.
- * @returns {HTMLElement|undefined} - Returns the HTML element if an Origami component, else undefined.
+ * @returns boolean - Returns the whether the HTML element if an Origami component.
  */
-function getOrigamiEventTarget(event) {
-	// IE backwards compatibility (get the actual target). If not IE, uses
-	// `event.target`
-	const element = event.target || event.srcElement;
-
-	if (element && element.getAttribute('data-o-component')) {
-		return element;
-	}
+function isOrigamiComponent(element) {
+	return element && element.getAttribute('data-o-component')
 }
 
 /**

--- a/libraries/o-tracking/src/libs/tracing.js
+++ b/libraries/o-tracking/src/libs/tracing.js
@@ -95,7 +95,7 @@ const getContextProps = (attrs, props, isOriginalEl) => {
 	return customProps;
 };
 
-export function getTrace (el) {
+function getTrace (el) {
 	const rootEl = document;
 	const originalEl = el;
 	const selector = originalEl.getAttribute('data-trackable') ? `[data-trackable="${originalEl.getAttribute('data-trackable')}"]` : originalEl.nodeName;
@@ -125,3 +125,7 @@ export function getTrace (el) {
 	}
 	return { trace, customContext };
 }
+
+export default {
+	getTrace
+};


### PR DESCRIPTION
# o-tracking/add trace to custom events
## What
This PR adds context to custom events. Including:
- context.url
- context.domPathTokens
- support for `data-trackable-context-*` attributes

## Why
Currently custom events are the only events that can be emitted on elements which are missing this contextual information.
This means, if an engineer wishes to have the same contextual information as when an event is viewed/clicked then they must effectively re-implement get-trace in their own app.

## Impact
This change will mean existing usage of custom events:
- will have extra data added to its context object, however no properties will be overridden, with the exception of `url` and `domPath`  (mirroring behaviour on other event types).
- more data will be sent into spoor.