### PR TITLE
fix: way obtain scrollContainer element

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -78,7 +78,7 @@ class Stream {
 				if(this.options.addClass){
 					containerClassName.push(this.options.addClass);
 				}
-				const customScrollContainer = document.querySelector(this.options.scrollContainer);
+				const customScrollContainer = this.streamEl.closest(this.options.scrollContainer);
 				scriptElement.onload = () => {
 					this.embed = Coral.createStreamEmbed(
 						{


### PR DESCRIPTION
change the way to obtain scrollContainer element. 
Why ? Previously we were using document.querySelector which on the app was getting a wrong element since there were several elements/containers with that class. This way we ensure that we are getting the container which is parent of the element where the comments are in