### PR TITLE
feat: apply invalid input styles to inputs without browser validation

### DIFF
--- a/components/o-forms/src/scss/modifiers/_inverse.scss
+++ b/components/o-forms/src/scss/modifiers/_inverse.scss
@@ -68,7 +68,7 @@
 		}
 
 		.o-forms-input--invalid {
-			*:invalid:not(:disabled) {
+			*:invalid:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled) {
 				color: _oFormsGet('invalid-base-color-inverse');
 				border-color: _oFormsGet('invalid-base-border-inverse');
 

--- a/components/o-forms/src/scss/shared/_validity.scss
+++ b/components/o-forms/src/scss/shared/_validity.scss
@@ -6,7 +6,7 @@
 	}
 
 	.o-forms-input--invalid {
-		*:invalid:not(:disabled) {
+		*:invalid:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled) {
 			color: _oFormsGet('invalid-base');
 			border-color: _oFormsGet('invalid-base');
 


### PR DESCRIPTION
This PR updates the selector that applies the red border and text color to inputs, textareas, and selects, to target these elements even if they're not marked as invalid by browser validation (with the `invalid` pseudo-class).

See https://financialtimes.slack.com/archives/C02FU5ARJ/p1685436315480479 for context.