### PR TITLE
fix(concept-button): sets aria-label on initialise

### DIFF
--- a/components/ft-concept-button/src/js/ft-concept-button.js
+++ b/components/ft-concept-button/src/js/ft-concept-button.js
@@ -12,6 +12,14 @@ export default class FtConceptButton {
 		this.button = this.element.querySelector('.ft-concept-button__button');
 		this.live = this.element.querySelector('.ft-concept-button__announcement');
 		this.options = Object.assign({}, options || this.getOptionsFromDom());
+
+		// Set the correct initial state of the button
+		this._initializeState();
+	}
+
+	_initializeState() {
+		const state = this.isPressed;
+		this.isPressed = state;
 	}
 
 	get isPressed() {


### PR DESCRIPTION
### The issue 
The ft-concept-button sets it’s aria-label based on whether the button has been pressed or not. However, initially the button has no aria-label (unless it has been set directly in the mark-up), it only gets set when the isPressed function is called on toggle. So when the page loads, there are no aria-labels.

### Solution
Ideally, default aria-labels should be set directly in the markup/html, however, we can add some code to defensively add this, if it hasn't been.
If you add this.isPressed = this.isPressed; into the constructor, it will set the aria-label when the button is initialised. 

### Thoughts 
We should be adding aria-labels directly to the markup, but I think this code is still work adding, in case aria-labels haven't been added