### PR TITLE
docs: update o-typography README 'Constructing o-typography' instructions

### DIFF
--- a/components/o-typography/README.md
+++ b/components/o-typography/README.md
@@ -510,7 +510,7 @@ Unless you're using the Build Service no JS will run automatically. You must eit
 **Constructing o-typography**
 
 ```js
-import oTypography from 'o-typography';
+import oTypography from '@financial-times/o-typography';
 
 const otypography = new oTypography();
 ```


### PR DESCRIPTION
Using the below import statement results in a build error:

```js
import oTypography from 'o-typography';
```

```
ERROR in ./client/scripts/main.js
Module not found: Error: Can't resolve 'o-typography' in '{path}/next-newsletter-signup/client/scripts'
 @ ./client/scripts/main.js 6:0-39 7:24-35
```

This resolved by changing the import statement to:

```js
import oTypography from '@financial-times/o-typography';
```