### PR TITLE
feat: add an extra content block to record article_id and asset_type …

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -92,7 +92,7 @@ class Stream {
 							customScrollContainer,
 							events: (events) => {
 								events.onAny((name, data) => {
-									this.publishEvent({ name, data: { ...data, content: { uuid: this.options.articleId }}});
+									this.publishEvent({ name, data });
 								});
 							}
 						}

--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -92,7 +92,7 @@ class Stream {
 							customScrollContainer,
 							events: (events) => {
 								events.onAny((name, data) => {
-									this.publishEvent({name, data});
+									this.publishEvent({ name, data: { ...data, content: { uuid: this.options.articleId }}});
 								});
 							}
 						}
@@ -191,14 +191,23 @@ class Stream {
 				const oCommentsEvent = new CustomEvent(mappedEvent.oComments, oCommentsEventOptions);
 				this.streamEl.dispatchEvent(oCommentsEvent);
 
+				// Refactor defaultDetail to add a 'content' block before dispatching the event
+				const defaultDetailWithContentAdded =  { 			
+					category: 'comment',
+					action: mappedEvent.oTracking,
+					coral: true,
+					isWithheld: status === 'SYSTEM_WITHHELD',
+					content : {
+						asset_type: this.options.assetType,
+						uuid: this.options.articleId,
+					}
+				}
+
 				if (mappedEvent.oTracking && !this.options.disableOTracking) {
 					const oTrackingEventOptions = {
 						bubbles: true,
 						detail: {
-							category: 'comment',
-							action: mappedEvent.oTracking,
-							coral: true,
-							isWithheld: status === 'SYSTEM_WITHHELD'
+							...defaultDetailWithContentAdded
 						}
 					};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5772,9 +5772,8 @@
 		},
 		"components/o-top-banner": {
 			"name": "@financial-times/o-top-banner",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "MIT",
-			"devDependencies": {},
 			"engines": {
 				"npm": "^7 || ^8"
 			},


### PR DESCRIPTION
In the Apps side (ft-app), we need to add spoor tracking for when comments are posted/read/(potentially more event in the future).

We are mostly interested in to receive the 'asset_type' and 'article_uuid' when events are emitted.

To get these data, we would need to pass in from the [Apps side ](https://github.com/Financial-Times/ft-app/pull/2219) an extra property via adding `data-trackable-asset-type`. The Article uuid is already available in the o-comments side. A separate PR to address this will be opened.

For the o-comments side, this PR adds a small object called `content` packaging both 'asset_type' and 'uuid'
```
content: {
   asset_type: "article",
   uuid: "uuid-of-the-article"
}
```

Resulting effect

### Before
![Screenshot 2023-06-19 at 13 18 27](https://github.com/Financial-Times/origami/assets/9668520/47ffcdf6-ed70-4663-8936-453b2652ca0f)

### After
![Screenshot 2023-06-19 at 13 17 39](https://github.com/Financial-Times/origami/assets/9668520/7cff2564-8828-4194-abf8-d16ad655fe96)


Meta
[Jira](https://financialtimes.atlassian.net/browse/AT-5762)