### PR TITLE
fix: o-forms, deprecate pseudo-radio-link [OR-62]

### DIFF
--- a/components/o-forms/README.md
+++ b/components/o-forms/README.md
@@ -322,7 +322,9 @@ To show a state label with no text set the modifier class `o-forms-input__state-
 
 ##### Pseudo box radio inputs
 
-Its possible to achieve the look of box style radio inputs with anchor elements instead of actual radio inputs, we call these pseudo box radio inputs. They are useful, for example, as a control to toggle between two versions of a page.
+**Deprecated, we no longer recommend pseudo box radio inputs. These will be removed in a future major version:**
+
+Its possible to achieve the look of box style radio inputs with anchor elements instead of actual radio inputs, we call these pseudo box radio inputs. This is no longer recommended and should not be used in new projects.
 
 ```html
 <div class="o-forms-input o-forms-input--pseudo-radio-link">
@@ -331,6 +333,7 @@ Its possible to achieve the look of box style radio inputs with anchor elements 
 </div>
 ```
 
+Links which look like form inputs may be confusing for some users of assistive technologies, as they may be accessed or behave differently than expected. Further, unlike true o-forms radio inputs, there is no fieldset with legend to group the links. For most cases, use standard [box radio inputs](#box-radio-inputs) instead.
 #### Checkbox inputs
 
 ##### Square checkbox inputs

--- a/components/o-forms/main.scss
+++ b/components/o-forms/main.scss
@@ -10,7 +10,7 @@
 @import 'src/scss/main';
 
 /// @access public
-/// @param {Map} $opts [('elements': ('checkbox', 'date', 'password', 'pseudo-radio-link', 'radio-round', 'radio-box', 'select', 'textarea', 'text', 'toggle'), 'features': ('disabled', 'inline', 'inverse', 'error-summary', 'right', 'small', 'state', 'suffix'))] The o-form features to include styles for (see the README for a full list).
+/// @param {Map} $opts [('elements': ('checkbox', 'date', 'password', 'radio-round', 'radio-box', 'select', 'textarea', 'text', 'toggle'), 'features': ('disabled', 'inline', 'inverse', 'error-summary', 'right', 'small', 'state', 'suffix'))] The o-form features to include styles for (see the README for a full list).
 /// @example
 ///		@include oForms($opts: (
 ///			'elements': ('text', 'checkbox'),

--- a/components/o-forms/origami.json
+++ b/components/o-forms/origami.json
@@ -50,10 +50,11 @@
 		},
 		{
 			"name": "pseudo-radio-links",
-			"title": "Pseudo Radio Links",
+			"title": "Pseudo Radio Links (Deprecated)",
 			"template": "/demos/src/multiple-input-field.mustache",
 			"description": "Anchor elements that imitate box-style radio inputs",
-			"data": "/demos/src/data/pseudo-radio-links.json"
+			"data": "/demos/src/data/pseudo-radio-links.json",
+			"hidden": true
 		},
 		{
 			"name": "checkboxes",

--- a/components/o-forms/src/scss/_deprecated.scss
+++ b/components/o-forms/src/scss/_deprecated.scss
@@ -1,6 +1,6 @@
 /// @access private
 /// @output Styling for anchor 'controls'
-
+/// @deprecated Remove in a future major version. https://github.com/Financial-Times/origami/issues/535
 @mixin _oFormsPseudoRadioLink {
 	.o-forms-input--pseudo-radio-link {
 		@include _oFormsControlsBoxContainer();
@@ -12,6 +12,7 @@
 /// @access private
 /// @param {Map|null} $theme Custom theme map
 /// Outpus styling for box-styled anchors
+/// @deprecated Remove in a future major version. https://github.com/Financial-Times/origami/issues/535
 @mixin _oFormsPseudoRadioLinkStyles($theme: null) {
 	border-color: _oFormsGet('default-border', $from: $theme);
 

--- a/components/o-forms/src/scss/main.scss
+++ b/components/o-forms/src/scss/main.scss
@@ -13,7 +13,6 @@
 @import './checkbox';
 @import './date';
 @import './file-input';
-@import './pseudo-radio-link';
 @import './radio-box';
 @import './radio-round';
 @import './select';
@@ -25,3 +24,6 @@
 @import './modifiers/custom'; // for radio box & anchors
 @import './modifiers/inverse'; // for toggle
 @import './modifiers/state'; // for radio box
+
+// Deprecated features
+@import './deprecated';

--- a/components/o-forms/src/scss/modifiers/_custom.scss
+++ b/components/o-forms/src/scss/modifiers/_custom.scss
@@ -125,6 +125,9 @@
 
 	.o-forms-input--#{$class} {
 		@if $input == 'pseudo-radio-link' {
+			// We can provide a notice here that pseudo-radio-links are deprecated,
+			// as we know that the user is explicitly requesting and using it.
+			@warn 'o-forms: Pseudo Radio Links are deprecated and will be removed in the next major release. This is due to accessibility issues, see the README for more information. Please use standard box-styled radio inputs instead. https://registry.origami.ft.com/components/o-forms/readme?brand=core#pseudo-box-radio-inputs';
 			@include _oFormsPseudoRadioLinkStyles($theme);
 		} @else if $input == 'radio' {
 			@include _oFormsRadioBoxInputStyles($theme);


### PR DESCRIPTION
Links which look like form inputs may be confusing for some users of assistive technologies, as they may be accessed or behave differently than expected. Further, unlike true o-forms radio inputs, there is no fieldset with legend to group the links.

Instead use a standard box style radio button:
https://github.com/Financial-Times/origami/issues/535