### PR TITLE
[OR-163] Add a tooltip theme for FT Professional

### DIFF
--- a/components/o-tooltip/README.md
+++ b/components/o-tooltip/README.md
@@ -57,6 +57,8 @@ Attributes can be set declaratively, or passed in on instantiation in an options
 - `data-o-tooltip-z-index`: Optional. The z-index for the tooltip.
 - `data-o-tooltip-animation-distance`: Optional. String with `px` suffix. Distance away from target to start and end animation. Defaults to '10px'.
 - `data-o-tooltip-append-to-body`: Optional. Append the tooltip to the `body` element so it is positioned and sized according to the body rather than a parent element. By default the tooltip is appended as a sibling of the tooltip target. Defaults to `false`.
+- `data-o-tooltip-theme`: Optional. For applying a theme when creating a tooltip imperatively, otherwise if copying tooltip markup use the theme class as described below. Defaults to `undefined`.
+
 #### Themes
 
 To apply a theme declaratively add the class `o-tooltip o-tooltip--[theme name]` to your markup. E.g. to output a tooltip for the professional theme:
@@ -77,6 +79,8 @@ To apply a theme declaratively add the class `o-tooltip o-tooltip--[theme name]`
 	</div>
 </div>
 ```
+
+You may also set a theme imperatively using the JavaScript API.
 ### JavaScript
 
 No code will run automatically unless you are using the Build Service.

--- a/components/o-tooltip/README.md
+++ b/components/o-tooltip/README.md
@@ -57,7 +57,26 @@ Attributes can be set declaratively, or passed in on instantiation in an options
 - `data-o-tooltip-z-index`: Optional. The z-index for the tooltip.
 - `data-o-tooltip-animation-distance`: Optional. String with `px` suffix. Distance away from target to start and end animation. Defaults to '10px'.
 - `data-o-tooltip-append-to-body`: Optional. Append the tooltip to the `body` element so it is positioned and sized according to the body rather than a parent element. By default the tooltip is appended as a sibling of the tooltip target. Defaults to `false`.
+#### Themes
 
+To apply a theme declaratively add the class `o-tooltip o-tooltip--[theme name]` to your markup. E.g. to output a tooltip for the professional theme:
+
+```html
+<div class='demo-tooltip-target' id="declarative-tooltip-target">
+	A bit of UI to annotate
+</div>
+
+<div data-o-component="o-tooltip"
+	class="o-tooltip o-tooltip--professional"
+	data-o-tooltip-position="below"
+	data-o-tooltip-target="declarative-tooltip-target"
+	data-o-tooltip-show-on-construction=true
+	id="my-tooltip-element">
+	<div class='o-tooltip-content'>
+		Some text to go in the tooltip
+	</div>
+</div>
+```
 ### JavaScript
 
 No code will run automatically unless you are using the Build Service.
@@ -135,9 +154,13 @@ The `oTooltip` mixin is used to output tooltip selectors and styles. This output
 /* etc. */
 ```
 
-There is [full Sass documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-tooltip/sassdoc).
+You may also choose to output tooltips for only specific themes:
+```scss
+@include oTooltip($opts: ('professional'));
+```
 
-## Customisation
+There is [full Sass documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-tooltip/sassdoc).
+## Custom Themes
 
 Include the `oTooltipAddTheme` mixin to output a custom tooltip theme. The mixin accepts a name for your theme and a map of options:
 

--- a/components/o-tooltip/demos/src/professional-demo.mustache
+++ b/components/o-tooltip/demos/src/professional-demo.mustache
@@ -1,0 +1,17 @@
+<div class="o-colors-page-background">
+	<div class='demo-tooltip-container' id="box-tooltip">
+
+		<button class='o-buttons o-buttons--secondary o-buttons--big demo-tooltip-target' id="demo-tooltip-target">
+			Share
+		</button>
+
+		<div data-o-component="o-tooltip" class="o-tooltip o-tooltip--professional"
+		data-o-tooltip-position="above"
+		data-o-tooltip-target="demo-tooltip-target"
+		data-o-tooltip-show-on-construction="true">
+			<div class='o-tooltip-content'>
+				<p>supercalifragilisticexpialidocious</p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/components/o-tooltip/main.scss
+++ b/components/o-tooltip/main.scss
@@ -13,8 +13,14 @@
 /// @output The output includes the `.o-tooltip` class definition.
 /// @example scss - All tooltip styles
 ///   @include oTooltip();
+/// @example scss -  Tooltip styles without extra themes such as for ft professional
+///   @include oTooltip($opts: ());
 /// @access public
-@mixin oTooltip() {
+@mixin oTooltip($opts: (
+	'themes': ('professional')
+)) {
+	$themes: if(map-has-key($opts, 'themes'), map-get($opts, 'themes'), ());
+
 	// Tooltip relies on the o-grid layout sizes being defined.
 	// This is still specification-compliant, as these mixins only output
 	// element selectors – nothing prefixed with o-grid
@@ -217,6 +223,14 @@
 			right: -(oSpacingByName('s3'));
 			left: -(oSpacingByName('s3'));
 			bottom: -(oSpacingByName('s3'));
+		}
+	}
+
+	@each $theme in $themes {
+		@if _oTooltipSupports($theme) {
+			.o-tooltip.o-tooltip--#{$theme} {
+				@include _oTooltipThemeContent($theme);
+			}
 		}
 	}
 }

--- a/components/o-tooltip/origami.json
+++ b/components/o-tooltip/origami.json
@@ -26,6 +26,12 @@
 			"description": "Basic demo"
 		},
 		{
+			"title": "Professional Demo",
+			"name": "professional-demo",
+			"template": "demos/src/professional-demo.mustache",
+			"description": "A basic demo using the FT Professional sub-brand theme."
+		},
+		{
 			"title": "Hover",
 			"name": "hover",
 			"template": "demos/src/hover.mustache",

--- a/components/o-tooltip/src/js/tooltip.js
+++ b/components/o-tooltip/src/js/tooltip.js
@@ -139,6 +139,9 @@ class Tooltip {
 		const element = document.createElement('div');
 		targetEl.setAttribute('id', opts.target);
 		element.setAttribute('data-o-component', 'o-tooltip');
+		if(typeof opts.theme === 'string') {
+			element.setAttribute('class', `o-tooltip o-tooltip--${opts.theme}`);
+		}
 		element.insertAdjacentHTML('afterbegin', `<div class='o-tooltip-content'>${opts.content}</div>`);
 		return element;
 	}

--- a/components/o-tooltip/src/scss/_brand.scss
+++ b/components/o-tooltip/src/scss/_brand.scss
@@ -15,9 +15,16 @@
 		'variables': (
 			'background-color': oColorsByName('white'),
 			'foreground-color': null, // inherit by default
-			'close-foreground-color': oColorsByName('black-60')
+			'close-foreground-color': oColorsByName('black-60'),
+			'professional': (
+				'background-color': oColorsByName('slate'),
+				'foreground-color': oColorsByName('white'),
+				'close-foreground-color': oColorsByName('white')
+			)
 		),
-		'supports-variants': ()
+		'supports-variants': (
+			'professional'
+		)
 	));
 }
 

--- a/components/o-tooltip/test/Tooltip.test.js
+++ b/components/o-tooltip/test/Tooltip.test.js
@@ -237,6 +237,12 @@ describe("Tooltip", () => {
 			proclaim.strictEqual(opts.position, 'below');
 		});
 
+		it("sets a opts.theme when a theme is specified", ()=>{
+			const opts = Tooltip.checkOptions({"target": "#el", "theme": "professional"});
+			proclaim.isFalse(throwStub.called);
+			proclaim.strictEqual(opts.theme, 'professional');
+		});
+
 		it("does not error if position is `top`, `bottom`, `left`, `right` or falsey", () => {
 			["above", "left", "right", "below", undefined].forEach((value) => {
 				Tooltip.checkOptions({"target": "#el", "position": value});
@@ -289,6 +295,18 @@ describe("Tooltip", () => {
 
 			tooltip.render();
 			proclaim.strictEqual(tooltipEl.style.zIndex, fakeZ);
+		});
+
+		it("sets a theme class if the theme option is set", () => {
+			const parent = document.getElementById('demo-tooltip-theme-test-1');
+			sinon.stub(parent, 'appendChild');
+			const tooltip = new Tooltip(stubEl, {
+				target: 'demo-tooltip-insertion-test-1-target',
+				content: 'content',
+				theme: 'professional'
+			});
+			proclaim.include(tooltip.tooltipEl.getAttribute('class'), 'o-tooltip');
+			proclaim.include(tooltip.tooltipEl.getAttribute('class'), 'o-tooltip--professional');
 		});
 
 		it("adds a close button with an aria label, role and title when opts.showOnConstruction is set to true", () => {

--- a/components/o-tooltip/test/helpers/fixtures.js
+++ b/components/o-tooltip/test/helpers/fixtures.js
@@ -134,6 +134,12 @@ function declarativeCode () {
 				</div>
 			</div>
 
+			<div id="demo-tooltip-theme-test-1">
+				<div class='tooltip-target' id="demo-tooltip-theme-test-1-target">
+					Thing to point the tooltip at.
+				</div>
+			</div>
+
 		</div>
 
 	`;


### PR DESCRIPTION
The second commit here makes sure the FT Professional theme (or any custom theme) can be applied imperatively via the JavaScript API – where tooltip markup is generated for the user 

<img width="422" alt="Screenshot 2023-05-18 at 13 40 49" src="https://github.com/Financial-Times/origami/assets/10405691/a525ae1e-1875-4e30-8a63-d81adf1479ef">
