### PR TITLE
feat: o-forms, add ft-live subbrand [OR-314]

### DIFF
--- a/components/o-forms/README.md
+++ b/components/o-forms/README.md
@@ -287,10 +287,11 @@ To create a radio input use a [multiple input](#multiple-input-fields) field str
  </span>
 </div>
 ```
-Round radio inputs support 2 themes.
+Round radio inputs support 3 themes.
 
-- **professional**: For a round radio with professional theme set `o-forms-field--professional` on the field element.
-- **professional-inverse**: For round radio with inverse professional theme Set `o-forms-field--professional-inverse` on the field element.
+- **professional**: For a round radios with the FT Professional theme, set `o-forms-field--professional` on the field element.
+- **professional-inverse**: For round radios with the inverse FT Professional theme, set `o-forms-field--professional-inverse` on the field element.
+- **ft-live**: For round radios with the FT Live theme, add `o-forms-field--professional-inverse` on the field element.
 
 [_See radio buttons in the registry_](https://registry.origami.ft.com/components/o-forms#demo-round-styled-radio-inputs)
 
@@ -327,10 +328,11 @@ The below example shows a box style radio button with a positive "yes" and negat
 
 To show a state label with no text set the modifier class `o-forms-input__state--icon-only` on the `o-forms-input__state` state element. Or to use custom copy for the saving and saved states add the modifier class `o-forms-input__state--custom` and put your copy within the state element. However, as mentioned previously, we recommend setting a custom label using the [setState JavaScript method](#state) instead of adding this markup manually.
 
-Box radio inputs support 2 themes.
+Box radio inputs support 3 themes.
 
-- **professional**: For a box radio with professional theme set `o-forms-field--professional` on the field element.
-- **professional-inverse**: For box radio with inverse professional theme set `o-forms-field--professional-inverse` on the field element.
+- **professional**: For a box radio with FT Professional theme set `o-forms-field--professional` on the field element.
+- **professional-inverse**: For box radio with inverse FT Professional theme set `o-forms-field--professional-inverse` on the field element.
+- **ft-live**: For box radios with the FT Live theme, set `o-forms-field--professional-inverse` on the field element.
 
 ##### Pseudo box radio inputs
 
@@ -387,9 +389,9 @@ To align the checkbox to the **right** of its `label`, add the `o-forms-input__r
 ```
 Square checkboxes also support an additional theme:
 
-- **professional**: To add the professional theme to a square checkbox, add the `o-forms-field--professional` modifier class to the field element.
-
-- **professional-inverse**: To add the professional inverse theme to a square checkbox, add the `o-forms-field--professional-inverse` modifier class to the field element.
+- **professional**: To add the Professional theme to a square checkbox, add the `o-forms-field--professional` modifier class to the field element.
+- **professional-inverse**: To add the inverse FT Professional theme to a square checkbox, add the `o-forms-field--professional-inverse` modifier class to the field element.
+- **ft-live**: To add the FT Live theme to a square checkbox, add the `o-forms-field--ft-live` modifier class to the field element.
 
 ##### Toggle checkbox inputs
 

--- a/components/o-forms/README.md
+++ b/components/o-forms/README.md
@@ -291,7 +291,7 @@ Round radio inputs support 3 themes.
 
 - **professional**: For a round radios with the FT Professional theme, set `o-forms-field--professional` on the field element.
 - **professional-inverse**: For round radios with the inverse FT Professional theme, set `o-forms-field--professional-inverse` on the field element.
-- **ft-live**: For round radios with the FT Live theme, add `o-forms-field--professional-inverse` on the field element.
+- **ft-live**: For round radios with the FT Live theme, add `o-forms-field--ft-live` on the field element.
 
 [_See radio buttons in the registry_](https://registry.origami.ft.com/components/o-forms#demo-round-styled-radio-inputs)
 

--- a/components/o-forms/demos/src/ft-live.mustache
+++ b/components/o-forms/demos/src/ft-live.mustache
@@ -1,0 +1,108 @@
+<div class="demo-inverse">
+	<form action data-o-component="o-forms">
+		<div class="o-forms-field o-forms-field--optional o-forms-field--ft-live" role="group" aria-labelledby="radio-group-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="radio-group-title">Round-style radio buttons for proffessional-inverse theme </span>
+				<span class="o-forms-title__prompt" id="radio-round-group-info">Optional prompt/description text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--radio-round">
+				<span class="o-forms-input--radio-round__container">
+					<label for="radio-yes">
+						<input id="radio-yes" type="radio" name="round">
+						<span class="o-forms-input__label">Yes</span>
+					</label>
+					<label for="radio-no">
+						<input id="radio-no" type="radio" name="round" checked>
+						<span class="o-forms-input__label">No</span>
+					</label>
+				</span>
+			</span>
+		</div>
+
+		<div class="o-forms-field o-forms-field--optional o-forms-field--ft-live" role="group" aria-labelledby="disabled-radio-group-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="disabled-radio-group-title"> Disabled Round-style radio buttons for proffessional-inverse theme </span>
+				<span class="o-forms-title__prompt" id="disabled-radio-round-group-info">Optional prompt/description text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--radio-round">
+				<span class="o-forms-input--radio-round__container">
+					<label for="disabled-radio-yes">
+						<input id="disabled-radio-yes" type="radio" name="disabled-round" disabled>
+						<span class="o-forms-input__label">Yes</span>
+					</label>
+					<label for="disabled-radio-no">
+						<input id="disabled-radio-no" type="radio" name="disabled-round" checked disabled>
+						<span class="o-forms-input__label">No</span>
+					</label>
+				</span>
+			</span>
+		</div>
+
+
+		<div class="o-forms-field o-forms-field--optional o-forms-field--ft-live" role="group" aria-labelledby="checkbox-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="checkbox-title">Checkboxes for professional theme</span>
+				<span class="o-forms-title__prompt" id="checkbox-group-info">Optional prompt/description text</span>
+			</span>
+			<span class="o-forms-input o-forms-input--checkbox">
+					<label for="checkbox-daily">
+						<input id="checkbox-daily" type="checkbox" name="checkbox" checked>
+						<span class="o-forms-input__label">Daily</span>
+					</label>
+					<label for="checkbox-monthly">
+						<input id="checkbox-montly" type="checkbox" name="checkbox">
+						<span class="o-forms-input__label">Monthly</span>
+					</label>
+					<label for="checkbox-yearly">
+						<input id="checkbox-yearly" type="checkbox" name="checkbox" disabled checked>
+						<span disabled class="o-forms-input__label">Yearly (diabled)</span>
+					</label>
+			</span>
+		</div>
+
+		<div
+		class="o-forms-field o-forms-field--optional o-forms-field--ft-live"
+		role="group"
+		aria-labelledby="o-forms-labelledby_7634680990004467"
+		aria-describedby="o-forms-describedby_48039907598536646"
+		>
+		<span class="o-forms-title">
+			<span class="o-forms-title__main" id="o-forms-labelledby_7634680990004467">
+			Box style radio buttons
+			</span>
+			<span
+			class="o-forms-title__prompt"
+			id="o-forms-describedby_48039907598536646"
+			>
+			Optional prompt text
+			</span>
+		</span>
+		<span class="o-forms-input o-forms-input--radio-box">
+			<span class="o-forms-input--radio-box__container">
+			<label for="o-forms-radio_button_03846211359091578">
+				<input
+				type="radio"
+				id="o-forms-radio_button_03846211359091578"
+				name="default"
+				value="Daily"
+				checked=""
+				/>
+				<span class="o-forms-input__label">Daily</span>
+			</label>
+			<label for="o-forms-radio_button_84933557360032">
+				<input
+				type="radio"
+				id="o-forms-radio_button_84933557360032"
+				name="default"
+				value="Weekly"
+				/>
+				<span class="o-forms-input__label">Weekly</span>
+			</label>
+			</span>
+		</span>
+		</div>
+
+	</form>
+</div>

--- a/components/o-forms/main.scss
+++ b/components/o-forms/main.scss
@@ -45,7 +45,8 @@
 		'inverse',
 		'white',
 		'professional',
-		'professional-inverse'
+		'professional-inverse',
+		'ft-live'
 	)
 )) {
 	$elements: map-get($opts, 'elements');

--- a/components/o-forms/origami.json
+++ b/components/o-forms/origami.json
@@ -47,6 +47,16 @@
 			]
 		},
 		{
+			"name": "ft-live",
+			"title": "FT Live inverse theme",
+			"template": "/demos/src/ft-live.mustache",
+			"description": "FT Live theme",
+			"sass": "demos/src/inverse.scss",
+			"brands": [
+				"core"
+			]
+		},
+		{
 			"name": "inverse-form",
 			"title": "Inverse Form",
 			"template": "/demos/src/inverse-form.mustache",

--- a/components/o-forms/src/scss/shared/_brand.scss
+++ b/components/o-forms/src/scss/shared/_brand.scss
@@ -61,10 +61,17 @@ $_o-forms-shared-brand-config: (
 				default-border: oColorsByName('mint'),
 				controls-checked-base: oColorsByName('slate'),
 			),
+			'ft-live': (
+				default-text: oColorsByName('white'),
+				controls-base: oColorsByName('ft-pink'),
+				default-border: oColorsByName('ft-pink'),
+				controls-checked-base: oColorsByName('slate')
+			),
 		)),
 		'supports-variants': (
 			'professional',
-			'professional-inverse'
+			'professional-inverse',
+			'ft-live'
 		)
 	));
 }

--- a/components/o-forms/src/tsx/Form.tsx
+++ b/components/o-forms/src/tsx/Form.tsx
@@ -14,7 +14,7 @@ export interface TypeFormField {
 	isOptional?: boolean;
 	inlineField?: boolean;
 	isVerticalCenter?: boolean;
-	theme?: 'inverse' | 'white' | 'professional' | 'professional-inverse';
+	theme?: 'inverse' | 'white' | 'professional' | 'professional-inverse' | 'ft-live';
 }
 
 export interface FormFieldProps extends TypeFormField {

--- a/components/o-forms/src/tsx/RadioBtns.tsx
+++ b/components/o-forms/src/tsx/RadioBtns.tsx
@@ -21,11 +21,11 @@ export interface RadioBtnProps extends InputProps {
 }
 
 export interface RadioBtnsProps extends RadioBtnsWrapperProps, TypeFormField {
-	theme?: 'professional' | 'professional-inverse';
+	theme?: 'professional' | 'professional-inverse' | 'ft-live';
 }
 
 export interface RadioBtnsBoxProps extends RadioBtnsBoxWrapperProps, TypeFormField {
-	theme?: 'professional' | 'professional-inverse';
+	theme?: 'professional' | 'professional-inverse' | 'ft-live';
 }
 
 function RadioBtnsBoxWrapper({

--- a/components/o-forms/stories/boxRadioBtns.stories.tsx
+++ b/components/o-forms/stories/boxRadioBtns.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "ft-live"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/checkboxes.stories.tsx
+++ b/components/o-forms/stories/checkboxes.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "ft-live"],
 		  }
 		: hideArg;
 

--- a/components/o-forms/stories/radioBtns.stories.tsx
+++ b/components/o-forms/stories/radioBtns.stories.tsx
@@ -19,7 +19,7 @@ const themeControl =
 				control: {
 					type: "select",
 				},
-				options: [undefined, "professional", "professional-inverse"],
+				options: [undefined, "professional", "professional-inverse", "ft-live"],
 		  }
 		: hideArg;
 


### PR DESCRIPTION
Radios round, radios square, and checkboxes. E.g.


<img width="206" alt="Screenshot 2023-09-11 at 15 41 21" src="https://github.com/Financial-Times/origami/assets/10405691/39965f29-7012-4186-b1cf-94b82f19c73e">
<img width="276" alt="Screenshot 2023-09-11 at 15 41 38" src="https://github.com/Financial-Times/origami/assets/10405691/f295f688-7f79-476d-a4e1-87f9ab813a9d">
<img width="279" alt="Screenshot 2023-09-11 at 15 41 55" src="https://github.com/Financial-Times/origami/assets/10405691/7aeca121-96f1-4df5-9c53-5cda3b9f6512">

Figma Library updates to follow:
https://financialtimes.atlassian.net/browse/OR-314