### PR TITLE
feat: update to use v2 of date-fns npm module

### DIFF
--- a/components/o-teaser/package.json
+++ b/components/o-teaser/package.json
@@ -46,7 +46,7 @@
   "percy": true,
   "private": false,
   "dependencies": {
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.30.0",
     "dateformat": "^3.0.3",
     "dompurify": "^2.3.9",
     "html-react-parser": "^3.0.1"

--- a/components/o-teaser/src/tsx/always-show-timestamp.tsx
+++ b/components/o-teaser/src/tsx/always-show-timestamp.tsx
@@ -1,6 +1,6 @@
 import TimeStamp from './time-stamp';
 import RelativeTime from './relative-time';
-import {differenceInCalendarDays} from 'date-fns';
+import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { Status } from './props';
 
 /**
@@ -8,15 +8,22 @@ import { Status } from './props';
  * If same calendar day, we show relative time e.g. X hours ago or Updated X min ago
  * If different calendar day, we show full Date time e.g. June 9, 2021
  */
-export default (props: Status) => {
-	const localTodayDate = new Date().toISOString().substr(0, 10); // keep only the date bit
-	const dateToCompare = new Date(props.publishedDate)
-		.toISOString()
-		.substr(0, 10);
 
-	if (differenceInCalendarDays(localTodayDate, dateToCompare) >= 1) {
+export default (props: Status) => {
+	const {
+		publishedDate,
+	} = props
+
+	const daysAgo = differenceInCalendarDays(
+		new Date(),
+		typeof publishedDate === 'string' ? parseISO(publishedDate) : publishedDate
+	)
+
+	const oneOrMoreDaysAgo = daysAgo >= 1;
+
+	if (oneOrMoreDaysAgo) {
 		return <TimeStamp {...props} />;
-	} else {
-		return <RelativeTime {...props} showAlways={true} />;
 	}
+
+	return <RelativeTime {...props} showAlways={true} />;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4952,7 +4952,7 @@
 		},
 		"components/ft-concept-button": {
 			"name": "@financial-times/ft-concept-button",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -4974,7 +4974,7 @@
 		},
 		"components/n-notification": {
 			"name": "@financial-times/n-notification",
-			"version": "8.2.4",
+			"version": "8.2.5",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5009,7 +5009,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^2.1.2"
@@ -5037,7 +5037,7 @@
 		},
 		"components/o-banner": {
 			"name": "@financial-times/o-banner",
-			"version": "4.5.0",
+			"version": "4.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5059,7 +5059,7 @@
 		},
 		"components/o-big-number": {
 			"name": "@financial-times/o-big-number",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5076,7 +5076,7 @@
 		},
 		"components/o-buttons": {
 			"name": "@financial-times/o-buttons",
-			"version": "7.8.2",
+			"version": "7.9.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5117,7 +5117,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "10.3.1",
+			"version": "10.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5139,7 +5139,7 @@
 		},
 		"components/o-cookie-message": {
 			"name": "@financial-times/o-cookie-message",
-			"version": "6.6.0",
+			"version": "6.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"superstore-sync": "^2.1.1"
@@ -5173,7 +5173,7 @@
 		},
 		"components/o-editorial-layout": {
 			"name": "@financial-times/o-editorial-layout",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5193,7 +5193,7 @@
 		},
 		"components/o-editorial-typography": {
 			"name": "@financial-times/o-editorial-typography",
-			"version": "2.3.4",
+			"version": "2.3.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.0"
@@ -5237,7 +5237,7 @@
 		},
 		"components/o-footer": {
 			"name": "@financial-times/o-footer",
-			"version": "9.2.7",
+			"version": "9.2.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5262,7 +5262,7 @@
 		},
 		"components/o-footer-services": {
 			"name": "@financial-times/o-footer-services",
-			"version": "4.2.6",
+			"version": "4.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5280,7 +5280,7 @@
 		},
 		"components/o-forms": {
 			"name": "@financial-times/o-forms",
-			"version": "9.11.2",
+			"version": "9.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.uniqueid": "^4.0.7",
@@ -5335,7 +5335,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "11.0.6",
+			"version": "11.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5362,7 +5362,7 @@
 		},
 		"components/o-header-services": {
 			"name": "@financial-times/o-header-services",
-			"version": "5.5.0",
+			"version": "5.5.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5387,7 +5387,7 @@
 		},
 		"components/o-icons": {
 			"name": "@financial-times/o-icons",
-			"version": "7.6.0",
+			"version": "7.7.0",
 			"license": "MIT",
 			"engines": {
 				"npm": "^7 || ^8"
@@ -5395,7 +5395,7 @@
 		},
 		"components/o-labels": {
 			"name": "@financial-times/o-labels",
-			"version": "6.5.6",
+			"version": "6.5.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5414,7 +5414,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -5479,7 +5479,7 @@
 		},
 		"components/o-message": {
 			"name": "@financial-times/o-message",
-			"version": "5.4.2",
+			"version": "5.4.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5",
@@ -5501,7 +5501,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.2",
+			"version": "3.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5519,7 +5519,7 @@
 		},
 		"components/o-multi-select": {
 			"name": "@financial-times/o-multi-select",
-			"version": "2.2.0",
+			"version": "2.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -5556,7 +5556,7 @@
 		},
 		"components/o-overlay": {
 			"name": "@financial-times/o-overlay",
-			"version": "4.2.8",
+			"version": "4.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"focusable": "^2.3.0",
@@ -5588,7 +5588,7 @@
 		},
 		"components/o-quote": {
 			"name": "@financial-times/o-quote",
-			"version": "5.3.2",
+			"version": "5.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5607,7 +5607,7 @@
 		},
 		"components/o-share": {
 			"name": "@financial-times/o-share",
-			"version": "9.0.2",
+			"version": "10.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5636,7 +5636,7 @@
 		},
 		"components/o-social-follow": {
 			"name": "@financial-times/o-social-follow",
-			"version": "1.0.7",
+			"version": "1.0.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5657,7 +5657,7 @@
 		},
 		"components/o-spacing": {
 			"name": "@financial-times/o-spacing",
-			"version": "3.2.3",
+			"version": "3.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5673,7 +5673,7 @@
 		},
 		"components/o-stepped-progress": {
 			"name": "@financial-times/o-stepped-progress",
-			"version": "4.0.7",
+			"version": "4.0.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5694,7 +5694,7 @@
 		},
 		"components/o-subs-card": {
 			"name": "@financial-times/o-subs-card",
-			"version": "6.2.4",
+			"version": "6.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-colors": "^6.5.0",
@@ -5732,7 +5732,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.3.1",
+			"version": "9.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5783,10 +5783,10 @@
 		},
 		"components/o-teaser": {
 			"name": "@financial-times/o-teaser",
-			"version": "6.2.7",
+			"version": "6.2.8",
 			"license": "MIT",
 			"dependencies": {
-				"date-fns": "^1.29.0",
+				"date-fns": "^2.30.0",
 				"dateformat": "^3.0.3",
 				"dompurify": "^2.3.9",
 				"html-react-parser": "^3.0.1"
@@ -5810,7 +5810,7 @@
 		},
 		"components/o-teaser-collection": {
 			"name": "@financial-times/o-teaser-collection",
-			"version": "4.2.3",
+			"version": "4.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5827,11 +5827,6 @@
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.4.1"
 			}
-		},
-		"components/o-teaser/node_modules/date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
 		},
 		"components/o-teaser/node_modules/dateformat": {
 			"version": "3.0.3",
@@ -5857,7 +5852,7 @@
 		},
 		"components/o-tooltip": {
 			"name": "@financial-times/o-tooltip",
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^4.0.6"
@@ -5905,7 +5900,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "6.0.6",
+			"version": "6.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5926,7 +5921,7 @@
 		},
 		"components/o-typography": {
 			"name": "@financial-times/o-typography",
-			"version": "7.4.1",
+			"version": "7.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"fontfaceobserver": "^2.0.9"
@@ -5951,7 +5946,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.9",
+			"version": "7.2.10",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -9550,15 +9545,20 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-			"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
 			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
+				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/@babel/standalone": {
 			"version": "7.16.11",
@@ -27367,9 +27367,12 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
 			"engines": {
 				"node": ">=0.11"
 			},
@@ -62108,11 +62111,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-			"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
 			"requires": {
-				"regenerator-runtime": "^0.13.4"
+				"regenerator-runtime": "^0.14.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+					"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+				}
 			}
 		},
 		"@babel/standalone": {
@@ -63171,17 +63181,12 @@
 			"requires": {
 				"@financial-times/o-date": "^6.0.0",
 				"@financial-times/o-normalise": "^3.3.0",
-				"date-fns": "^1.29.0",
+				"date-fns": "^2.30.0",
 				"dateformat": "^3.0.3",
 				"dompurify": "^2.3.9",
 				"html-react-parser": "^3.0.1"
 			},
 			"dependencies": {
-				"date-fns": {
-					"version": "1.30.1",
-					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-					"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-				},
 				"dateformat": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -76531,9 +76536,12 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"requires": {
+				"@babel/runtime": "^7.21.0"
+			}
 		},
 		"date-format": {
 			"version": "4.0.4",


### PR DESCRIPTION
## Describe your changes

Currently o-teaser uses date-fns version 1. This functionally is fine, however v1 has bad tree shaking capabilities. This means and repository using o-teaser on the front end has a significantly larger bundle size. In next-article, date-fns is responsible for around 1/6th of the JS we ship to the browser.

By updating to version 2, this allows tree shaking and other nice things. The v1 -> v2 change was mostly around types, removing default support for strings in date-fns methods.


This change was pretty hard to test, as I couldn't see examples of testing React components in Origami. I messed around with Storybook to verify it, but if anyone is able to help me write some tests that would be fantastic!

Here's it working:
<img width="1063" alt="The royal wedding" src="https://github.com/Financial-Times/origami/assets/5731733/c5611072-1837-4f6f-a882-4e587182e739">
<img width="1098" alt="The royal wedding" src="https://github.com/Financial-Times/origami/assets/5731733/143dd154-2abc-4786-902c-049d0c6aed3b">




## Issue ticket number and link

https://financialtimes.atlassian.net/browse/CPREL-852

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
