### PR TITLE
feat: o-buttons, add ft-live subbrand [OR-313]

### DIFF
--- a/components/o-buttons/README.md
+++ b/components/o-buttons/README.md
@@ -65,6 +65,7 @@ A theme may be applied to a button to change its appearance. o-buttons provides 
 | b2c     | .o-buttons--b2c     | primary            | core           |
 | professional     | .o-buttons--professional     | primary, secondary, ghost            | core           |
 | professional-inverse     | .o-buttons--professional-inverse     | primary, secondary, ghost            | core           |
+| ft-live     | .o-buttons--ft-live     | primary, secondary, ghost            | core           |
 
 ```html
 <button class="o-buttons o-buttons--primary o-buttons--inverse">Submit</button>
@@ -217,7 +218,7 @@ To output default o-buttons CSS make a single call to the primary mixin `oButton
 @include oButtons($opts: (
 	'sizes': ('big'), // e.g .o-buttons--big
 	'types': ('primary', 'secondary', 'ghost'), // e.g .o-buttons--primary
-	'themes': ('mono', 'inverse', 'b2c', 'professional', 'professional-inverse'), // e.g .o-buttons--inverse
+	'themes': ('mono', 'inverse', 'b2c', 'professional', 'professional-inverse', 'ft-live'), // e.g .o-buttons--inverse
 	'icons': ('arrow-left', 'arrow-right', 'search'), // any fticons, e.g .o-buttons-icons.o-buttons-icons--search
 	'pagination': true, // .o-buttons-pagination
 	'groups': true // .o-buttons-group

--- a/components/o-buttons/demos/src/demo.scss
+++ b/components/o-buttons/demos/src/demo.scss
@@ -56,6 +56,7 @@ p {
 		'b2c',
 		'professional',
 		'professional-inverse',
+		'ft-live'
 	),
 	'icons': join($_o-buttons-icons, ('book')), // Also include the book icon, which is not in the defaut set.
 	'pagination': true,

--- a/components/o-buttons/demos/src/ft-live.mustache
+++ b/components/o-buttons/demos/src/ft-live.mustache
@@ -1,0 +1,14 @@
+<button class="o-buttons o-buttons--primary o-buttons--ft-live">Primary FT Live Theme</button>
+<button class="o-buttons o-buttons--primary o-buttons--ft-live">Primary FT Live Theme</button>
+<button class="o-buttons o-buttons--primary o-buttons--ft-live o-buttons-icon o-buttons-icon--arrow-right">Primary FT Live Theme</button>
+<button class="o-buttons o-buttons--primary o-buttons--big o-buttons--ft-live" disabled>Primary FT Live Theme</button>
+<hr>
+<button class="o-buttons o-buttons--secondary o-buttons--ft-live">secondary FT Live Theme</button>
+<button class="o-buttons o-buttons--secondary o-buttons--ft-live">secondary FT Live Theme</button>
+<button class="o-buttons o-buttons--secondary o-buttons--ft-live o-buttons-icon o-buttons-icon--arrow-right">secondary FT Live Theme</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big o-buttons--ft-live" disabled>secondary FT Live Theme</button>
+<hr>
+<button class="o-buttons o-buttons--ghost o-buttons--ft-live">Ghost FT Live Theme</button>
+<button class="o-buttons o-buttons--ghost o-buttons--ft-live">Ghost FT Live Theme</button>
+<button class="o-buttons o-buttons--ghost o-buttons--ft-live o-buttons-icon o-buttons-icon--arrow-right">Ghost FT Live Theme</button>
+<button class="o-buttons o-buttons--ghost o-buttons--big o-buttons--ft-live" disabled>Ghost FT Live Theme</button>

--- a/components/o-buttons/origami.json
+++ b/components/o-buttons/origami.json
@@ -96,6 +96,16 @@
 			"description": "Inverse Professional themed buttons."
 		},
 		{
+			"name": "ft-live",
+			"title": "FT Live theme",
+			"brands": [
+				"core"
+			],
+			"bodyClasses": "demo-inverse",
+			"template": "/demos/src/ft-live.mustache",
+			"description": "FT Live themed buttons."
+		},
+		{
 			"name": "B2C",
 			"title": "B2C theme",
 			"brands": [

--- a/components/o-buttons/src/scss/_brand.scss
+++ b/components/o-buttons/src/scss/_brand.scss
@@ -49,6 +49,10 @@ $_o-buttons-shared-brand-config: (
 				'color': 'slate',
 				'context': 'paper'
 			),
+			'ft-live': (
+				'color': 'ft-pink',
+				'context': 'slate'
+			),
 			'professional-inverse': (
 				'color': 'mint',
 				'context': 'slate'
@@ -62,18 +66,21 @@ $_o-buttons-shared-brand-config: (
 			'secondary',
 			'primary-b2c',
 			'primary-professional',
+			'primary-ft-live',
 			'primary-professional-inverse',
 			'primary-inverse',
 			'primary-mono',
 			'secondary-inverse',
 			'secondary-mono',
 			'secondary-professional',
+			'secondary-ft-live',
 			'secondary-professional-inverse',
 			'ghost',
 			'ghost-inverse',
 			'ghost-mono',
 			'ghost-professional',
-			'ghost-professional-inverse'
+			'ghost-professional-inverse',
+			'ghost-ft-live'
 		))
 	);
 }

--- a/components/o-buttons/src/scss/_variables.scss
+++ b/components/o-buttons/src/scss/_variables.scss
@@ -18,6 +18,7 @@ $_o-buttons-themes: (
 	mono,
 	b2c,
 	professional,
+	ft-live,
 	'professional-inverse'
 ) !default;
 

--- a/components/o-buttons/src/tsx/button.tsx
+++ b/components/o-buttons/src/tsx/button.tsx
@@ -2,7 +2,7 @@ export interface ButtonProps {
 	label: string;
 	type: "primary" | "secondary" | "ghost";
 	size?: "big" | "";
-	theme?: "inverse" | "mono" | "professional" | "professional-inverse";
+	theme?: "inverse" | "mono" | "professional" | "professional-inverse" | 'ft-live';
 	icon?:
 		| "arrow-left"
 		| "arrow-right"


### PR DESCRIPTION
This includes primary, secondary, and ghost buttons. As well as things like pagination and disabled states. E.g.


<img width="511" alt="Screenshot 2023-09-11 at 15 44 51" src="https://github.com/Financial-Times/origami/assets/10405691/2c1dcb48-31ac-4556-9401-8afa1c6edb79">
<img width="179" alt="Screenshot 2023-09-11 at 15 45 04" src="https://github.com/Financial-Times/origami/assets/10405691/182ce3a4-5dd2-4547-9c28-cbf8afd7d84a">
<img width="148" alt="Screenshot 2023-09-11 at 15 45 12" src="https://github.com/Financial-Times/origami/assets/10405691/eb94a0fb-5789-492a-b695-8d013d7a38f7">
<img width="114" alt="Screenshot 2023-09-11 at 15 45 23" src="https://github.com/Financial-Times/origami/assets/10405691/bee1a581-c7f4-4c8a-8d43-caacb57b04b4">


Figma updates to follow: 

https://financialtimes.atlassian.net/browse/OR-313

