### PR TITLE
fix: Remove "engines.node" from o3 components

### DIFF
--- a/components/o3-button/package.json
+++ b/components/o3-button/package.json
@@ -30,10 +30,7 @@
 		"build": "bash ../../scripts/component/build-o3.bash o3-button"
 	},
 	"engines": {
-		"npm": "^8 || ^9"
-	},
-	"volta": {
-		"node": "18.17.1"
+		"npm": ">7"
 	},
 	"private": false,
 	"peerDependencies": {

--- a/components/o3-web-token/package.json
+++ b/components/o3-web-token/package.json
@@ -28,10 +28,7 @@
 		"build": "node ../../apps/dictionary/scripts/build-config/build.js"
 	},
 	"engines": {
-		"npm": "^8 || ^9"
-	},
-	"volta": {
-		"node": "18.17.1"
+		"npm": ">7"
 	},
 	"private": false
 }


### PR DESCRIPTION
Origami components do not require node except for development, so we decided to remove engines.node to avoid warnings when users are building components with another node version. The origami repo is a mono repo, so we can rely on the root engines.node for development. Components do require a flat dependency tree, enforced through peer dependencies, so we change engines.npm to a permissive >7.