### PR TITLE
fix: link astro's storybook links to chromatic

### DIFF
--- a/apps/astro-website/redirects.js
+++ b/apps/astro-website/redirects.js
@@ -48,4 +48,7 @@ export const redirects = {
 		"/blog/2021/07/01/origami-on-npm-and-how-to-migrate",
 	"/docs/": "/documentation",
 	"/docs/developer-guide/": "/documentation",
+	"/storybook/brands/core/": "https://main--655e0e31554f2044e99ab763.chromatic.com",
+	"/storybook/brands/internal/": "https://main--655e310aa5b077441db35a73.chromatic.com",
+	"/storybook/brands/whitelabel/": "https://main--655e316ac888d527a0be5f2b.chromatic.com",
 }


### PR DESCRIPTION
## Describe your changes

Removing Storybook from the website build process broke the links to Storybook. As a fix we will point to the new instances hosted on chromatic.


## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
