### PR TITLE
backstage: Remove "percy" from component package.json

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -15,6 +15,7 @@ on:
       - "package-lock.json"
       - "components/**"
       - "!components/**/*.md"
+      - "!components/o3-*/**"
   push:
     branches: main
     paths:
@@ -22,6 +23,7 @@ on:
       - "package-lock.json"
       - "components/**"
       - "!components/**/*.md"
+      - "!components/o3-*/**"
 
 jobs:
   changes:

--- a/components/ft-concept-button/package.json
+++ b/components/ft-concept-button/package.json
@@ -29,6 +29,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/g-audio/package.json
+++ b/components/g-audio/package.json
@@ -21,6 +21,5 @@
 	"peerDependencies": {
 		"@financial-times/o-icons": "^7.2.1"
 	},
-	"percy": true,
 	"private": false
 }

--- a/components/n-notification/package.json
+++ b/components/n-notification/package.json
@@ -34,6 +34,5 @@
 		"lint": "bash ../../scripts/component/lint.bash",
 		"watch": "bash ../../scripts/component/watch.bash"
 	},
-	"percy": true,
 	"private": false
 }

--- a/components/o-audio/package.json
+++ b/components/o-audio/package.json
@@ -34,6 +34,5 @@
 		"node": "14.16.1",
 		"npm": "7.11.1"
 	},
-	"percy": true,
 	"private": false
 }

--- a/components/o-autocomplete/package.json
+++ b/components/o-autocomplete/package.json
@@ -49,6 +49,5 @@
   "dependencies": {
     "@financial-times/accessible-autocomplete": "^2.1.2"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-banner/package.json
+++ b/components/o-banner/package.json
@@ -44,6 +44,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-big-number/package.json
+++ b/components/o-big-number/package.json
@@ -34,6 +34,5 @@
 		"node": "14.16.1",
 		"npm": "7.11.1"
 	},
-	"percy": true,
 	"private": false
 }

--- a/components/o-buttons/package.json
+++ b/components/o-buttons/package.json
@@ -38,6 +38,5 @@
 		"node": "14.16.1",
 		"npm": "7.11.1"
 	},
-	"percy": true,
 	"private": false
 }

--- a/components/o-colors/package.json
+++ b/components/o-colors/package.json
@@ -51,6 +51,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -44,6 +44,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-cookie-message/package.json
+++ b/components/o-cookie-message/package.json
@@ -49,6 +49,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-date/package.json
+++ b/components/o-date/package.json
@@ -33,6 +33,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-editorial-layout/package.json
+++ b/components/o-editorial-layout/package.json
@@ -37,6 +37,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-editorial-typography/package.json
+++ b/components/o-editorial-typography/package.json
@@ -34,6 +34,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-expander/package.json
+++ b/components/o-expander/package.json
@@ -42,6 +42,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-fonts/package.json
+++ b/components/o-fonts/package.json
@@ -32,6 +32,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-footer-services/package.json
+++ b/components/o-footer-services/package.json
@@ -37,6 +37,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-footer/package.json
+++ b/components/o-footer/package.json
@@ -48,6 +48,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-forms/package.json
+++ b/components/o-forms/package.json
@@ -52,7 +52,6 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false,
   "dependencies": {
     "@types/lodash.uniqueid": "^4.0.7",

--- a/components/o-ft-affiliate-ribbon/package.json
+++ b/components/o-ft-affiliate-ribbon/package.json
@@ -34,6 +34,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-grid/package.json
+++ b/components/o-grid/package.json
@@ -36,6 +36,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-header-services/package.json
+++ b/components/o-header-services/package.json
@@ -47,6 +47,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -49,6 +49,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-icons/package.json
+++ b/components/o-icons/package.json
@@ -28,6 +28,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-labels/package.json
+++ b/components/o-labels/package.json
@@ -39,6 +39,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-layout/package.json
+++ b/components/o-layout/package.json
@@ -52,6 +52,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-lazy-load/package.json
+++ b/components/o-lazy-load/package.json
@@ -32,6 +32,5 @@
     "url": "https://github.com/Financial-Times/origami/issues/new?labels=o-lazy-load,components",
     "email": "origami.support@ft.com"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-loading/package.json
+++ b/components/o-loading/package.json
@@ -35,6 +35,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-message/package.json
+++ b/components/o-message/package.json
@@ -46,6 +46,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-meter/package.json
+++ b/components/o-meter/package.json
@@ -42,6 +42,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-multi-select/package.json
+++ b/components/o-multi-select/package.json
@@ -44,7 +44,6 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false,
   "devDependencies": {
     "@financial-times/o-forms": "^9.9.0",

--- a/components/o-normalise/package.json
+++ b/components/o-normalise/package.json
@@ -39,6 +39,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-overlay/package.json
+++ b/components/o-overlay/package.json
@@ -53,6 +53,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-quote/package.json
+++ b/components/o-quote/package.json
@@ -43,6 +43,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-share/package.json
+++ b/components/o-share/package.json
@@ -53,6 +53,5 @@
   "dependencies": {
     "ftdomdelegate": "^4.0.6"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-social-follow/package.json
+++ b/components/o-social-follow/package.json
@@ -48,6 +48,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-spacing/package.json
+++ b/components/o-spacing/package.json
@@ -36,6 +36,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-stepped-progress/package.json
+++ b/components/o-stepped-progress/package.json
@@ -44,6 +44,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-subs-card/package.json
+++ b/components/o-subs-card/package.json
@@ -48,6 +48,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-syntax-highlight/package.json
+++ b/components/o-syntax-highlight/package.json
@@ -35,6 +35,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-table/package.json
+++ b/components/o-table/package.json
@@ -54,6 +54,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-tabs/package.json
+++ b/components/o-tabs/package.json
@@ -38,6 +38,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-teaser-collection/package.json
+++ b/components/o-teaser-collection/package.json
@@ -44,6 +44,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -43,7 +43,6 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false,
   "dependencies": {
     "date-fns": "^1.29.0",

--- a/components/o-toggle/package.json
+++ b/components/o-toggle/package.json
@@ -36,6 +36,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-tooltip/package.json
+++ b/components/o-tooltip/package.json
@@ -52,6 +52,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-top-banner/package.json
+++ b/components/o-top-banner/package.json
@@ -37,6 +37,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-topper/package.json
+++ b/components/o-topper/package.json
@@ -41,6 +41,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -56,6 +56,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-video/package.json
+++ b/components/o-video/package.json
@@ -42,6 +42,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-viewport/package.json
+++ b/components/o-viewport/package.json
@@ -33,6 +33,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }

--- a/components/o-visual-effects/package.json
+++ b/components/o-visual-effects/package.json
@@ -32,6 +32,5 @@
     "node": "14.16.1",
     "npm": "7.11.1"
   },
-  "percy": true,
   "private": false
 }


### PR DESCRIPTION
It does not appear to be used by our percy script. We could instead not run the action given o3 component changes.

If there are o2 and o3 changes in place the action will run but as o3 components have no traditional demos, Percy will not actually do anything.