### PR TITLE
fix: remove references to deleted notion docs, link to iconography co…

### DIFF
--- a/apps/website/pages/home.html
+++ b/apps/website/pages/home.html
@@ -38,7 +38,7 @@ nav_order: 1
 				You can browse live demos and documentation for Origami components in <a href="https://registry.origami.ft.com/components">the component registry</a>.
 			</p>
 			<p>
-				The Customer Products design team own complimentary tooling/documentation for Newsroom products. This includes  <a href="https://www.figma.com/files/938480807921629744/team/938730024138282825/Design-Systems?fuid=840167457508775739">figma library</a>
+				The Customer Products design team own complimentary tooling/documentation for Newsroom products. This includes a <a href="https://www.figma.com/files/938480807921629744/team/938730024138282825/Design-Systems?fuid=840167457508775739">Figma library</a>.
 			</p>
 			<p>
 				For iconography contribution guides, see <a href="https://github.com/Financial-Times/origami-image-service/blob/main/image-sets/fticon/v1/contributing.md#adding-or-updating-an-icon">our guide on GitHub</a>.

--- a/apps/website/pages/home.html
+++ b/apps/website/pages/home.html
@@ -38,10 +38,10 @@ nav_order: 1
 				You can browse live demos and documentation for Origami components in <a href="https://registry.origami.ft.com/components">the component registry</a>.
 			</p>
 			<p>
-				The Customer Products design team own complimentary tooling/documentation for Newsroom products.
+				The Customer Products design team own complimentary tooling/documentation for Newsroom products. This includes  <a href="https://www.figma.com/files/938480807921629744/team/938730024138282825/Design-Systems?fuid=840167457508775739">figma library</a>
 			</p>
 			<p>
-				This includes further <a href="https://www.notion.so/prd-newsroom/Design-System-35c1fc00fc9d404c8a31a374e2b8c8e4">design system documentation</a> and a <a href="https://www.figma.com/files/938480807921629744/team/938730024138282825/Design-Systems?fuid=840167457508775739">figma library</a>.
+				For iconography contribution guides, see <a href="https://github.com/Financial-Times/origami-image-service/blob/main/image-sets/fticon/v1/contributing.md#adding-or-updating-an-icon">our guide on GitHub</a>.
 			</p>
 		</div>
 


### PR DESCRIPTION
…ntribution guide

## Describe your changes

* Removes references to deleted Notion guide.
* Includes a new link to guides on iconography contribution process.

## Issue ticket number and link
[OR-235](https://financialtimes.atlassian.net/jira/software/c/projects/OR/boards/1658?modal=detail&selectedIssue=OR-235)

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.


[OR-235]: https://financialtimes.atlassian.net/browse/OR-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ