### PR TITLE
or-237: use correct 'regular' font weight on professional-inverse themed…

### DIFF
--- a/components/o-top-banner/main.scss
+++ b/components/o-top-banner/main.scss
@@ -109,6 +109,7 @@
 	$button-color: _oTopBannerGet('button-background-color', $theme);
 	$copy-color: _oTopBannerGet('copy-color', $theme);
 	$heading-color: _oTopBannerGet('heading-color', $theme);
+    $heading-font-weight: _oTopBannerGet('heading-font-weight', $theme);
 	$background-color: _oTopBannerGet('background-color', $theme);
 	$brand-border-color: _oTopBannerGet('brand-border-color', $theme);
 
@@ -116,9 +117,17 @@
 	color: $copy-color;
 	border-color: $brand-border-color;
 
-	@if($heading-color) {
+	@if($heading-color or $heading-font-weight) {
 		.o-top-banner__heading {
-			color: $heading-color;
+			@if ($heading-color) {
+			  color: $heading-color;
+			}
+		    @if ($heading-font-weight) {
+			  @include oTypographySans(
+					  $scale: ('default': 2, 'S': 3),
+					  $weight: $heading-font-weight
+			  );
+			}
 		}
 	}
 

--- a/components/o-top-banner/main.scss
+++ b/components/o-top-banner/main.scss
@@ -109,7 +109,7 @@
 	$button-color: _oTopBannerGet('button-background-color', $theme);
 	$copy-color: _oTopBannerGet('copy-color', $theme);
 	$heading-color: _oTopBannerGet('heading-color', $theme);
-    $heading-font-weight: _oTopBannerGet('heading-font-weight', $theme);
+	$heading-font-weight: _oTopBannerGet('heading-font-weight', $theme);
 	$background-color: _oTopBannerGet('background-color', $theme);
 	$brand-border-color: _oTopBannerGet('brand-border-color', $theme);
 
@@ -120,13 +120,13 @@
 	@if($heading-color or $heading-font-weight) {
 		.o-top-banner__heading {
 			@if ($heading-color) {
-			  color: $heading-color;
+				color: $heading-color;
 			}
-		    @if ($heading-font-weight) {
-			  @include oTypographySans(
-					  $scale: ('default': 2, 'S': 3),
-					  $weight: $heading-font-weight
-			  );
+			@if ($heading-font-weight) {
+				@include oTypographySans(
+					$scale: ('default': 2, 'S': 3),
+					$weight: $heading-font-weight
+				);
 			}
 		}
 	}

--- a/components/o-top-banner/src/scss/_brand.scss
+++ b/components/o-top-banner/src/scss/_brand.scss
@@ -21,7 +21,8 @@
 			'professional-inverse': (
 				'background-color': oColorsByName('slate'),
 				'copy-color': oColorsByName('white'),
-				'brand-border-color': oColorsByName('mint-70')
+				'brand-border-color': oColorsByName('mint-70'),
+				'heading-font-weight': regular
 			)
 		),
 		'supports-variants': ())


### PR DESCRIPTION
… o-top-banner component

## Describe your changes
This change makes the professional-inverse brand's o-top-banner heading text regular font weight.

Before
<img width="1251" alt="image" src="https://github.com/Financial-Times/origami/assets/7166831/a613bbee-bb12-4673-882f-d155f1e3c69a">

After
<img width="1266" alt="image" src="https://github.com/Financial-Times/origami/assets/7166831/835243e5-cecd-4747-b94c-5eaa4a05a9d6">

## Issue ticket number and link
[OR-237](https://financialtimes.atlassian.net/jira/software/c/projects/OR/boards/1658?modal=detail&selectedIssue=OR-237)

## Link to Figma designs

## Checklist before requesting a review
- [x] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.


[OR-237]: https://financialtimes.atlassian.net/browse/OR-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ