### PR TITLE
backstage: rename conflicting CI job names

### DIFF
--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  check-monorepo-config:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check-privacy.yml
+++ b/.github/workflows/check-privacy.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  check-privacy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Describe your changes

There are multiple jobs called `test`. We also have a branch protection rule that requires a job called `test` to pass to allow merging.

This means any of the `test` jobs can pass for this to merge. The rule should point to unique jobs so that test suites must run.

I.e, with the current setup, someone could delete the actual [test](https://github.com/Financial-Times/origami/blob/main/.github/workflows/test.yml#L182) job and still merge because the `check-config.yml` and `check-privacy.yml` both contain `test` jobs. 

Branch protection rules will also be updated to ensure these other two test jobs are requires before merging.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
