### PR TITLE
fix: o-header, subnav, improve scroll button behaviour.

### DIFF
--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -34,7 +34,8 @@
     "@financial-times/o-toggle": "^3.0.0",
     "@financial-times/o-typography": "^7.0.1",
     "@financial-times/o-utils": "^2.0.0",
-    "@financial-times/o-visual-effects": "^4.0.1"
+    "@financial-times/o-visual-effects": "^4.0.1",
+    "@financial-times/o-viewport": "^5.1.1"
   },
   "devDependencies": {
     "@financial-times/o-fonts": "^5.2.0",

--- a/components/o-header/src/js/subnav.js
+++ b/components/o-header/src/js/subnav.js
@@ -1,3 +1,4 @@
+import viewport from '@financial-times/o-viewport';
 import * as oUtils from '@financial-times/o-utils';
 
 function init(headerEl) {
@@ -7,13 +8,15 @@ function init(headerEl) {
 		return;
 	}
 
+	// Looks like we can't remove this on destroy,
+	// as another component may be using it.
+	viewport.listenTo('resize');
+
 	const buttons = Array.from(subnav.getElementsByTagName('button'));
 	const wrapper = subnav.querySelector('[data-o-header-subnav-wrapper]');
 
-	let scrollWidth;
-	const wrapperWidth = wrapper.clientWidth;
-
 	function checkCurrentPosition() {
+		const wrapperWidth = wrapper.clientWidth;
 		const currentSelection = wrapper.querySelector('[aria-current]');
 		if (currentSelection) {
 			const currentSelectionEnd = currentSelection.getBoundingClientRect().right;
@@ -36,7 +39,8 @@ function init(headerEl) {
 	}
 
 	function scrollable() {
-		scrollWidth = wrapper.scrollWidth;
+		const scrollWidth = wrapper.scrollWidth;
+		const wrapperWidth = wrapper.clientWidth;
 
 		buttons.forEach(button => {
 			if (direction(button) === 'left') {
@@ -51,6 +55,8 @@ function init(headerEl) {
 
 	function scroll(e) {
 		let distance = 100;
+		const scrollWidth = wrapper.scrollWidth;
+		const wrapperWidth = wrapper.clientWidth;
 
 		if (direction(e.currentTarget) === 'left') {
 			distance = (wrapper.scrollLeft > distance ? distance : wrapper.scrollLeft) * -1;
@@ -66,6 +72,13 @@ function init(headerEl) {
 
 	wrapper.addEventListener('scroll', oUtils.throttle(scrollable, 100));
 	window.addEventListener('oViewport.resize', scrollable);
+
+	const observer = new MutationObserver(checkCurrentPosition);
+	observer.observe(wrapper, {
+		attributes: false,
+		childList: true,
+		subtree: true
+	});
 
 	buttons.forEach(button => {
 		button.onclick = scroll;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4835,7 +4835,7 @@
 		},
 		"components/ft-concept-button": {
 			"name": "@financial-times/ft-concept-button",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5163,7 +5163,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.7.1",
+			"version": "9.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5239,6 +5239,7 @@
 				"@financial-times/o-toggle": "^3.0.0",
 				"@financial-times/o-typography": "^7.0.1",
 				"@financial-times/o-utils": "^2.0.0",
+				"@financial-times/o-viewport": "^5.1.1",
 				"@financial-times/o-visual-effects": "^4.0.1"
 			}
 		},
@@ -5401,7 +5402,7 @@
 		},
 		"components/o-multi-select": {
 			"name": "@financial-times/o-multi-select",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.5.0",
@@ -5771,7 +5772,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "6.0.4",
+			"version": "6.0.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5816,7 +5817,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.6",
+			"version": "7.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
1. Viewport resize: Previously, o-header would only respond to viewport resize if the user had initialised `o-viewport`. This was undocumented. Let us always initialise `o-viewport` and include it as a dependency.
2. Viewport resize part 2: The wrapper width was calculated and stored on initialisation. This value is then wrong after resize, breaking the calculation to decide whether to show scroll buttons.
3. DOM mutation: When subnav items change, recalculate subnav scrollability. This supports single page application (or similar), where navigation items are updated dynamically.