### PR TITLE
fix: the link on principles

### DIFF
--- a/apps/astro-website/src/pages/documentation/index.astro
+++ b/apps/astro-website/src/pages/documentation/index.astro
@@ -48,10 +48,13 @@ const tutorialDocuments = await Astro.glob(
 					when developing components and services:
 				</p>
 				<ul>
+					<!-- this is for main page of documentation-principles-->
 					{
 						allPrinciples.map(principle => (
 							<li>
-								<a href={`/documentation/${principle.slug}`}>{principle.data.title}</a>
+								<a href={`/documentation/${principle.slug}/`}>
+									{principle.data.title}
+								</a>
 							</li>
 						))
 					}

--- a/apps/astro-website/src/pages/documentation/principles/index.astro
+++ b/apps/astro-website/src/pages/documentation/principles/index.astro
@@ -30,12 +30,15 @@ const allPrinciples = await getCollection("documents", ({id}) =>
 			somebody trying to transfer their code to be maintained by the team.
 		</p>
 		{
+			// this is inside the principles page that shows the nav and the description
 			allPrinciples.map(principle => {
 				return (
 					<>
 						<h2 id={principle.data.title} class="o-layout__linked-heading">
 							<a
-								href={`#${principle.data.title}`}
+								href={`#${principle.data.title
+									.toLowerCase()
+									.replace(/ /g, "_")}`}
 								title="Link directly to this section of the page"
 								class="o-layout__linked-heading__link">
 								<span class="o-layout__linked-heading__content">
@@ -46,7 +49,7 @@ const allPrinciples = await getCollection("documents", ({id}) =>
 						</h2>
 						<p>
 							{principle.data.description}
-							<a href={principle.slug.split("/")[1]}>
+							<a href={principle.slug.split("/")[1] + "/"}>
 								{" " + principle.data.cta}
 							</a>
 						</p>


### PR DESCRIPTION
## Describe your changes
the links for documentation/principles/#.... sometimes show the spaces between the words like 
```documentation/principles/#Tone%20&%20language```
I could correct most of them but the last part that is left is when you click on links on the nav bar on the left side of principle page (/documentation/principles/) and they show the wrong format as I showed above 👆 . 

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
