### PR TITLE
fix: change style shadow dom container

### DIFF
--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -21,7 +21,8 @@
 	}
 	#coral {
 		--ft-magnify: 1.31282;
-		display: inline-block!important;
+                 // See https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?view=detail&selectedIssue=CI-1725
+		display: inline-block !important;
 		width:100%;
 		.coral-comment-content {
             		font-size: 1.23077rem;


### PR DESCRIPTION
We are having an issue on safari where the comments overflow the parent container.
We can fix that and setting 
**display: inline-block!important
width:100%.**
We need to set the **!important** due the Coral script introduce an inline style on that element setting display:block

[ticket](https://financialtimes.atlassian.net/browse/CI-1725)
