### PR TITLE
fix: remove storybook building from build-website.bash

### DIFF
--- a/scripts/build-website.bash
+++ b/scripts/build-website.bash
@@ -5,8 +5,6 @@
 set -e
 cd apps/astro-website/
 NODE_OPTIONS=--max-old-space-size=10248 npm run astro build
-cd ../storybook/
-npm run build-storybook
 cd ../../
 
 if ! [ -z "$SHOULD_DELETE_ALL_YOUR_FILES" ]; then


### PR DESCRIPTION
## Describe your changes

build-website is failing when it tries to `cd` into the old storybook directory. As this no longer exists, it fails every build.


## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
