### PR TITLE
backstage: link to storybook composition instance

### DIFF
--- a/apps/astro-website/src/pages/storybook.astro
+++ b/apps/astro-website/src/pages/storybook.astro
@@ -42,13 +42,13 @@ const description = "Storybook for Origami components and services"
 				<h2>Supported Brands</h2>
 				<ul>
 					<li>
-						<a href="/storybook/brands/core/"> Core</a>
+						<a href="https://main--655f72ec522e424302dc6201.chromatic.com/?path=/story/o2-core_components"> Core</a>
 					</li>
 					<li>
-						<a href="/storybook/brands/internal/"> Internal</a>
+						<a href="https://main--655f72ec522e424302dc6201.chromatic.com/?path=/story/o2-internal_components"> Internal</a>
 					</li>
 					<li>
-						<a href="/storybook/brands/whitelabel/"> Whitelabel</a>
+						<a href="https://main--655f72ec522e424302dc6201.chromatic.com/?path=/story/o2-whitelabel_components"> Whitelabel</a>
 					</li>
 				</ul>
 			</div>


### PR DESCRIPTION
## Describe your changes

Storybook's composition instance gives a better experience to our users by bringing all of our brands into one Storybook instance. Linking to the headings for each brands will help users see that other brand options are available within storybook should they wish to browse them.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
