### PR TITLE
**Do not merge**: add demo to buttons and forms for FT Live / Community 

### DIFF
--- a/components/o-buttons/demos/src/demo.scss
+++ b/components/o-buttons/demos/src/demo.scss
@@ -56,6 +56,7 @@ p {
 		'b2c',
 		'professional',
 		'professional-inverse',
+		'community'
 	),
 	'icons': join($_o-buttons-icons, ('book')), // Also include the book icon, which is not in the defaut set.
 	'pagination': true,

--- a/components/o-buttons/src/scss/_brand.scss
+++ b/components/o-buttons/src/scss/_brand.scss
@@ -49,6 +49,10 @@ $_o-buttons-shared-brand-config: (
 				'color': 'slate',
 				'context': 'paper'
 			),
+			'community': (
+				'color': 'ft-pink',
+				'context': 'slate'
+			),
 			'professional-inverse': (
 				'color': 'mint',
 				'context': 'slate'
@@ -62,12 +66,14 @@ $_o-buttons-shared-brand-config: (
 			'secondary',
 			'primary-b2c',
 			'primary-professional',
+			'primary-community',
 			'primary-professional-inverse',
 			'primary-inverse',
 			'primary-mono',
 			'secondary-inverse',
 			'secondary-mono',
 			'secondary-professional',
+			'secondary-community',
 			'secondary-professional-inverse',
 			'ghost',
 			'ghost-inverse',

--- a/components/o-buttons/src/scss/_brand.scss
+++ b/components/o-buttons/src/scss/_brand.scss
@@ -79,7 +79,8 @@ $_o-buttons-shared-brand-config: (
 			'ghost-inverse',
 			'ghost-mono',
 			'ghost-professional',
-			'ghost-professional-inverse'
+			'ghost-professional-inverse',
+			'ghost-community'
 		))
 	);
 }

--- a/components/o-buttons/src/scss/_variables.scss
+++ b/components/o-buttons/src/scss/_variables.scss
@@ -18,6 +18,7 @@ $_o-buttons-themes: (
 	mono,
 	b2c,
 	professional,
+	community,
 	'professional-inverse'
 ) !default;
 

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -2,7 +2,7 @@ export interface ButtonProps {
 	label: string;
 	type: "primary" | "secondary" | "ghost";
 	size?: "big" | "";
-	theme?: "inverse" | "mono" | "professional" | "professional-inverse";
+	theme?: "inverse" | "mono" | "professional" | "professional-inverse" | 'community';
 	icon?:
 		| "arrow-left"
 		| "arrow-right"

--- a/components/o-forms/demos/src/community.mustache
+++ b/components/o-forms/demos/src/community.mustache
@@ -1,0 +1,109 @@
+<div class="demo">
+	<form action data-o-component="o-forms">
+		<div class="o-forms-field o-forms-field--optional o-forms-field--community" role="group" aria-labelledby="radio-group-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="radio-group-title">Round-style radio buttons for proffessional theme</span>
+				<span class="o-forms-title__prompt" id="radio-round-group-info">Optional prompt/description text</span>
+			</span>
+			<span class="o-forms-input o-forms-input--radio-round">
+				<span class="o-forms-input--radio-round__container">
+					<label for="radio-yes">
+						<input id="radio-yes" type="radio" name="round" checked>
+						<span class="o-forms-input__label">Yes</span>
+					</label>
+					<label for="radio-no">
+						<input id="radio-no" type="radio" name="round">
+						<span class="o-forms-input__label">No</span>
+					</label>
+				</span>
+			</span>
+		</div>
+		<div class="o-forms-field o-forms-field--optional o-forms-field--community" role="group" aria-labelledby="disabled-radio-group-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="disabled-radio-group-title"> Disabled Round-style radio buttons for proffessional theme </span>
+				<span class="o-forms-title__prompt" id="disabled-radio-round-group-info">Optional prompt/description text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--radio-round">
+				<span class="o-forms-input--radio-round__container">
+					<label for="disabled-radio-yes">
+						<input id="disabled-radio-yes" type="radio" name="disabled-round" disabled>
+						<span class="o-forms-input__label">Yes</span>
+					</label>
+					<label for="disabled-radio-no">
+						<input id="disabled-radio-no" type="radio" name="disabled-round" checked disabled>
+						<span class="o-forms-input__label">No</span>
+					</label>
+				</span>
+			</span>
+		</div>
+		<div class="o-forms-field o-forms-field--optional o-forms-field--community" role="group" aria-labelledby="checkbox-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="checkbox-title">Checkboxes for community theme</span>
+				<span class="o-forms-title__prompt" id="checkbox-group-info">Optional prompt/description text</span>
+			</span>
+			<span class="o-forms-input o-forms-input--checkbox">
+					<label for="checkbox-daily">
+						<input id="checkbox-daily" type="checkbox" name="checkbox" checked>
+						<span class="o-forms-input__label">Daily</span>
+					</label>
+					<label for="checkbox-monthly">
+						<input id="checkbox-montly" type="checkbox" name="checkbox">
+						<span class="o-forms-input__label">Monthly</span>
+					</label>
+					<label for="checkbox-yearly">
+						<input id="checkbox-yearly" type="checkbox" name="checkbox" disabled checked>
+						<span disabled class="o-forms-input__label">Yearly (diabled)</span>
+					</label>
+			</span>
+		</div>
+
+
+		<div
+		class="o-forms-field o-forms-field--optional o-forms-field--community"
+		role="group"
+		aria-labelledby="o-forms-labelledby_7631356478552304"
+		aria-describedby="o-forms-describedby_8691591009608423"
+		>
+		<span class="o-forms-title">
+			<span class="o-forms-title__main" id="o-forms-labelledby_7631356478552304">
+			Box style radio buttons
+			</span>
+			<span
+			class="o-forms-title__prompt"
+			id="o-forms-describedby_8691591009608423"
+			>
+			Optional prompt text
+			</span>
+		</span>
+		<span class="o-forms-input o-forms-input--radio-box">
+			<span class="o-forms-input--radio-box__container">
+			<label for="o-forms-radio_button_5452943941372214">
+				<input
+				type="radio"
+				id="o-forms-radio_button_5452943941372214"
+				name="default"
+				value="Daily"
+				checked=""
+				/>
+				<span class="o-forms-input__label">Daily</span>
+			</label>
+			<label for="o-forms-radio_button_668296921327457">
+				<input
+				type="radio"
+				id="o-forms-radio_button_668296921327457"
+				name="default"
+				value="Weekly"
+				/>
+				<span class="o-forms-input__label">Weekly</span>
+			</label>
+			</span>
+		</span>
+		</div>
+
+
+
+	</form>
+
+</div>
+

--- a/components/o-forms/main.scss
+++ b/components/o-forms/main.scss
@@ -42,6 +42,7 @@
 		'suffix'
 	),
 	'themes': (
+		'community',
 		'inverse',
 		'white',
 		'professional',
@@ -69,6 +70,26 @@
 	$file: index($elements, 'file');
 
 	@include _oFormsBase();
+
+	@if $themes {
+		@each $theme in $themes {
+			$default-text-color: _oFormsGet("default-text", $theme);
+			@if $default-text-color and oColorsColorBrightness($default-text-color) > 65% {
+				@debug $theme, $default-text-color, oColorsColorBrightness($default-text-color);
+				.o-forms-field--#{$theme} .o-forms-title {
+					.o-forms-title__main:after,
+					.o-forms-title__prompt {
+						color: rgba(_oFormsGet("default-text", $theme), 0.7);
+					}
+				}
+				.o-forms-field--#{$theme} input {
+					@include oNormaliseFocusApply() {
+						@include oNormaliseFocusContentInverse();
+					}
+				}
+			}
+		}
+	}
 
 	@if index($elements, 'pseudo-radio-link') {
 		@include _oFormsPseudoRadioLink();

--- a/components/o-forms/origami.json
+++ b/components/o-forms/origami.json
@@ -37,6 +37,16 @@
 			]
 		},
 		{
+			"name": "community",
+			"title": "Community theme",
+			"template": "/demos/src/community.mustache",
+			"description": "Community theme",
+			"sass": "demos/src/inverse.scss",
+			"brands": [
+				"core"
+			]
+		},
+		{
 			"name": "professional-inverse",
 			"title": "Professional inverse theme",
 			"template": "/demos/src/professional-inverse.mustache",

--- a/components/o-forms/src/scss/_checkbox.scss
+++ b/components/o-forms/src/scss/_checkbox.scss
@@ -124,19 +124,34 @@
 				color: _oFormsGet("default-text", $theme);
 			}
 		}
+
+		@if $theme and oColorsColorBrightness(_oFormsGet("default-text", $theme)) > 65% {
+		input[type=checkbox] { // stylelint-disable-line selector-no-qualifying-type
+			&:focus {
+				@include oNormaliseFocusUnsetContent();
+				& + .o-forms-input__label:before { // stylelint-disable-line selector-no-qualifying-type
+					@include oNormaliseFocusContentInverse();
+				}
+			}
+
+			// Unset :focus styles where :focus-visible is supported.
+			// Ideally we would set `:focus-visible` by default and use
+			// `@supports not selector(:focus-visible)` to provide a
+			// `:focus` fallback, however some of our supported browsers
+			// do not understand `@supports: selector()`.
+			@supports selector(:focus-visible) {
+				&:focus + .o-forms-input__label:before { // stylelint-disable-line selector-no-qualifying-type
+					@include oNormaliseFocusUnsetContent();
+				}
+
+				&:focus-visible {
+					& + .o-forms-input__label:before { // stylelint-disable-line selector-no-qualifying-type
+						@include oNormaliseFocusContentInverse();
+					}
+				}
+			}
+		}
+		}
 	}
 
-	@if $theme == "professional-inverse" {
-		.o-forms-title {
-			.o-forms-title__main:after,
-			.o-forms-title__prompt {
-				color: rgba(_oFormsGet("default-text", $theme), 0.7);
-			}
-		}
-		input {
-			@include oNormaliseFocusApply() {
-				@include oNormaliseFocusContentInverse();
-			}
-		}
-	}
 }

--- a/components/o-forms/src/scss/_radio-box.scss
+++ b/components/o-forms/src/scss/_radio-box.scss
@@ -103,7 +103,12 @@
 		&:focus {
 			@include oNormaliseFocusUnsetContent();
 			& + .o-forms-input__label { // stylelint-disable-line selector-no-qualifying-type
-				@include oNormaliseFocusContent();
+				$default-text: _oFormsGet("default-text", $theme);
+				@if $default-text and oColorsColorBrightness($default-text) > 65% {
+					@include oNormaliseFocusContentInverse();
+				} @else {
+					@include oNormaliseFocusContent();
+				}
 			}
 		}
 
@@ -119,7 +124,12 @@
 
 			&:focus-visible {
 				& + .o-forms-input__label { // stylelint-disable-line selector-no-qualifying-type
-					@include oNormaliseFocusContent();
+					$default-text: _oFormsGet("default-text", $theme);
+					@if $default-text and oColorsColorBrightness($default-text) > 65% {
+						@include oNormaliseFocusContentInverse();
+					} @else {
+						@include oNormaliseFocusContent();
+					}
 				}
 			}
 		}

--- a/components/o-forms/src/scss/_radio-round.scss
+++ b/components/o-forms/src/scss/_radio-round.scss
@@ -101,19 +101,7 @@
 		}
 	}
 
-	@if $theme == "professional-inverse" {
-		.o-forms-title {
-			.o-forms-title__main:after,
-			.o-forms-title__prompt {
-				color: rgba(_oFormsGet("default-text", $theme), 0.7);
-			}
-		}
-		input {
-			@include oNormaliseFocusApply() {
-				@include oNormaliseFocusContentInverse();
-			}
-		}
-
+	@if $theme and oColorsColorBrightness(_oFormsGet("default-text", $theme)) > 65% {
 		input[type="radio"] {// stylelint-disable-line selector-no-qualifying-type
 			&:focus {
 				@include oNormaliseFocusUnsetContent();

--- a/components/o-forms/src/scss/shared/_brand.scss
+++ b/components/o-forms/src/scss/shared/_brand.scss
@@ -61,10 +61,17 @@ $_o-forms-shared-brand-config: (
 				default-border: oColorsByName('mint'),
 				controls-checked-base: oColorsByName('slate'),
 			),
+			'community': (
+				default-text: oColorsByName('white'),
+				controls-base: oColorsByName('ft-pink'),
+				default-border: oColorsByName('ft-pink'),
+				controls-checked-base: oColorsByName('slate')
+			),
 		)),
 		'supports-variants': (
 			'professional',
-			'professional-inverse'
+			'professional-inverse',
+			'community'
 		)
 	));
 }

--- a/components/o-forms/src/tsx/Form.tsx
+++ b/components/o-forms/src/tsx/Form.tsx
@@ -14,7 +14,7 @@ export interface TypeFormField {
 	isOptional?: boolean;
 	inlineField?: boolean;
 	isVerticalCenter?: boolean;
-	theme?: 'inverse' | 'white' | 'professional' | 'professional-inverse';
+	theme?: 'inverse' | 'white' | 'professional' | 'professional-inverse' | 'community';
 }
 
 export interface FormFieldProps extends TypeFormField {

--- a/components/o-forms/src/tsx/RadioBtns.tsx
+++ b/components/o-forms/src/tsx/RadioBtns.tsx
@@ -21,11 +21,11 @@ export interface RadioBtnProps extends InputProps {
 }
 
 export interface RadioBtnsProps extends RadioBtnsWrapperProps, TypeFormField {
-	theme?: 'professional' | 'professional-inverse';
+	theme?: 'professional' | 'professional-inverse' | 'community';
 }
 
 export interface RadioBtnsBoxProps extends RadioBtnsBoxWrapperProps, TypeFormField {
-	theme?: 'professional' | 'professional-inverse';
+	theme?: 'professional' | 'professional-inverse' | 'community';
 }
 
 function RadioBtnsBoxWrapper({

--- a/components/o-forms/stories/boxRadioBtns.stories.tsx
+++ b/components/o-forms/stories/boxRadioBtns.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "community"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/checkboxes.stories.tsx
+++ b/components/o-forms/stories/checkboxes.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "community"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/radioBtns.stories.tsx
+++ b/components/o-forms/stories/radioBtns.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "community"],
 		  }
 		: hideArg;
 


### PR DESCRIPTION
*Do not merge*

Fixes an issue with o-forms that means focus styles are not correctly inversed for all FT Professional form elements. I'll open this as a seperate PR at some point.

This is here just for demo purposes, do not merge.