### PR TITLE
fix: fix how we render storybook select labels.

### DIFF
--- a/components/o-forms/stories/boxRadioBtns.stories.tsx
+++ b/components/o-forms/stories/boxRadioBtns.stories.tsx
@@ -18,13 +18,8 @@ const themeControl =
 		? {
 				control: {
 					type: "select",
-					labels: {
-						"": "default",
-						professional: "professional",
-						'professional-inverse': "professional-inverse",
-					},
 				},
-				options: ["", "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/checkboxes.stories.tsx
+++ b/components/o-forms/stories/checkboxes.stories.tsx
@@ -18,13 +18,8 @@ const themeControl =
 		? {
 				control: {
 					type: "select",
-					labels: {
-						"": "default",
-						professional: "professional",
-						'professional-inverse': "professional-inverse",
-					},
 				},
-				options: ["", "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/radioBtns.stories.tsx
+++ b/components/o-forms/stories/radioBtns.stories.tsx
@@ -18,13 +18,8 @@ const themeControl =
 		? {
 				control: {
 					type: "select",
-					labels: {
-						"": "default",
-						professional: "professional",
-						'professional-inverse': "professional-inverse",
-					},
 				},
-				options: ["", "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse"],
 		  }
 		: hideArg;
 


### PR DESCRIPTION
 Remove the empty string as a key and instead use undefined. It seems that an empty string as a value for storybook controls does not work. The bad part is that the storybook does not errors or give us warning about them and fails other controls to render for other components. We should just use undefined as means for the user to go back default style. 

We could also not have an option for users to go back to default styling (mostly meaning initial render) but that seems like a bad user experience while exploring the components. 

This PR should fix the issues with controls for storybook components. 