### PR TITLE
feat: add show search bar prop to header

### DIFF
--- a/components/o-header/README.md
+++ b/components/o-header/README.md
@@ -42,6 +42,14 @@ const headerEl = document.querySelector('.o-header');
 const header = new oHeader(headerEl);
 ```
 
+you can have the search-bar open by default 
+
+```js
+import Header from '@financial-times/o-header';
+const headerEl = document.querySelector('.o-header');
+const header = new oHeader(headerEl, { searchBarOpen: true });
+```
+
 Alternatively, a `o.DOMContentLoaded` event can be dispatched on the document to auto-construct an o-header object for each element with a `data-o-component="o-header"` attribute:
 
 ```js

--- a/components/o-header/README.md
+++ b/components/o-header/README.md
@@ -37,15 +37,17 @@ Some elements inside the header require specific data attributes so the JavaScri
 An o-header object must be constructed for every `<header>` you have on your page that uses this component.
 
 ```js
-import Header from '@financial-times/o-header';
+import oHeader from '@financial-times/o-header';
 const headerEl = document.querySelector('.o-header');
 const header = new oHeader(headerEl);
 ```
 
-you can have the search-bar open by default 
+The oHeader constructor accepts an optional options object, used to control certain behaviors:
+
+- searchBarOpen determines whether the header's search bar is immediately visible. Defaults to false.
 
 ```js
-import Header from '@financial-times/o-header';
+import oHeader from '@financial-times/o-header';
 const headerEl = document.querySelector('.o-header');
 const header = new oHeader(headerEl, { searchBarOpen: true });
 ```

--- a/components/o-header/src/js/header.js
+++ b/components/o-header/src/js/header.js
@@ -6,7 +6,7 @@ import sticky from './sticky.js';
 
 class Header {
 
-	constructor (headerEl, config = {}) {
+	constructor (headerEl, options = {}) {
 		if (!headerEl) {
 			headerEl = document.querySelector('[data-o-component="o-header"]');
 		} else if (typeof headerEl === 'string') {
@@ -19,7 +19,7 @@ class Header {
 
 		this.headerEl = headerEl;
 
-		search.init(this.headerEl, config);
+		search.init(this.headerEl, options);
 		mega.init(this.headerEl);
 		drawer.init(this.headerEl);
 		subnav.init(this.headerEl);
@@ -29,7 +29,7 @@ class Header {
 		this.headerEl.setAttribute('data-o-header--js', '');
 	}
 
-	static init (rootEl, config = {}) {
+	static init (rootEl, options = {}) {
 		if (!rootEl) {
 			rootEl = document.body;
 		}
@@ -37,12 +37,12 @@ class Header {
 			rootEl = document.querySelector(rootEl);
 		}
 		if (/\bo-header\b/.test(rootEl.getAttribute('data-o-component'))) {
-			return new Header(rootEl, config);
+			return new Header(rootEl, options);
 		}
 
 		return [].map.call(rootEl.querySelectorAll('[data-o-component="o-header"]'), el => {
 			if (!el.hasAttribute('data-o-header--js')) {
-				return new Header(el, config);
+				return new Header(el, options);
 			}
 		}).filter((header) => {
 			return header !== undefined;

--- a/components/o-header/src/js/header.js
+++ b/components/o-header/src/js/header.js
@@ -6,7 +6,7 @@ import sticky from './sticky.js';
 
 class Header {
 
-	constructor (headerEl) {
+	constructor (headerEl, config = {}) {
 		if (!headerEl) {
 			headerEl = document.querySelector('[data-o-component="o-header"]');
 		} else if (typeof headerEl === 'string') {
@@ -19,7 +19,7 @@ class Header {
 
 		this.headerEl = headerEl;
 
-		search.init(this.headerEl);
+		search.init(this.headerEl, config);
 		mega.init(this.headerEl);
 		drawer.init(this.headerEl);
 		subnav.init(this.headerEl);
@@ -29,7 +29,7 @@ class Header {
 		this.headerEl.setAttribute('data-o-header--js', '');
 	}
 
-	static init (rootEl) {
+	static init (rootEl, config = {}) {
 		if (!rootEl) {
 			rootEl = document.body;
 		}
@@ -37,12 +37,12 @@ class Header {
 			rootEl = document.querySelector(rootEl);
 		}
 		if (/\bo-header\b/.test(rootEl.getAttribute('data-o-component'))) {
-			return new Header(rootEl);
+			return new Header(rootEl, config);
 		}
 
 		return [].map.call(rootEl.querySelectorAll('[data-o-component="o-header"]'), el => {
 			if (!el.hasAttribute('data-o-header--js')) {
-				return new Header(el);
+				return new Header(el, config);
 			}
 		}).filter((header) => {
 			return header !== undefined;

--- a/components/o-header/src/js/search.js
+++ b/components/o-header/src/js/search.js
@@ -1,6 +1,6 @@
 import Toggle from '@financial-times/o-toggle';
 
-function init (headerEl) {
+function init (headerEl, { searchBarOpen: isOpen } = {}) {
 	const target = headerEl.querySelector('[data-o-header-search]');
 	const controls = target && headerEl.querySelectorAll(`[aria-controls="${target.id}"]`);
 
@@ -24,7 +24,7 @@ function init (headerEl) {
 	};
 
 	for (let i = 0, len = controls.length; i < len; i++) {
-		new Toggle(controls[i], { target, callback });
+		new Toggle(controls[i], { target, callback, isOpen });
 	}
 }
 

--- a/components/o-header/stories/header.stories.tsx
+++ b/components/o-header/stories/header.stories.tsx
@@ -28,7 +28,7 @@ export default {
 } as ComponentMeta<typeof MainHeader>;
 
 export const HeaderPrimary: ComponentStory<typeof MainHeader> = args => {
-	useEffect(() => void javascript.init(), []);
+	useEffect(() => void javascript.init(undefined, { searchBarOpen: true }), []);
 	return (
 		<>
 			<MainHeader {...args} />

--- a/components/o-toggle/README.md
+++ b/components/o-toggle/README.md
@@ -93,6 +93,23 @@ const toggle = new Toggle(toggleEl, {
 	});
 ```
 
+Or, you can have the target opened by default 
+```js
+import Toggle from '@financial-times/o-toggle';
+const toggleEl = document.querySelector('.o-toggle');
+const toggle = new Toggle(toggleEl, {
+		target: '.my-target',
+		isOpen: true,
+		callback: function(state, event) {
+			if (state === 'open') {
+				console.log('Target opened');
+			} else if (state === 'close') {
+				console.log('Target closed');
+			}
+		}
+	});
+```
+
 A second parameter can be passed to the oToggle constructor or to the `.init()` function with a config object that has the following options:
 
 -   _target_: HTMLElement or selector of the element that will be toggled

--- a/components/o-toggle/README.md
+++ b/components/o-toggle/README.md
@@ -93,7 +93,7 @@ const toggle = new Toggle(toggleEl, {
 	});
 ```
 
-Or, you can have the target opened by default 
+Toggle can determines whether the target immediately in open state using isOpen. Defaults to false.
 ```js
 import Toggle from '@financial-times/o-toggle';
 const toggleEl = document.querySelector('.o-toggle');

--- a/components/o-toggle/src/js/toggle.js
+++ b/components/o-toggle/src/js/toggle.js
@@ -94,7 +94,12 @@ class Toggle {
 		}
 
 		this.target.addToggle(this);
-		this.target.close();
+
+		if (config.isOpen) {
+			this.target.open();
+		} else {
+			this.target.close();
+		}
 	}
 
 	open() {


### PR DESCRIPTION
## Describe your changes
We in professional-life-cycle team are conducting an new test for enhanced search and we need the header to have the ability to be shown by default via a prop

In this PR I have added a config object to the Header component in the config I have added a prop **searchBarOpen** to control if the search-bar would be opened by default or not the default behavior for the header is still the same the new feature will only work when **searchBarOpen=true**

I have also added a new prop to o-toggle **isOpened** to determine if the target is open by default or not

## Issue ticket number and link
[ELES-701](https://financialtimes.atlassian.net/browse/ELES-701)

## Link to Figma designs
https://www.figma.com/file/Hjz28uiQqs8pxUm6X7fCG5/FT.com_Search_Test?node-id=46%3A4083&mode=dev

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [X] I have updated the relevant docs

[ELES-701]: https://financialtimes.atlassian.net/browse/ELES-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ