### PR TITLE
fix: o-overlay, which to a h2 header

### DIFF
--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -302,9 +302,7 @@ class Overlay {
 				heading.appendChild(button);
 			}
 
-			const title = document.createElement('span');
-			title.setAttribute('role', 'heading');
-			title.setAttribute('aria-level', '1');
+			const title = document.createElement('h2');
 			title.className = 'o-overlay__title';
 			title.innerHTML = this.opts.heading.title;
 			title.setAttribute('id', headingId);

--- a/components/o-overlay/src/scss/_mixins.scss
+++ b/components/o-overlay/src/scss/_mixins.scss
@@ -29,8 +29,12 @@
 		opacity: 1;
 		transition: opacity 0.3s ease-in-out;
 	}
+	.o-overlay__heading,
+	.o-overlay__title {
+		@include oTypographySans($scale: 2, $weight: 'regular');
+	}
+
 	.o-overlay__heading {
-		@include oTypographySans($scale: 2, $include-font-family: false);
 		margin: 0;
 		overflow: hidden;
 		background: _oOverlayGet('heading-background');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4952,7 +4952,7 @@
 		},
 		"components/ft-concept-button": {
 			"name": "@financial-times/ft-concept-button",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -4974,7 +4974,7 @@
 		},
 		"components/n-notification": {
 			"name": "@financial-times/n-notification",
-			"version": "8.2.4",
+			"version": "8.2.5",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5009,7 +5009,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^2.1.2"
@@ -5037,7 +5037,7 @@
 		},
 		"components/o-banner": {
 			"name": "@financial-times/o-banner",
-			"version": "4.5.0",
+			"version": "4.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5059,7 +5059,7 @@
 		},
 		"components/o-big-number": {
 			"name": "@financial-times/o-big-number",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5076,7 +5076,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.8.2",
+			"version": "7.9.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5117,7 +5117,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "10.3.1",
+			"version": "10.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5139,7 +5139,7 @@
 		},
 		"components/o-cookie-message": {
 			"name": "@financial-times/o-cookie-message",
-			"version": "6.6.0",
+			"version": "6.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"superstore-sync": "^2.1.1"
@@ -5173,7 +5173,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5193,7 +5193,7 @@
 		},
 		"components/o-editorial-typography": {
 			"name": "@financial-times/o-editorial-typography",
-			"version": "2.3.4",
+			"version": "2.3.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5237,7 +5237,7 @@
 		},
 		"components/o-footer": {
 			"name": "@financial-times/o-footer",
-			"version": "9.2.7",
+			"version": "9.2.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5262,7 +5262,7 @@
 		},
 		"components/o-footer-services": {
 			"name": "@financial-times/o-footer-services",
-			"version": "4.2.6",
+			"version": "4.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5280,7 +5280,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.11.2",
+			"version": "9.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5335,7 +5335,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "11.0.6",
+			"version": "11.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5362,7 +5362,7 @@
 		},
 		"components/o-header-services": {
 			"name": "@financial-times/o-header-services",
-			"version": "5.5.0",
+			"version": "5.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5387,7 +5387,7 @@
 		},
 		"components/o-icons": {
 			"name": "@financial-times/o-icons",
-			"version": "7.6.0",
+			"version": "7.7.0",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5395,7 +5395,7 @@
 		},
 		"components/o-labels": {
 			"name": "@financial-times/o-labels",
-			"version": "6.5.6",
+			"version": "6.5.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5414,7 +5414,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5479,7 +5479,7 @@
 		},
 		"components/o-message": {
 			"name": "@financial-times/o-message",
-			"version": "5.4.2",
+			"version": "5.4.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5501,7 +5501,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.2",
+			"version": "3.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5519,7 +5519,7 @@
 		},
 		"components/o-multi-select": {
 			"name": "@financial-times/o-multi-select",
-			"version": "2.2.0",
+			"version": "2.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5556,7 +5556,7 @@
 		},
 		"components/o-overlay": {
 			"name": "@financial-times/o-overlay",
-			"version": "4.2.8",
+			"version": "4.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"focusable": "^2.3.0",
@@ -5588,7 +5588,7 @@
 		},
 		"components/o-quote": {
 			"name": "@financial-times/o-quote",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5607,7 +5607,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "9.0.2",
+			"version": "10.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5636,7 +5636,7 @@
 		},
 		"components/o-social-follow": {
 			"name": "@financial-times/o-social-follow",
-			"version": "1.0.7",
+			"version": "1.0.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5657,7 +5657,7 @@
 		},
 		"components/o-spacing": {
 			"name": "@financial-times/o-spacing",
-			"version": "3.2.3",
+			"version": "3.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5673,7 +5673,7 @@
 		},
 		"components/o-stepped-progress": {
 			"name": "@financial-times/o-stepped-progress",
-			"version": "4.0.7",
+			"version": "4.0.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5694,7 +5694,7 @@
 		},
 		"components/o-subs-card": {
 			"name": "@financial-times/o-subs-card",
-			"version": "6.2.4",
+			"version": "6.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5732,7 +5732,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.3.1",
+			"version": "9.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5783,7 +5783,7 @@
 		},
 		"components/o-teaser": {
 			"name": "@financial-times/o-teaser",
-			"version": "6.2.7",
+			"version": "6.2.8",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^1.29.0",
@@ -5810,7 +5810,7 @@
 		},
 		"components/o-teaser-collection": {
 			"name": "@financial-times/o-teaser-collection",
-			"version": "4.2.3",
+			"version": "4.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5857,7 +5857,7 @@
 		},
 		"components/o-tooltip": {
 			"name": "@financial-times/o-tooltip",
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5905,7 +5905,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "6.0.6",
+			"version": "6.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5926,7 +5926,7 @@
 		},
 		"components/o-typography": {
 			"name": "@financial-times/o-typography",
-			"version": "7.4.1",
+			"version": "7.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"fontfaceobserver": "^2.0.9"
@@ -5951,7 +5951,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.9",
+			"version": "7.2.10",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
Typically one h1 on a page helps create a navigatable structure. There Is No Document Outline Algorithm.
https://adrianroselli.com/2016/08/there-is-no-document-outline-algorithm.html#Update10

But I wasn't sure what the right answer is now we have `aria-modal` that can trap focus and mark other elements as inert, and went on a little side quest.

Turns out W3C's APG Task Force (ARIA Authoring Practices Guide) discussed this in a meeting a few years ago. https://github.com/w3c/aria-practices/issues/551#issuecomment-365134527

They concluded:

- It is helpful if there is a consistent approach across dialogs in an application.
- There is not necessarily a need for the APG to prescribe a specific approach.

So, I guess provided you're in a modal either h1 or h2 is fine.

APG continue to use h2 in their example and Material UI are undecided, with some interesting back and fourth on when a h1 or h2 might be a better experience.
https://github.com/mui/material-ui/issues/34250

Probably, it's not a big deal either way. If I had to pick a global rule based on the above and no access to direct user testing for this, I'd go with h2.

Here it is. A quick PR to switch to a h2.

This was prompted by a user question in the support Slack channel. https://financialtimes.slack.com/archives/C02FU5ARJ/p1696242420071219