### PR TITLE
feat: o-typography, add ft-live sub-brand support for links [OR-315]

### DIFF
--- a/components/o-typography/README.md
+++ b/components/o-typography/README.md
@@ -91,6 +91,7 @@ See the [demos](http://registry.origami.ft.com/components/o-typography) for a fu
 - `o-typography-inverse` - Make body copy and links white, for use on a dark background.
 - `o-typography-professional` - Change link colours for the FT Professional sub-brand (core brand only)
 - `o-typography-professional o-typography-inverse` - A version of the inverse theme for use with the FT Professional sub-brand (core brand only)
+- `o-typography-ft-live o-typography-inverse` - A version of the inverse theme for use with the FT Live sub-brand (core brand only)
 
 E.g:
 ```html
@@ -270,6 +271,7 @@ You may also output link styles for a given theme:
 - `inverse`
 - `professional` (core brand only)
 - `professional-inverse` (core brand only)
+- `ft-live` (core brand only)
 
 ```scss
 a {

--- a/components/o-typography/demos/src/ft-live-links.mustache
+++ b/components/o-typography/demos/src/ft-live-links.mustache
@@ -1,0 +1,4 @@
+<p class="o-typography-body o-typography-ft-live o-typography-inverse">
+    We have a <a href="#" class="o-typography-link">standard link</a> style.
+    Links may open in a new window/tab but we <a href="https://www.w3.org/TR/WCAG20-TECHS/G200.html" class="o-typography-link">recommend against this</a> in most cases.
+</p>

--- a/components/o-typography/main.scss
+++ b/components/o-typography/main.scss
@@ -127,6 +127,15 @@
 				--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-professional-inverse')};
 			}
 		}
+
+		@if _oTypographySupports('ft-live') {
+			.o-typography-ft-live {
+				--_o-typography-link-color: #{_oTypographyGet('base', 'link-ft-live')};
+				--_o-typography-link-decoration-color: #{_oTypographyGet('base-decoration', 'link-ft-live')};
+				--_o-typography-link-color-hover: #{_oTypographyGet('hover', 'link-ft-live')};
+				--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-ft-live')};
+			}
+		}
 	}
 
 	// Lists

--- a/components/o-typography/origami.json
+++ b/components/o-typography/origami.json
@@ -73,6 +73,14 @@
 			"brands": ["core"]
 		},
 		{
+			"name": "ft-live-links",
+			"title": "FT Live Links",
+			"template": "demos/src/ft-live-links.mustache",
+			"description": "Link styles for the FT Live sub-brand.",
+			"documentClasses": "o-grid-container o-typography--loading-display o-typography--loading-sans o-typography--loading-sans-bold o-typography--loading-display-bold demo-inverse",
+			"brands": ["core"]
+		},
+		{
 			"name": "body",
 			"title": "Body",
 			"template": "demos/src/body.mustache",

--- a/components/o-typography/src/scss/_brand.scss
+++ b/components/o-typography/src/scss/_brand.scss
@@ -142,6 +142,12 @@ $_o-typography-font-scale: (
 				'hover': oColorsByName('mint-70'),
 				'hover-decoration': oColorsByName('mint-70')
 			),
+			'link-ft-live': (
+				'base': oColorsByName('ft-pink'),
+				'base-decoration': oColorsMix('ft-pink', 'slate', 80),
+				'hover': oColorsByName('ft-pink'),
+				'hover-decoration': oColorsMix('ft-pink', 'slate', 80)
+			),
 			'heading-level-one': (
 				'scale': 5,
 				'weight': 'semibold'
@@ -168,7 +174,8 @@ $_o-typography-font-scale: (
 			)
 		),
 		'supports-variants': (
-			'professional'
+			'professional',
+			'ft-live'
 		)
 	));
 }

--- a/components/o-typography/src/scss/use-cases/_general.scss
+++ b/components/o-typography/src/scss/use-cases/_general.scss
@@ -124,6 +124,7 @@
 	$theme: if($theme == 'inverse', 'link-inverse', $theme);
 	$theme: if($theme == 'professional', 'link-professional', $theme);
 	$theme: if($theme == 'professional-inverse', 'link-professional-inverse', $theme);
+	$theme: if($theme == 'ft-live', 'link-ft-live', $theme);
 
 	// Get custom base colour.
 	$theme-base: _oTypographyGet('base', $theme);


### PR DESCRIPTION
E.g.
<img width="940" alt="Screenshot 2023-09-11 at 16 02 32" src="https://github.com/Financial-Times/origami/assets/10405691/957040e7-09f2-495b-b6e6-12b3019154b0">


Figma updates to follow: 
https://financialtimes.atlassian.net/browse/OR-315