### PR TITLE
CPREL-782: Stop cookie banner content showing in SERP page description

### DIFF
--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -34,7 +34,8 @@ To display custom cookie message content with default buttons, add child HTML al
 	aria-labelledby="demo-label-element-id"
 	aria-describedby="demo-description-element-id"
 	data-o-component="o-cookie-message"
-	class="o-cookie-message">
+	class="o-cookie-message"
+	data-nosnippet>
 	<!-- custom cookie message copy / html here -->
 	<!-- include ids for the aria labelledby and describedby attributes -->
 	<!-- e.g. -->
@@ -53,7 +54,8 @@ To support a core experience without JavaScript, add the full `o-cookie-message`
 	aria-labelledby="o-cookie-message-label"
 	aria-describedby="o-cookie-message-description"
 	data-o-component="o-cookie-message"
-	class="o-cookie-message">
+	class="o-cookie-message"
+	data-nosnippet>
 	<div class="o-cookie-message__outer">
 		<div class="o-cookie-message__inner">
 			<div class="o-cookie-message__content">

--- a/components/o-cookie-message/demos/src/custom-html.mustache
+++ b/components/o-cookie-message/demos/src/custom-html.mustache
@@ -3,7 +3,8 @@
 	aria-labelledby="demo-label-element-id"
 	aria-describedby="demo-description-element-id"
 	data-o-component="o-cookie-message"
-	class="o-cookie-message">
+	class="o-cookie-message"
+    data-nosnippet>
 	<!-- custom cookie message copy / html here -->
 	<!-- include ids for the aria labelledby and describedby attributes -->
 	<!-- e.g. -->

--- a/components/o-cookie-message/src/js/cookie-message.js
+++ b/components/o-cookie-message/src/js/cookie-message.js
@@ -70,7 +70,7 @@ class CookieMessage {
 
 	createCookieMessage() {
 		const wrapContent = content => `
-<div class="o-cookie-message__outer">
+<div class="o-cookie-message__outer" data-nosnippet="true">
 	<div class="o-cookie-message__inner">
 		<div class="o-cookie-message__content">
 				${content}

--- a/components/o-cookie-message/src/tsx/cookie-message.tsx
+++ b/components/o-cookie-message/src/tsx/cookie-message.tsx
@@ -47,7 +47,8 @@ export function CookieMessage({
 			role="dialog"
 			data-o-component="o-cookie-message"
 			className="o-cookie-message"
-			{...dataAttributes}>
+			{...dataAttributes}
+			data-nosnippet="true">
 			{fullMarkup ? (
 				<div className="o-cookie-message__outer">
 					<div className="o-cookie-message__inner">

--- a/components/o-cookie-message/test/helpers/fixtures.js
+++ b/components/o-cookie-message/test/helpers/fixtures.js
@@ -24,7 +24,7 @@ export function generateHTML(type) { insert(html[type]); }
 export const html = {
 	standard: `<div role="dialog" data-o-component="o-cookie-message" class='o-cookie-message'></div>`,
 	domAttributes: `<div role="dialog" data-o-component="o-cookie-message" data-o-cookie-message-accept-url="example.com" class='o-cookie-message'></div>`,
-	customCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" data-o-cookie-message-use-custom-html="true" class='o-cookie-message'>
+	customCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" data-o-cookie-message-use-custom-html="true" class='o-cookie-message' data-nosnippet="true">
 		Custom cookie message!
 		<div class="o-cookie-message__close-btn-container">
 			<button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">
@@ -33,7 +33,7 @@ export const html = {
 		</div>
 	</div>`,
 	imperativeCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active" aria-labelledby="o-cookie-message-label" aria-describedby="o-cookie-message-description">
-		<div class="o-cookie-message__outer">
+		<div class="o-cookie-message__outer" data-nosnippet="true">
 			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">
@@ -62,7 +62,7 @@ export const html = {
 		</div>
 	</div>`,
 	imperativeAltCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active o-cookie-message--alternative" aria-labelledby="o-cookie-message-label" aria-describedby="o-cookie-message-description">
-		<div class="o-cookie-message__outer">
+		<div class="o-cookie-message__outer" data-nosnippet="true">
 			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">

--- a/package-lock.json
+++ b/package-lock.json
@@ -4952,7 +4952,7 @@
 		},
 		"components/ft-concept-button": {
 			"name": "@financial-times/ft-concept-button",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -4974,7 +4974,7 @@
 		},
 		"components/n-notification": {
 			"name": "@financial-times/n-notification",
-			"version": "8.2.4",
+			"version": "8.2.5",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5009,7 +5009,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^2.1.2"
@@ -5037,7 +5037,7 @@
 		},
 		"components/o-banner": {
 			"name": "@financial-times/o-banner",
-			"version": "4.5.0",
+			"version": "4.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5059,7 +5059,7 @@
 		},
 		"components/o-big-number": {
 			"name": "@financial-times/o-big-number",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5076,7 +5076,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.8.2",
+			"version": "7.9.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5117,7 +5117,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "10.3.1",
+			"version": "10.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5139,7 +5139,7 @@
 		},
 		"components/o-cookie-message": {
 			"name": "@financial-times/o-cookie-message",
-			"version": "6.6.0",
+			"version": "6.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"superstore-sync": "^2.1.1"
@@ -5173,7 +5173,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5193,7 +5193,7 @@
 		},
 		"components/o-editorial-typography": {
 			"name": "@financial-times/o-editorial-typography",
-			"version": "2.3.4",
+			"version": "2.3.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5237,7 +5237,7 @@
 		},
 		"components/o-footer": {
 			"name": "@financial-times/o-footer",
-			"version": "9.2.7",
+			"version": "9.2.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5262,7 +5262,7 @@
 		},
 		"components/o-footer-services": {
 			"name": "@financial-times/o-footer-services",
-			"version": "4.2.6",
+			"version": "4.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5280,7 +5280,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.11.2",
+			"version": "9.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5335,7 +5335,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "11.0.6",
+			"version": "11.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5362,7 +5362,7 @@
 		},
 		"components/o-header-services": {
 			"name": "@financial-times/o-header-services",
-			"version": "5.5.0",
+			"version": "5.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5387,7 +5387,7 @@
 		},
 		"components/o-icons": {
 			"name": "@financial-times/o-icons",
-			"version": "7.6.0",
+			"version": "7.7.0",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5395,7 +5395,7 @@
 		},
 		"components/o-labels": {
 			"name": "@financial-times/o-labels",
-			"version": "6.5.6",
+			"version": "6.5.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5414,7 +5414,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5479,7 +5479,7 @@
 		},
 		"components/o-message": {
 			"name": "@financial-times/o-message",
-			"version": "5.4.2",
+			"version": "5.4.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5501,7 +5501,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.2",
+			"version": "3.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5519,7 +5519,7 @@
 		},
 		"components/o-multi-select": {
 			"name": "@financial-times/o-multi-select",
-			"version": "2.2.0",
+			"version": "2.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5556,7 +5556,7 @@
 		},
 		"components/o-overlay": {
 			"name": "@financial-times/o-overlay",
-			"version": "4.2.8",
+			"version": "4.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"focusable": "^2.3.0",
@@ -5588,7 +5588,7 @@
 		},
 		"components/o-quote": {
 			"name": "@financial-times/o-quote",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5607,7 +5607,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "9.0.2",
+			"version": "10.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5636,7 +5636,7 @@
 		},
 		"components/o-social-follow": {
 			"name": "@financial-times/o-social-follow",
-			"version": "1.0.7",
+			"version": "1.0.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5657,7 +5657,7 @@
 		},
 		"components/o-spacing": {
 			"name": "@financial-times/o-spacing",
-			"version": "3.2.3",
+			"version": "3.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5673,7 +5673,7 @@
 		},
 		"components/o-stepped-progress": {
 			"name": "@financial-times/o-stepped-progress",
-			"version": "4.0.7",
+			"version": "4.0.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5694,7 +5694,7 @@
 		},
 		"components/o-subs-card": {
 			"name": "@financial-times/o-subs-card",
-			"version": "6.2.4",
+			"version": "6.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5732,7 +5732,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.3.1",
+			"version": "9.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5783,7 +5783,7 @@
 		},
 		"components/o-teaser": {
 			"name": "@financial-times/o-teaser",
-			"version": "6.2.7",
+			"version": "6.2.8",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^1.29.0",
@@ -5810,7 +5810,7 @@
 		},
 		"components/o-teaser-collection": {
 			"name": "@financial-times/o-teaser-collection",
-			"version": "4.2.3",
+			"version": "4.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5857,7 +5857,7 @@
 		},
 		"components/o-tooltip": {
 			"name": "@financial-times/o-tooltip",
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5905,7 +5905,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "6.0.6",
+			"version": "6.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5926,7 +5926,7 @@
 		},
 		"components/o-typography": {
 			"name": "@financial-times/o-typography",
-			"version": "7.4.1",
+			"version": "7.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"fontfaceobserver": "^2.0.9"
@@ -5951,7 +5951,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.9",
+			"version": "7.2.10",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
## Describe your changes
Adding `data-nosnippet` to cookie-message to ensure that its content is not used by google as the description on SERP. 

## Issue ticket number and link
https://financialtimes.atlassian.net/browse/CPREL-782

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
