### PR TITLE
fix: re order lists so that the contents are correctly removed when d…

### DIFF
--- a/components/o-grid/README.md
+++ b/components/o-grid/README.md
@@ -22,13 +22,14 @@ A 12 column responsive, flexbox-based grid system for laying out documents, temp
 -   [Contact](#contact)
 -   [Licence](#licence)
 
+This component is a collection of Sass styles to build a 12 column grid system, with a few JavaScript helpers.
+
 Our grid consists of:
 -	12 columns, of equal size
 -	5 layouts (breakpoints) to support devices of various sizes
 -   gutters of variable width, that adjust according to the current layout
 -   a maximum page width of 1220px, by default
 
-This component is a collection of Sass styles to build a 12 column grid system, with a few JavaScript helpers.
 
 [![Grid system](https://raw.githubusercontent.com/Financial-Times/origami/main/components/o-grid/img/grid-system.png)](https://raw.githubusercontent.com/Financial-Times/origami/main/components/o-grid/img/grid-system.png)
 

--- a/components/o-grid/README.md
+++ b/components/o-grid/README.md
@@ -25,10 +25,10 @@ A 12 column responsive, flexbox-based grid system for laying out documents, temp
 This component is a collection of Sass styles to build a 12 column grid system, with a few JavaScript helpers.
 
 Our grid consists of:
--	12 columns, of equal size
--	5 layouts (breakpoints) to support devices of various sizes
--   gutters of variable width, that adjust according to the current layout
--   a maximum page width of 1220px, by default
+-    12 columns, of equal size.
+-    5 layouts (breakpoints) to support devices of various sizes.
+-    Gutters of variable width, that adjust according to the current layout.
+-    A maximum page width of 1220px, by default.
 
 
 [![Grid system](https://raw.githubusercontent.com/Financial-Times/origami/main/components/o-grid/img/grid-system.png)](https://raw.githubusercontent.com/Financial-Times/origami/main/components/o-grid/img/grid-system.png)

--- a/components/o-grid/README.md
+++ b/components/o-grid/README.md
@@ -2,12 +2,6 @@
 
 A 12 column responsive, flexbox-based grid system for laying out documents, templates and components.
 
-Our grid consists of:
-- 12 columns, of equal size
-- 5 layouts (breakpoints) to support devices of various sizes
-- gutters of variable width, that adjust according to the current layout
-- a maximum page width of 1220px, by default
-
 -   [Usage](#usage)
 -   [Quick Start](#quick-start)
 -   [Grid dimensions](#grid-dimensions)
@@ -27,6 +21,12 @@ Our grid consists of:
 -   [Migration](#migration)
 -   [Contact](#contact)
 -   [Licence](#licence)
+
+Our grid consists of:
+-	12 columns, of equal size
+-	5 layouts (breakpoints) to support devices of various sizes
+-   gutters of variable width, that adjust according to the current layout
+-   a maximum page width of 1220px, by default
 
 This component is a collection of Sass styles to build a 12 column grid system, with a few JavaScript helpers.
 


### PR DESCRIPTION
…isplayed on the registry

## Describe your changes

With the previous release, the first list is omitted when rendered on the Registry.

<img width="1281" alt="image" src="https://github.com/Financial-Times/origami/assets/7166831/d7ca0c9b-0582-4f42-967e-8fcd11a162bd">

This is because the Registry's readme builder will [remove the first list in the rendered HTML](https://github.com/Financial-Times/origami-registry-ui/blob/e0198010cdb31b2cff1f49ba4cb7ad039f856adf/lib/code-docs/readme/index.js#L49). The MD parser seems to have merged this first list with the contents, and as the above code is identifying the whole block as the Nav, it removes it.

Re-ordering this so that the copy list comes after the content list should fix this.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
