### PR TITLE
Capture progress video events

### DIFF
--- a/components/o-video/src/js/video.js
+++ b/components/o-video/src/js/video.js
@@ -15,7 +15,6 @@ function listenOnce(el, eventName, fn) {
 }
 
 function eventListener(video, ev) {
-
 	// On some platforms (eg iOS), the Google advert library will use the main <video> element
 	// used by o-video to also play a pre-roll advert; as the advert plays, this will trigger
 	// the normal <video> event listeners.  Discard events that we can identify as coming
@@ -55,13 +54,14 @@ const dispatchedProgress = {};
 function shouldDispatch(video) {
 	const progress = video.getProgress();
 	const id = video.opts.id;
+
 	//100% progress doesn't seem to be launched in chrome
 	const relevantProgressPoints = [
 		8, 9, 10, 11, 12,
 		23, 24, 25, 26, 27,
 		48, 49, 50, 51, 52,
 		73, 74, 75, 76, 77,
-		99,100
+		96, 97, 98, 99, 100
 	];
 
 	// Initialise dispatched progress store


### PR DESCRIPTION
I've found that in some videos the progress video event is not sent at some points. For example this [video page](https://ft.com:/video/3a6c06ee-14b7-4d6f-8b08-08cdd947c0a7?playlist-name=editors-picks&playlist-offset=0 ) sends progress events only until 98 percent , so 99 and 100 is not sent ever. 
Increasing this range to 5 points as the same of the other parts we want to capture progress event video we ensure that at least one of those points are capture.

 