### PR TITLE
Add header component

### DIFF
--- a/apps/astro-website/src/components/header/Header.astro
+++ b/apps/astro-website/src/components/header/Header.astro
@@ -1,12 +1,19 @@
 ---
+import SecondaryNav from "./SecondaryNav.astro"
+import NavItem from "./NavItem.astro"
+
+const currentPage = Astro.url.pathname
+
 const primaryNav = [
 	{
 		label: "Home",
 		url: "/",
+		"aria-current": currentPage === "/" ? "page" : undefined,
 	},
 	{
 		label: "Documentation",
 		url: "/documentation",
+		"aria-current": currentPage === "/documentation" ? "page" : undefined,
 	},
 	{
 		label: "Registry",
@@ -15,10 +22,12 @@ const primaryNav = [
 	{
 		label: "Storybook",
 		url: "/storybook",
+		"aria-current": currentPage === "/storybook" ? "page" : undefined,
 	},
 	{
 		label: "Blog",
 		url: "/blog",
+		"aria-current": currentPage === "/blog" ? "page" : undefined,
 	},
 ]
 ---
@@ -45,38 +54,29 @@ const primaryNav = [
 
 <header class="o-header-services" data-o-component="o-header-services">
 	<div class="o-header-services__top">
-		<!-- Link to a fallback nav for the core experience when using a drawer and hamburger icon. -->
 		<div class="o-header-services__hamburger">
-			<a
-				class="o-header-services__hamburger-icon"
-				href="#core-nav-fallback"
-				role="button"
-			>
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
 				<span class="o-header-services__visually-hidden"
 					>Open primary navigation</span
 				>
 			</a>
 		</div>
-		<div class="o-header-services__logo"></div>
+		<a href="/" class="o-header-services__logo"
+			><span class="o-header-services__visually-hidden">To homepage</span></a
+		>
 		<div class="o-header-services__title">
 			<a class="o-header-services__product-name" href="/">Origami</a>
-			<span class="o-header-services__product-tagline">
-				Frontend Components & Services</span
+			<span class="o-header-services__product-tagline"
+				>Frontend Components &amp; Services</span
 			>
 		</div>
 	</div>
 
 	<nav class="o-header-services__primary-nav" aria-label="primary">
 		<ul class="o-header-services__primary-nav-list">
-			{
-				primaryNav.map(nav => (
-					<li>
-						<a aria-current="page" href={nav.url}>
-							{nav.label}
-						</a>
-					</li>
-				))
-			}
+			{primaryNav.map(nav => <NavItem nav={nav} />)}
 		</ul>
 	</nav>
+
+	<SecondaryNav />
 </header>

--- a/apps/astro-website/src/components/header/NavItem.astro
+++ b/apps/astro-website/src/components/header/NavItem.astro
@@ -1,0 +1,9 @@
+---
+const {nav} = Astro.props
+---
+
+<li>
+	<a aria-current={nav["aria-current"]} href={nav.url}>
+		{nav.label}
+	</a>
+</li>

--- a/apps/astro-website/src/components/header/SecondaryNav.astro
+++ b/apps/astro-website/src/components/header/SecondaryNav.astro
@@ -1,0 +1,98 @@
+---
+import NavItem from "./NavItem.astro"
+
+const currentPage = Astro.url.pathname
+
+const paths = currentPage.split("/").filter(x => x)
+const ancestors = generateAncestors(paths)
+const children = []
+
+const allPages = await Astro.glob("@/pages/**")
+const urls = allPages
+	.map(page => page.url)
+	.filter(url => url && !url.includes("[slug]"))
+
+urls
+	.filter(x => x.includes(currentPage))
+	.forEach(breadCrumb => {
+		const breadCrumbsArray = breadCrumb
+			.split(currentPage)[1]
+			.split("/")
+			.filter(x => x)
+		if (breadCrumbsArray.length != 1) {
+			return
+		}
+		const url = `${breadCrumb}`
+		children.push({
+			label: capitaliseFirstLetter(breadCrumbsArray[0].replace(/[-_]/g, " ")),
+			url,
+			"aria-current": Astro.url.pathname === url ? "page" : undefined,
+		})
+	})
+
+function generateAncestors(paths) {
+	const urls = []
+	paths.forEach((breadCrumb, i) => {
+		const url = `/${paths.slice(0, i + 1).join("/")}`
+		const label = breadCrumb.replace(/[-_]/g, " ")
+		urls.push({
+			label,
+			url,
+			"aria-current": Astro.url.pathname === url ? "page" : undefined,
+		})
+	})
+	return urls
+}
+
+function capitaliseFirstLetter(string) {
+	const firstLetter = string.charAt(0).toUpperCase()
+	const remainingLetters = string.substring(1)
+	return firstLetter + remainingLetters
+}
+
+const renderSecondaryNav = ancestors.length > 0 && children.length > 0
+---
+
+{
+	renderSecondaryNav && (
+		<nav
+			class="o-header-services__secondary-nav"
+			aria-label="secondary"
+			data-o-header-services-nav="">
+			<div
+				class="o-header-services__secondary-nav-content"
+				data-o-header-services-nav-list="">
+				{ancestors && (
+					<ol
+						class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--ancestors"
+						aria-label="Ancestor sections">
+						{ancestors.map(nav => (
+							<NavItem nav={nav} />
+						))}
+					</ol>
+				)}
+				{children && (
+					<ul
+						class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--children"
+						aria-label="Child sections">
+						{children.map(nav => (
+							<NavItem nav={nav} />
+						))}
+					</ul>
+				)}
+			</div>
+			<button
+				class="o-header-services__scroll-button o-header-services__scroll-button--left"
+				title="scroll left"
+				aria-hidden="true"
+				disabled
+			/>
+			<button
+				class="o-header-services__scroll-button o-header-services__scroll-button--right"
+				title="scroll right"
+				aria-hidden="true"
+				disabled
+			/>
+		</nav>
+	)
+}

--- a/apps/astro-website/src/layouts/Layout.astro
+++ b/apps/astro-website/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import Header from "@/components/Header.astro"
+import Header from "@/components/header/Header.astro"
 import Footer from "@/components/Footer.astro"
 ---
 

--- a/apps/astro-website/src/pages/index.astro
+++ b/apps/astro-website/src/pages/index.astro
@@ -1,9 +1,9 @@
 ---
+import {EMAIL, SLACK} from "@/helpers/variables"
 import Layout from "@/layouts/Layout.astro"
 import HeroImage from "@/components/hero-image.astro"
 
 const title = "Origami"
-const contact = {email: "origami.support@ft.com", slack: "origami-support"}
 ---
 
 <Layout>
@@ -80,12 +80,12 @@ const contact = {email: "origami.support@ft.com", slack: "origami-support"}
 				<ul>
 					<li>
 						There is a community Slack channel named <a
-							href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}"
-							target="_blank">#{contact.slack}</a
+							href={`https://financialtimes.slack.com/messages/${SLACK}`}
+							target="_blank">#{SLACK}</a
 						>
 					</li>
 					<li>
-						There is a <a href="mailto:{contact.email}">mailing list</a> for contacting
+						There is a <a href={`mailto:${EMAIL}`}>mailing list</a> for contacting
 						the Origami Core Team
 					</li>
 				</ul>
@@ -95,9 +95,9 @@ const contact = {email: "origami.support@ft.com", slack: "origami-support"}
 </Layout>
 
 <style lang="scss" is:global>
-// NOTE
-// Some temporary styles just to make this look less awful while
-// we work on it. Remove these as soon as styling work begins
+	// NOTE
+	// Some temporary styles just to make this look less awful while
+	// we work on it. Remove these as soon as styling work begins
 
 	html,
 	body {


### PR DESCRIPTION
## Describe your changes
The header component now automatically generates secondary navigation. Ancestors and children for secondary nav are determined based on the path you are on the URL. This ignores the `/` url and `[slug]` paths.

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [x] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
