### PR TITLE
fix: release-please, set "last-release-sha"

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
 	"bootstrap-sha": "4d52a27b6c08755d6c527723c2595ade3e024898",
+	"last-release-sha": "05ebbb9f6dee6cfe63ad2b96bb4b783d8ba2b706",
 	"packages": {
 		"components/ft-concept-button": {},
 		"components/g-audio": {},

--- a/scripts/regenerate-ci-config-files.js
+++ b/scripts/regenerate-ci-config-files.js
@@ -28,6 +28,7 @@ await del([".github/workflows/percy-*.yml", ".github/workflows/test-*.yml"])
 let dotReleasePleaseManifest = {}
 let releasePleaseConfig = {
 	"bootstrap-sha": "4d52a27b6c08755d6c527723c2595ade3e024898",
+	"last-release-sha": "05ebbb9f6dee6cfe63ad2b96bb4b783d8ba2b706",
 	packages: {},
 }
 


### PR DESCRIPTION
It looks like release-please is failing to find all tags to represent recent releases, looking through the last 500 commits, and making incorrect release PRs. This effectively blocks us from releasing components.

"[last-release-sha] can be useful when you've accidentally merged a bad release PR" as it will "set the commit sha release-please will use from which to gather commits"

https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
