### PR TITLE
backstage: update md frontmatter and render blogs correctly

### DIFF
--- a/apps/astro-website/README.md
+++ b/apps/astro-website/README.md
@@ -28,9 +28,7 @@ The formal Origami specification lives in the [`_specification-v1` folder](_spec
 
 ### Blog posts
 
-[TODO]
-
-Blog posts live in the [`_posts` folder](_posts) and the file names are prefixed with the post date. Posts can include an `author` frontmatter value to signify who wrote the post, and an array of `tags` which are displayed alongside the post. The `description` frontmatter is particularly important for blog posts as it is displayed as a preview on the blog listing.
+Blog posts live in the [`posts` folder](src/content/posts) and the file names are prefixed with the post date. Posts can include an `author` frontmatter value to signify who wrote the post, and an array of `tags` which are displayed alongside the post. The `description` frontmatter is particularly important for blog posts as it is displayed as a preview on the blog listing. The `publishDate` frontmatter for a date that newsletter was published. And `tldr` frontmatter is used to display a summary of the post before the main content. If it is omitted the description will be used instead.
 
 Newsletter blog posts must have an accompanying email, this is outlined in the section ["Authoring and sending a newsletter"](#authoring-and-sending-a-newsletter).
 
@@ -44,8 +42,8 @@ The process:
 
 1. Branch off `main` and create the required files. The format for the newsletter is strict, and you should probably copy an older newsletter to make sure it's correct. You need to create two files in this repo, replacing the date as appropriate (set to the expected published date):
 
-   - `_posts/YYYY-MM-DD-newsletter.md`: for the blog post on the website
-   - `_emails/newsletter-YYYY-MM.html`: for the email we distribute
+   - `src/content/posts/YYYY-MM-DD-newsletter.md`: for the blog post on the website
+   - `src/content/emails/newsletter-YYYY-MM.html`: for the email we distribute
 
 2. Write the newsletter. This is best done in the blog post, as this is standard Markdown. The email newsletter relies on some pretty gross Liquid templating to ensure that we avoid copy/paste errors in the HTML. Sorry. The email also has required front-matter: a `title` which becomes the subject of the email, and `companion_post_url` which is used to link to the blog post and should be the full URL. (when writing the newsletter, see the script `./scripts/project-board-summary.js` to help fill out the broader update section of the newsletter).
 

--- a/apps/astro-website/src/content/config.js
+++ b/apps/astro-website/src/content/config.js
@@ -8,6 +8,7 @@ const postsCollection = defineCollection({
 		publishDate: z.date(),
 		author: z.string(),
 		tags: z.array(z.string()).optional(),
+		tldr: z.string().optional(),
 	}),
 })
 

--- a/apps/astro-website/src/content/posts/2019-01-30-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-01-30-newsletter.md
@@ -5,12 +5,10 @@ author: Rowan Manning
 publishDate: 2019-01-30
 tags:
   - Newsletter
+tldr: This issue features a new component named o-stepped-progress, for tracking user progress through a multi-step process; a new beta for o-header-services, including new features and a lot of code improvements; and the release of the Polyfill Service v3, which is faster and more maintainable than ever before.
 ---
 
 _Welcome to the first issue of the Origami Newsletter! We'll be sending out an email like this at the end of each month, keeping people in Product and Technology up-to-date with what we're working on._
-
-**TL;DR:** This issue features a new component named o-stepped-progress, for tracking user progress through a multi-step process; a new beta for o-header-services, including new features and a lot of code improvements; and the release of the Polyfill Service v3, which is faster and more maintainable than ever before.
-
 
 ## Top three things
 

--- a/apps/astro-website/src/content/posts/2019-02-28-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-02-28-newsletter.md
@@ -5,10 +5,8 @@ author: Lee Moody
 publishDate: 2019-02-28
 tags:
   - Newsletter
+tldr: This issue features Origami components on npm; the release of o-layout v3, which includes two new layouts to help build internal tools and products; and the release of o-header-services v3, which includes new features, customisation, and a lot of code improvements.
 ---
-
-**TL;DR:** This issue features Origami components on npm; the release of o-layout v3, which includes two new layouts to help build internal tools and products; and the release of o-header-services v3, which includes new features, customisation, and a lot of code improvements.
-
 
 ## Top three things
 

--- a/apps/astro-website/src/content/posts/2019-03-11-site-update.md
+++ b/apps/astro-website/src/content/posts/2019-03-11-site-update.md
@@ -3,9 +3,8 @@ title: Origami Site Update
 description: We re-launched the Origami website and Origami component registry.
 publishDate: 2019-03-11
 author: Lee Moody
+tldr: We re-launched the [Origami website](/) and [Origami component registry](https://registry.origami.ft.com/components) with a unified design; overhauled documentation; refined specifications; and a new site structure to bring it all together.
 ---
-
-**TL;DR:** We re-launched the [Origami website](/) and [Origami component registry](https://registry.origami.ft.com/components) with a unified design; overhauled documentation; refined specifications; and a new site structure to bring it all together.
 
 ## Motivation &amp; Goals
 

--- a/apps/astro-website/src/content/posts/2019-03-29-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-03-29-newsletter.md
@@ -5,9 +5,9 @@ author: Gabrielle von Koss
 publishDate: 2019-03-29
 tags:
   - Newsletter
+tldr: This issue features the new Origami website with a new design and new documentation, a highlight of the improved service that the Polyfill Service provides, and an explanation of how ECMAScript Modules broke our components.
 ---
 
-**TL;DR:** This issue features the new Origami website with a new design and new documentation, a highlight of the improved service that the Polyfill Service provides, and an explanation of how ECMAScript Modules broke our components.
 
 ## Top three things
 

--- a/apps/astro-website/src/content/posts/2019-04-30-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-04-30-newsletter.md
@@ -7,8 +7,6 @@ tags:
   - Newsletter
 ---
 
-**TL;DR:** This issue features improvements to the image service, a new table filtering feature, and two new browser polyfills.
-
 ## Top three things
 
 These are some of the bigger things we've worked on or released over the last month.

--- a/apps/astro-website/src/content/posts/2019-05-31-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-05-31-newsletter.md
@@ -7,8 +7,6 @@ tags:
   - Newsletter
 ---
 
-**TL;DR:** This issue features a new and improved version of o-forms, a new component o-spacing, and fancy new features to our colour contrast checker.
-
 ## Top three things
 
 These are some of the bigger things we've worked on or released over the last month.

--- a/apps/astro-website/src/content/posts/2019-06-28-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-06-28-newsletter.md
@@ -7,8 +7,6 @@ tags:
   - Newsletter
 ---
 
-**TL;DR:** This issue announces a new team member, covers improvements to our operational documentation, and some projects that we built in our 10% time.
-
 ## Top three things
 
 These are some of the bigger things we've done over the last month.

--- a/apps/astro-website/src/content/posts/2019-07-31-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-07-31-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top three things
 

--- a/apps/astro-website/src/content/posts/2019-10-31-newsletter.md
+++ b/apps/astro-website/src/content/posts/2019-10-31-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-01-31-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-01-31-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 
 ## Top three things

--- a/apps/astro-website/src/content/posts/2020-03-02-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-03-02-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 
 ## Top three things

--- a/apps/astro-website/src/content/posts/2020-04-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-04-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-05-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-05-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-06-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-06-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-07-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-07-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-08-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-08-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 
@@ -61,7 +57,7 @@ A digest of other things that have happened since our last update:
 
 - NEW: [remark-preset-lint-origami-component](https://github.com/Financial-Times/remark-preset-lint-origami-component): A tool used by Origami Build Tools to verify component readme.
 - MINOR: [origami-build-tools](https://github.com/Financial-Times/origami-build-tools) has a fix to allow for custom `.eslintrc.js` configuration; does not load JavaScript in demos for core experience browsers; and now lints the readme as discussed previously.
-- MINOR: [create-origami-component](https://github.com/Financial-Times/create-origami-component) has been updated with fixes and improvements to support the creation of new Origami components (see the tutorial discussed previously). 
+- MINOR: [create-origami-component](https://github.com/Financial-Times/create-origami-component) has been updated with fixes and improvements to support the creation of new Origami components (see the tutorial discussed previously).
 - MINOR: [Polyfill Service](https://github.com/Financial-Times/polyfill-service) now includes a security policy.
 - MINOR: [polyfill-library](https://github.com/Financial-Times/polyfill-library) improves the message when no polyfills are required to be served to the requesting browser, fixes a `Promise.prototype.finally` support for Chrome 63, fixes a `Map` bug (thanks to external contributions from Github users joshsalverda and rmja).
 - MINOR: [o-date](https://github.com/Financial-Times/o-date) can now output multiple formats within one `time` element.

--- a/apps/astro-website/src/content/posts/2020-09-04-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-09-04-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-10-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-10-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-10-28-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-10-28-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2020-12-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2020-12-01-newsletter.md
@@ -7,11 +7,7 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
+
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2021-03-02-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-03-02-newsletter.md
@@ -7,12 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top Things
 
 Some of the bigger Origami news since our last issue:

--- a/apps/astro-website/src/content/posts/2021-04-12-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-04-12-newsletter.md
@@ -7,11 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
 
 ## Top things
 

--- a/apps/astro-website/src/content/posts/2021-06-01-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-06-01-newsletter.md
@@ -7,16 +7,9 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news from the last month:
-
 
 ### The Origami specification is no more
 

--- a/apps/astro-website/src/content/posts/2021-06-30-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-06-30-newsletter.md
@@ -7,12 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news from the last month:

--- a/apps/astro-website/src/content/posts/2021-08-09-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-08-09-newsletter.md
@@ -7,11 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-	<strong>
-	TL;DR:
-	</strong>
-</abbr> {{page.description}}
 
 ## Top Things
 

--- a/apps/astro-website/src/content/posts/2021-10-05-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-10-05-newsletter.md
@@ -7,16 +7,9 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news from the last month:
-
 
 ### The Origami Component System
 

--- a/apps/astro-website/src/content/posts/2021-11-05-newsletter.md
+++ b/apps/astro-website/src/content/posts/2021-11-05-newsletter.md
@@ -7,12 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news from the last month:

--- a/apps/astro-website/src/content/posts/2022-01-28-newsletter.md
+++ b/apps/astro-website/src/content/posts/2022-01-28-newsletter.md
@@ -7,12 +7,6 @@ tags:
 - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news from the last month:

--- a/apps/astro-website/src/content/posts/2022-03-30-newsletter.md
+++ b/apps/astro-website/src/content/posts/2022-03-30-newsletter.md
@@ -7,12 +7,6 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news since our last update:

--- a/apps/astro-website/src/content/posts/2022-12-14-focus-styles.md
+++ b/apps/astro-website/src/content/posts/2022-12-14-focus-styles.md
@@ -3,13 +3,8 @@ title: Updated Focus Styles
 description: We've released new focus styles to improve the accessibility of FT Group products which use Origami.
 author: Lee Moody
 publishDate: 2022-12-14
+tldr: We've released new focus styles to improve the accessibility of FT Group products which use Origami. These changes will roll out gradually as teams [pull in the latest Origami component releases](#upgrade-your-project). We're treating this as a minor release and there should be no code changes required to upgrade. However, this is a broad, global change and we encourage teams to [test focus states](#upgrade-your-project) within their projects – the Origami team are here to help if you have any questions, or spot any issues.
 ---
-
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> We've released new focus styles to improve the accessibility of FT Group products which use Origami. These changes will roll out gradually as teams [pull in the latest Origami component releases](#upgrade-your-project). We're treating this as a minor release and there should be no code changes required to upgrade. However, this is a broad, global change and we encourage teams to [test focus states](#upgrade-your-project) within their projects – the Origami team are here to help if you have any questions, or spot any issues.
 
 ## What are focus styles?
 

--- a/apps/astro-website/src/content/posts/2023-01-30-newsletter.md
+++ b/apps/astro-website/src/content/posts/2023-01-30-newsletter.md
@@ -7,11 +7,6 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
 
 ## Top things
 

--- a/apps/astro-website/src/content/posts/2023-03-03-newsletter.md
+++ b/apps/astro-website/src/content/posts/2023-03-03-newsletter.md
@@ -7,11 +7,6 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
 
 ## Top things
 

--- a/apps/astro-website/src/content/posts/2023-03-29-newsletter.md
+++ b/apps/astro-website/src/content/posts/2023-03-29-newsletter.md
@@ -7,12 +7,6 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news since our last update:

--- a/apps/astro-website/src/content/posts/2023-05-31-newsletter.md
+++ b/apps/astro-website/src/content/posts/2023-05-31-newsletter.md
@@ -7,12 +7,6 @@ tags:
   - Newsletter
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> {{page.description}}
-
 ## Top things
 
 Some of the bigger Origami news since our last update:

--- a/apps/astro-website/src/content/posts/2023-06-21-sass.md
+++ b/apps/astro-website/src/content/posts/2023-06-21-sass.md
@@ -5,13 +5,9 @@ author: Lee Moody
 publishDate: 2023-06-21
 tags:
   - Sass
+tldr: There's a bunch of reasons it would be desirable to drop Sass. Though there are some complexities and caveats to think through, I think now could be the time. Starting with Origami. Please send your thoughts and feedback, and keep an eye on future TGG (technical governance group) proposals.
 ---
 
-<abbr title="Too long; didn't read">
-<strong>
-TL;DR:
-</strong>
-</abbr> There's a bunch of reasons it would be desirable to drop Sass. Though there are some complexities and caveats to think through, I think now could be the time. Starting with Origami. Please send your thoughts and feedback, and keep an eye on future TGG (technical governance group) proposals.
 
 ## What is Sass
 

--- a/apps/astro-website/src/helpers/utils.js
+++ b/apps/astro-website/src/helpers/utils.js
@@ -32,3 +32,10 @@ export function convertToSlug(Text) {
 		.replace(/ /g, "-")
 		.replace(/[^\w-]+/g, "")
 }
+
+export function generateBlogPostURL(slug) {
+	return slug.replace(
+		/([\d]{4})-([\d]{2})-([\d]{2})-(.*)/g,
+		"$1/$2/$3/$4"
+	)
+}

--- a/apps/astro-website/src/helpers/utils.js
+++ b/apps/astro-website/src/helpers/utils.js
@@ -26,3 +26,9 @@ export function formatDateString(date) {
 	const day = newDate.getDate()
 	return `${day} ${month} ${year}`
 }
+
+export function convertToSlug(Text) {
+	return Text.toLowerCase()
+		.replace(/ /g, "-")
+		.replace(/[^\w-]+/g, "")
+}

--- a/apps/astro-website/src/pages/blog/[...slug].astro
+++ b/apps/astro-website/src/pages/blog/[...slug].astro
@@ -2,12 +2,14 @@
 import {getCollection} from "astro:content"
 import DocLayout from "@/layouts/DocLayout.astro"
 
-import {convertToSlug, formatDateString} from "@/helpers/utils"
+import {convertToSlug, formatDateString, generateBlogPostURL} from "@/helpers/utils"
 
 export async function getStaticPaths() {
 	const postEntries = await getCollection("posts")
 	return postEntries.map(entry => ({
-		params: {slug: entry.slug},
+		params: {
+			slug: generateBlogPostURL(entry.slug),
+		},
 		props: {entry},
 	}))
 }
@@ -17,7 +19,6 @@ const {Content} = await entry.render()
 const slugifiedName = convertToSlug(entry.data.title)
 const formatedDateString = formatDateString(entry.data.publishDate)
 const tags = entry.data.tags.length > 0 && entry.data.tags.join(",")
-
 ---
 
 <DocLayout>
@@ -48,7 +49,7 @@ const tags = entry.data.tags.length > 0 && entry.data.tags.join(",")
 	{}
 	<p>
 		<abbr title="Too long; didn't read">
-			<strong>TL;DR: </strong>
+			<strong>TL;DR:</strong>
 		</abbr>{entry.data.tldr || entry.data.description}
 	</p>
 	<Content />

--- a/apps/astro-website/src/pages/blog/[slug].astro
+++ b/apps/astro-website/src/pages/blog/[slug].astro
@@ -1,6 +1,8 @@
 ---
-import DocLayout from "@/layouts/DocLayout.astro"
 import {getCollection} from "astro:content"
+import DocLayout from "@/layouts/DocLayout.astro"
+
+import {convertToSlug, formatDateString} from "@/helpers/utils"
 
 export async function getStaticPaths() {
 	const postEntries = await getCollection("posts")
@@ -12,9 +14,42 @@ export async function getStaticPaths() {
 
 const {entry} = Astro.props
 const {Content} = await entry.render()
+const slugifiedName = convertToSlug(entry.data.title)
+const formatedDateString = formatDateString(entry.data.publishDate)
+const tags = entry.data.tags.length > 0 && entry.data.tags.join(",")
+
 ---
 
 <DocLayout>
-	<h1>{entry.data.title}</h1>
+	<h1 id={slugifiedName} class="o-layout__linked-heading">
+		<a
+			href={`#${slugifiedName}`}
+			title="Link directly to this section of the page"
+			class="o-layout__linked-heading__link"
+		>
+			<span class="o-layout__linked-heading__content">{entry.data.title}</span>
+			<span class="o-layout__linked-heading__label">#</span>
+		</a>
+	</h1>
+	<p>
+		Posted on <time datetime={entry.data.datePublished}
+			>{formatedDateString}</time
+		>
+		by {entry.data.author}.
+		{
+			tags && (
+				<>
+					<br />
+					Tagged with <span>{tags}</span>
+				</>
+			)
+		}
+	</p>
+	{}
+	<p>
+		<abbr title="Too long; didn't read">
+			<strong>TL;DR: </strong>
+		</abbr>{entry.data.tldr || entry.data.description}
+	</p>
 	<Content />
 </DocLayout>

--- a/apps/astro-website/src/pages/blog/index.astro
+++ b/apps/astro-website/src/pages/blog/index.astro
@@ -1,6 +1,6 @@
 ---
 import {getCollection} from "astro:content"
-import {formatDateString} from "@/helpers/utils"
+import {formatDateString, generateBlogPostURL} from "@/helpers/utils"
 import Layout from "@/layouts/Layout.astro"
 
 const allPosts = await getCollection("posts")
@@ -25,7 +25,7 @@ const sortedPosts = allPosts.sort(
 					return (
 						<li class="o-layout__listing__item">
 							<h2 class="o-layout__listing__item__title">
-								<a href={post.slug}>{post.data.title}</a>
+								<a href={"blog/" + generateBlogPostURL(post.slug)}>{post.data.title}</a>
 							</h2>
 							{post.data.description.length !== 0 && (
 								<p class="o-layout__listing__item__description">


### PR DESCRIPTION
## Describe your changes
Update newsletters frontmatter and use `tldr` as one of the variables. This pr changes how routing works compared to the old website. ~~In old website pathname for a blog post is determined by publish date and tags (for example `blog/2023/06/21/sass/`) but in Astro, these paths are updated to `blog/2023-06-21-sass`. if we want to keep the original routing we have to create folders in the Astro pages folder for each of them. We are kind of forced to use a new way of routing. Hopefully, this won't be too problematic. and possibly we might want to redirect from old routes to this.~~ this was reverted by last commit so not relevant anymore 

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [x] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
