### PR TITLE
fix: o-social-follow, update Twitter branding to X [OR-296]

### DIFF
--- a/components/o-social-follow/README.md
+++ b/components/o-social-follow/README.md
@@ -47,7 +47,7 @@ The next example shows multiple social media links.
 ```html
 <section class="o-social-follow" aria-label="Follow on social media">
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--twitter">
-		<span class="o-social-follow-icon__label">on twitter</span>
+		<span class="o-social-follow-icon__label">on X, formally know as Twitter</span>
 	</a>
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--facebook">
 		<span class="o-social-follow-icon__label">on facebook</span>

--- a/components/o-social-follow/README.md
+++ b/components/o-social-follow/README.md
@@ -47,7 +47,7 @@ The next example shows multiple social media links.
 ```html
 <section class="o-social-follow" aria-label="Follow on social media">
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--twitter">
-		<span class="o-social-follow-icon__label">on X, formally know as Twitter</span>
+		<span class="o-social-follow-icon__label">on X, formerly know as Twitter</span>
 	</a>
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--facebook">
 		<span class="o-social-follow-icon__label">on facebook</span>

--- a/components/o-social-follow/demos/src/social-follow.mustache
+++ b/components/o-social-follow/demos/src/social-follow.mustache
@@ -1,6 +1,6 @@
 <section class="o-social-follow"  aria-label="Follow on social media">
 	<a href="#" class="o-social-follow-icon {{#standalone}}o-social-follow-icon--standalone {{/standalone}}{{#inverse}}o-social-follow-icon--inverse {{/inverse}}o-social-follow-icon--twitter">
-		<span class="o-social-follow-icon__label">on twitter</span>
+		<span class="o-social-follow-icon__label">on X, formerly known as Twitter</span>
 	</a>
 	<a href="#" class="o-social-follow-icon {{#standalone}}o-social-follow-icon--standalone {{/standalone}}{{#inverse}}o-social-follow-icon--inverse {{/inverse}}o-social-follow-icon--facebook">
 		<span class="o-social-follow-icon__label">on facebook</span>

--- a/components/o-social-follow/package.json
+++ b/components/o-social-follow/package.json
@@ -8,6 +8,7 @@
     "social",
     "facebook",
     "twitter",
+    "x",
     "linkedin",
     "whatsapp",
     "instagram"

--- a/components/o-social-follow/src/scss/_variables.scss
+++ b/components/o-social-follow/src/scss/_variables.scss
@@ -2,7 +2,7 @@
 /// @type Map
 /// @access private
 $_o-social-follow-icons: (
-	twitter: #1da1f2,
+	twitter: #000000,
 	facebook: #3b579d,
 	linkedin: #0077b5,
 	youtube: #ff0000,

--- a/components/o-social-follow/src/tsx/social-follow.tsx
+++ b/components/o-social-follow/src/tsx/social-follow.tsx
@@ -24,8 +24,9 @@ export function SocialFollow({
 	return (
         <section className="o-social-follow"  aria-label="Follow on social media">
             {icons.map(icon => {
+                const iconDescription = icon === 'twitter' ? `on X, formerly known as Twitter` : `on ${icon}`;
                 return <a href="#" className={[...iconClassNames, `o-social-follow-icon--${icon}`].join(' ')}>
-                    <span className="o-social-follow-icon__label">on {icon}</span>
+                    <span className="o-social-follow-icon__label">{iconDescription}</span>
                 </a>
             })}
         </section>


### PR DESCRIPTION
I decided to make this a minor release, without removing Twitter from the API entirely, as SVG is not currently inlined for this component. It's already using the `x` logo from the Image Service update and we only need to replace the twitter blue with black.