### PR TITLE
fix: set o3-button peer dependencies as range

### DIFF
--- a/components/o3-button/package.json
+++ b/components/o3-button/package.json
@@ -34,6 +34,6 @@
 	},
 	"private": false,
 	"peerDependencies": {
-		"@financial-times/o3-web-token": "^0.1.2"
+		"@financial-times/o3-web-token": ">=0.1.2 < 1"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,7 +2261,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "3.2.4",
+			"version": "3.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",


### PR DESCRIPTION
## Describe your changes

`npm ci` rejects changes on #1341 due to the peer dependency rules of o3-button, these have been update to accept any version greater than and including the current peer dep and below `1.0.0`.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
