### PR TITLE
chore: upgrade local node / npm

### DIFF
--- a/.github/workflows/build-websites.yml
+++ b/.github/workflows/build-websites.yml
@@ -4,29 +4,28 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        lfs: true
-    - name: use node javascript
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        cache: 'npm'
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.6
-        bundler-cache: true
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: bash ./scripts/build-website.bash
-    - name: deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4.2.2
-      with:
-        branch: origami.ft.com
-        folder: origami.ft.com
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: use node javascript
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+          cache: "npm"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.6
+          bundler-cache: true
+      - run: npm ci
+      - run: bash ./scripts/build-website.bash
+      - name: deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: origami.ft.com
+          folder: origami.ft.com

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,11 +17,9 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - uses: actions/setup-node@v2
         with:
-          cache: 'npm'
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.releases_created }}
-      - run: npm i -g npm@7
+          cache: "npm"
+          node-version: 18.x
+          registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}

--- a/components/ft-concept-button/package.json
+++ b/components/ft-concept-button/package.json
@@ -26,8 +26,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-audio/package.json
+++ b/components/o-audio/package.json
@@ -31,8 +31,8 @@
 		"npm": "^7 || ^8"
 	},
 	"volta": {
-		"node": "14.16.1",
-		"npm": "7.11.1"
+		"node": "18.16.0",
+		"npm": "9.5.1"
 	},
 	"percy": true,
 	"private": false

--- a/components/o-banner/package.json
+++ b/components/o-banner/package.json
@@ -41,8 +41,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-big-number/package.json
+++ b/components/o-big-number/package.json
@@ -31,8 +31,8 @@
 		"npm": "^7 || ^8"
 	},
 	"volta": {
-		"node": "14.16.1",
-		"npm": "7.11.1"
+		"node": "18.16.0",
+		"npm": "9.5.1"
 	},
 	"percy": true,
 	"private": false

--- a/components/o-buttons/package.json
+++ b/components/o-buttons/package.json
@@ -35,8 +35,8 @@
 		"npm": "^7 || ^8"
 	},
 	"volta": {
-		"node": "14.16.1",
-		"npm": "7.11.1"
+		"node": "18.16.0",
+		"npm": "9.5.1"
 	},
 	"percy": true,
 	"private": false

--- a/components/o-colors/package.json
+++ b/components/o-colors/package.json
@@ -48,8 +48,8 @@
     "watch": "bash ../../scripts/component/watch.bash"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -41,8 +41,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-cookie-message/package.json
+++ b/components/o-cookie-message/package.json
@@ -46,8 +46,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-date/package.json
+++ b/components/o-date/package.json
@@ -30,8 +30,8 @@
     "@financial-times/ft-date-format": "^3.0.0"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-editorial-layout/package.json
+++ b/components/o-editorial-layout/package.json
@@ -34,8 +34,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-editorial-typography/package.json
+++ b/components/o-editorial-typography/package.json
@@ -31,8 +31,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -39,8 +39,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-fonts/package.json
+++ b/components/o-fonts/package.json
@@ -29,8 +29,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-footer-services/package.json
+++ b/components/o-footer-services/package.json
@@ -34,8 +34,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -45,8 +45,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -49,8 +49,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false,

--- a/components/o-ft-affiliate-ribbon/package.json
+++ b/components/o-ft-affiliate-ribbon/package.json
@@ -31,8 +31,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-grid/package.json
+++ b/components/o-grid/package.json
@@ -33,8 +33,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-header-services/package.json
+++ b/components/o-header-services/package.json
@@ -44,8 +44,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -46,8 +46,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-icons/package.json
+++ b/components/o-icons/package.json
@@ -25,8 +25,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-labels/package.json
+++ b/components/o-labels/package.json
@@ -36,8 +36,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -49,8 +49,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-lazy-load/package.json
+++ b/components/o-lazy-load/package.json
@@ -23,8 +23,8 @@
     "watch": "bash ../../scripts/component/watch.bash"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "version": "3.1.2",
   "homepage": "https://registry.origami.ft.com/components/o-lazy-load",

--- a/components/o-loading/package.json
+++ b/components/o-loading/package.json
@@ -32,8 +32,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-message/package.json
+++ b/components/o-message/package.json
@@ -43,8 +43,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-meter/package.json
+++ b/components/o-meter/package.json
@@ -39,8 +39,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-multi-select/package.json
+++ b/components/o-multi-select/package.json
@@ -41,8 +41,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false,

--- a/components/o-normalise/package.json
+++ b/components/o-normalise/package.json
@@ -36,8 +36,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -50,8 +50,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-quote/package.json
+++ b/components/o-quote/package.json
@@ -40,8 +40,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-share/package.json
+++ b/components/o-share/package.json
@@ -46,8 +46,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "dependencies": {
     "ftdomdelegate": "^4.0.6"

--- a/components/o-social-follow/package.json
+++ b/components/o-social-follow/package.json
@@ -44,8 +44,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-spacing/package.json
+++ b/components/o-spacing/package.json
@@ -33,8 +33,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -41,8 +41,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-subs-card/package.json
+++ b/components/o-subs-card/package.json
@@ -45,8 +45,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-syntax-highlight/package.json
+++ b/components/o-syntax-highlight/package.json
@@ -32,8 +32,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-table/package.json
+++ b/components/o-table/package.json
@@ -51,8 +51,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-tabs/package.json
+++ b/components/o-tabs/package.json
@@ -35,8 +35,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-teaser-collection/package.json
+++ b/components/o-teaser-collection/package.json
@@ -41,8 +41,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -40,8 +40,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false,

--- a/components/o-toggle/package.json
+++ b/components/o-toggle/package.json
@@ -33,8 +33,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-tooltip/package.json
+++ b/components/o-tooltip/package.json
@@ -49,8 +49,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -38,8 +38,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -53,8 +53,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -39,8 +39,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-viewport/package.json
+++ b/components/o-viewport/package.json
@@ -30,8 +30,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/components/o-visual-effects/package.json
+++ b/components/o-visual-effects/package.json
@@ -29,8 +29,8 @@
     "npm": "^7 || ^8"
   },
   "volta": {
-    "node": "14.16.1",
-    "npm": "7.11.1"
+    "node": "18.16.0",
+    "npm": "9.5.1"
   },
   "percy": true,
   "private": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,8 +72,8 @@
 				"stylelint-config-prettier": "^9.0.3"
 			},
 			"engines": {
-				"node": "16.13.0",
-				"npm": "8.5.4"
+				"node": "18.16.0",
+				"npm": "9.5.1"
 			}
 		},
 		"apps/storybook": {
@@ -4857,7 +4857,7 @@
 		},
 		"components/n-notification": {
 			"name": "@financial-times/n-notification",
-			"version": "8.2.3",
+			"version": "8.2.4",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4892,7 +4892,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.7.3",
+			"version": "1.7.4",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^2.1.2"
@@ -4920,7 +4920,7 @@
 		},
 		"components/o-banner": {
 			"name": "@financial-times/o-banner",
-			"version": "4.4.8",
+			"version": "4.4.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -4942,7 +4942,7 @@
 		},
 		"components/o-big-number": {
 			"name": "@financial-times/o-big-number",
-			"version": "3.2.0",
+			"version": "3.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4959,7 +4959,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.8.0",
+			"version": "7.8.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -4978,7 +4978,7 @@
 		},
 		"components/o-colors": {
 			"name": "@financial-times/o-colors",
-			"version": "6.5.0",
+			"version": "6.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-autoinit": "^3.1.0",
@@ -5000,7 +5000,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "10.2.0",
+			"version": "10.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5022,7 +5022,7 @@
 		},
 		"components/o-cookie-message": {
 			"name": "@financial-times/o-cookie-message",
-			"version": "6.5.1",
+			"version": "6.5.2",
 			"license": "MIT",
 			"dependencies": {
 				"superstore-sync": "^2.1.1"
@@ -5056,7 +5056,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5076,7 +5076,7 @@
 		},
 		"components/o-editorial-typography": {
 			"name": "@financial-times/o-editorial-typography",
-			"version": "2.3.3",
+			"version": "2.3.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5120,7 +5120,7 @@
 		},
 		"components/o-footer": {
 			"name": "@financial-times/o-footer",
-			"version": "9.2.6",
+			"version": "9.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5145,7 +5145,7 @@
 		},
 		"components/o-footer-services": {
 			"name": "@financial-times/o-footer-services",
-			"version": "4.2.5",
+			"version": "4.2.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5163,7 +5163,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.9.0",
+			"version": "9.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5193,7 +5193,7 @@
 		},
 		"components/o-ft-affiliate-ribbon": {
 			"name": "@financial-times/o-ft-affiliate-ribbon",
-			"version": "5.2.0",
+			"version": "5.2.1",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5218,7 +5218,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "11.0.5",
+			"version": "11.0.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5245,7 +5245,7 @@
 		},
 		"components/o-header-services": {
 			"name": "@financial-times/o-header-services",
-			"version": "5.3.3",
+			"version": "5.3.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5278,7 +5278,7 @@
 		},
 		"components/o-labels": {
 			"name": "@financial-times/o-labels",
-			"version": "6.5.3",
+			"version": "6.5.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5297,7 +5297,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.3.1",
+			"version": "5.3.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5349,7 +5349,7 @@
 		},
 		"components/o-loading": {
 			"name": "@financial-times/o-loading",
-			"version": "5.2.1",
+			"version": "5.2.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5362,7 +5362,7 @@
 		},
 		"components/o-message": {
 			"name": "@financial-times/o-message",
-			"version": "5.4.1",
+			"version": "5.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5384,7 +5384,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5402,7 +5402,7 @@
 		},
 		"components/o-multi-select": {
 			"name": "@financial-times/o-multi-select",
-			"version": "1.1.0",
+			"version": "2.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5423,7 +5423,7 @@
 		},
 		"components/o-normalise": {
 			"name": "@financial-times/o-normalise",
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5439,7 +5439,7 @@
 		},
 		"components/o-overlay": {
 			"name": "@financial-times/o-overlay",
-			"version": "4.2.7",
+			"version": "4.2.8",
 			"license": "MIT",
 			"dependencies": {
 				"focusable": "^2.3.0",
@@ -5471,7 +5471,7 @@
 		},
 		"components/o-quote": {
 			"name": "@financial-times/o-quote",
-			"version": "5.3.1",
+			"version": "5.3.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5490,7 +5490,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "9.0.1",
+			"version": "9.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5519,7 +5519,7 @@
 		},
 		"components/o-social-follow": {
 			"name": "@financial-times/o-social-follow",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5540,7 +5540,7 @@
 		},
 		"components/o-spacing": {
 			"name": "@financial-times/o-spacing",
-			"version": "3.2.2",
+			"version": "3.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5556,7 +5556,7 @@
 		},
 		"components/o-stepped-progress": {
 			"name": "@financial-times/o-stepped-progress",
-			"version": "4.0.6",
+			"version": "4.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5577,7 +5577,7 @@
 		},
 		"components/o-subs-card": {
 			"name": "@financial-times/o-subs-card",
-			"version": "6.2.3",
+			"version": "6.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5601,7 +5601,7 @@
 		},
 		"components/o-syntax-highlight": {
 			"name": "@financial-times/o-syntax-highlight",
-			"version": "4.2.3",
+			"version": "4.2.4",
 			"license": "MIT",
 			"dependencies": {
 				"prismjs": "^1.27.0"
@@ -5615,7 +5615,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.3.0",
+			"version": "9.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5649,7 +5649,7 @@
 		},
 		"components/o-tabs": {
 			"name": "@financial-times/o-tabs",
-			"version": "8.1.2",
+			"version": "8.1.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5666,7 +5666,7 @@
 		},
 		"components/o-teaser": {
 			"name": "@financial-times/o-teaser",
-			"version": "6.2.6",
+			"version": "6.2.7",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^1.29.0",
@@ -5693,7 +5693,7 @@
 		},
 		"components/o-teaser-collection": {
 			"name": "@financial-times/o-teaser-collection",
-			"version": "4.2.2",
+			"version": "4.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5726,7 +5726,7 @@
 		},
 		"components/o-toggle": {
 			"name": "@financial-times/o-toggle",
-			"version": "3.2.4",
+			"version": "3.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5740,7 +5740,7 @@
 		},
 		"components/o-tooltip": {
 			"name": "@financial-times/o-tooltip",
-			"version": "5.2.5",
+			"version": "5.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5772,7 +5772,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "6.0.5",
+			"version": "6.0.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5793,12 +5793,13 @@
 		},
 		"components/o-typography": {
 			"name": "@financial-times/o-typography",
-			"version": "7.3.5",
+			"version": "7.3.6",
 			"license": "MIT",
 			"dependencies": {
 				"fontfaceobserver": "^2.0.9"
 			},
 			"devDependencies": {
+				"@financial-times/o-colors": "^6.5.0",
 				"@financial-times/o-grid": "^6.1.1",
 				"@financial-times/o-normalise": "^3.3.0"
 			},
@@ -5817,7 +5818,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.7",
+			"version": "7.2.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5848,7 +5849,7 @@
 		},
 		"components/o-visual-effects": {
 			"name": "@financial-times/o-visual-effects",
-			"version": "4.2.0",
+			"version": "4.2.1",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -55654,7 +55655,7 @@
 		"@financial-times/n-notification": {
 			"version": "file:components/n-notification",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0"
 			}
@@ -55676,7 +55677,7 @@
 			"version": "file:components/o-autocomplete",
 			"requires": {
 				"@financial-times/accessible-autocomplete": "^2.1.2",
-				"@financial-times/o-forms": "^9.2.0",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-utils": "^2.1.0"
 			}
@@ -55712,9 +55713,9 @@
 			"version": "file:components/o-colors",
 			"requires": {
 				"@financial-times/o-autoinit": "^3.1.0",
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
-				"@financial-times/o-forms": "^9.2.0",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-overlay": "^4.2.1",
 				"@financial-times/o-syntax-highlight": "^4.2.0",
@@ -55724,7 +55725,7 @@
 		"@financial-times/o-comments": {
 			"version": "file:components/o-comments",
 			"requires": {
-				"@financial-times/o-forms": "^9.2.0",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-overlay": "^4.2.1"
 			}
 		},
@@ -55789,7 +55790,7 @@
 		"@financial-times/o-forms": {
 			"version": "file:components/o-forms",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -55832,9 +55833,9 @@
 		"@financial-times/o-layout": {
 			"version": "file:components/o-layout",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-footer-services": "^4.2.0",
-				"@financial-times/o-forms": "^9.2.0",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-header-services": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-syntax-highlight": "^4.2.0",
@@ -55875,21 +55876,21 @@
 		"@financial-times/o-multi-select": {
 			"version": "file:components/o-multi-select",
 			"requires": {
-				"@financial-times/o-forms": "^9.5.0",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-normalise": "^3.3.0"
 			}
 		},
 		"@financial-times/o-normalise": {
 			"version": "file:components/o-normalise",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-colors": "^6.5.0"
 			}
 		},
 		"@financial-times/o-overlay": {
 			"version": "file:components/o-overlay",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"focusable": "^2.3.0",
@@ -55966,9 +55967,9 @@
 		"@financial-times/o-table": {
 			"version": "file:components/o-table",
 			"requires": {
-				"@financial-times/o-buttons": "^7",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5",
-				"@financial-times/o-forms": "^9",
+				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-typography": "^7",
 				"ftdomdelegate": "^4.0.6"
@@ -56022,7 +56023,7 @@
 		"@financial-times/o-toggle": {
 			"version": "file:components/o-toggle",
 			"requires": {
-				"@financial-times/o-buttons": "^7.2.0",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-spacing": "^3.2.0"
@@ -56031,7 +56032,7 @@
 		"@financial-times/o-tooltip": {
 			"version": "file:components/o-tooltip",
 			"requires": {
-				"@financial-times/o-buttons": "^7",
+				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-colors": "^6.5.0",
 				"@financial-times/o-fonts": "^5",
 				"@financial-times/o-normalise": "^3.3.0",
@@ -56067,6 +56068,7 @@
 		"@financial-times/o-typography": {
 			"version": "file:components/o-typography",
 			"requires": {
+				"@financial-times/o-colors": "^6.5.0",
 				"@financial-times/o-grid": "^6.1.1",
 				"@financial-times/o-normalise": "^3.3.0",
 				"fontfaceobserver": "^2.0.9"

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
 	},
 	"homepage": "https://github.com/Financial-Times/origami#readme",
 	"volta": {
-		"node": "16.13.0",
-		"npm": "8.5.4"
+		"node": "18.16.0",
+		"npm": "9.5.1"
 	},
 	"engines": {
-		"node": "16.13.0",
-		"npm": "8.5.4"
+		"node": "18.16.0",
+		"npm": "9.5.1"
 	},
 	"workspaces": [
 		"components/*",


### PR DESCRIPTION
We do not need to install npm 7 in github actions anymore, the node bundled version is high enough now