### PR TITLE
chore: o-icons, release 7.6.0 not 8.0.0

### DIFF
--- a/components/o-icons/README.md
+++ b/components/o-icons/README.md
@@ -128,8 +128,8 @@ If you need to remove an icon from `o-icons` you run `node ./scripts/build-icon-
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
 ✨ active | 7 | N/A  | [migrate to v6](MIGRATION.md#migrating-from-v6-to-v7) |
-✨ active | 6 | 6.3  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-⚠ maintained | 5 | 5.9  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+⚠ maintained | 6 | 6.3  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+╳ deprecated | 5 | 5.9  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 ╳ deprecated | 4 | 4.5  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 ╳ deprecated | 3 | 3.3 | - |
 ╳ deprecated | 2 | 2.4 | - |


### PR DESCRIPTION
Release Please is [trying to release o-icons v8 ](https://github.com/Financial-Times/origami/pull/1227) due to an incorrect commit message in our history. It keeps trying. I wonder if explicitly requesting the release of o-icons current version will prevent this, or... cause more problems.
Let's find out.

https://github.com/googleapis/release-please#how-do-i-change-the-version-number
