### PR TITLE
feat: Add :read-only styles to match the disabled styles for inputs

### DIFF
--- a/components/o-forms/src/scss/shared/_single-inputs.scss
+++ b/components/o-forms/src/scss/shared/_single-inputs.scss
@@ -19,7 +19,8 @@
 /// @access private
 /// @output Shared disabled state styles for inputs.
 @mixin _oFormsInputDisabled {
-	&:disabled {
+	&:disabled,
+	&:read-only {
 		cursor: default;
 		color: _oFormsGet('disabled-text');
 		background-color: _oFormsGet('disabled-base');


### PR DESCRIPTION
Apparently HTML has a(nother) [way of making inputs immutable](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)

We use this in Spark for readonly text areas, and are currently overriding the o-forms styles to make it look more disabled.

In this PR i've made it always match the :disabled styles, but i'm not sure if that is always what people would want(?). I can also see an argument for this being a feature, a breaking change or a patch... I'll leave it in your wise hands