### PR TITLE
fix: change outline color for focus links under matisse theme

### DIFF
--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -345,6 +345,9 @@
 				color: oColorsMix($foreground, $color-name, 73);
 			}
 		}
+		:focus-visible {
+			outline: 2px solid oColorsByName('white');
+		}
 	}
 }
 


### PR DESCRIPTION
change outline color to white when focus links on alphaville/matisse template
[ticket](https://financialtimes.atlassian.net/browse/CI-1645)

BEFORE
![image](https://user-images.githubusercontent.com/102036944/231143770-a2c4e25f-9f2f-4143-93a2-6bd556fd574a.png)


AFTER
![image](https://user-images.githubusercontent.com/102036944/231143672-46f2b114-61ee-4b47-9782-c48013283367.png)

