### PR TITLE
backstage: update o-tracking events

### DIFF
--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -457,8 +457,8 @@ class Overlay {
 
 				// Add o-tracking integration
 				this.broadcast('event', 'oTracking', {
-					category: 'overlay',
-					action: 'show',
+					category: 'component',
+					action: 'view',
 					overlay_id: this.id,
 				});
 				this._trapFocus();
@@ -494,8 +494,8 @@ class Overlay {
 
 		this.broadcast('destroy');
 		this.broadcast('event', 'oTracking', {
-			category: 'overlay',
-			action: 'close',
+			category: 'component/cta',
+			action: 'click',
 			overlay_id: this.id,
 		});
 


### PR DESCRIPTION
### What
Updating the tracking event types in o-overlay, from `overlay` to `component`.

### Why
The analytics team have switched over to components, as it offers greater reporting insight.

### Impact
This change will mean existing usage of `overlay` for analysis will no longer receive events.
