### PR TITLE
fix: o-comments, make the comment textarea fit within the page layout

### DIFF
--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -144,7 +144,8 @@
 
 		// comment textarea
 		.coral-createComment {
-			display: block;
+			display: inline-block;
+			width:100%;
 		}
 
 		// post comment buttons


### PR DESCRIPTION
On Safari browsers, the Coral Comments box is much wider than the rest of the page and does not fit within the layout.

This applies a styling change to  the comments box that should improve this variance.

Before:
![image](https://github.com/Financial-Times/origami/assets/17812050/ad3c0d83-2997-46d5-9a06-0ce7ade86967)

After:
![image](https://github.com/Financial-Times/origami/assets/17812050/940f16ee-1d89-4bf1-9a3b-d02b8b6eba03)
