### PR TITLE
fix: allow for multiselect options with whitespace

### DIFF
--- a/components/o-multi-select/README.md
+++ b/components/o-multi-select/README.md
@@ -23,6 +23,8 @@ Check out [how to include Origami components in your project](https://origami.ft
 
 `o-multi-select` expects options to be provided in the `<select>` tag. This will make the component accessible for users with screen readers and users with JavaScript disabled. The component will automatically enhance the experience for users with JavaScript enabled.
 
+The value must not contain whitespace characters, as it should be valid as an [id attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
+
 ```html
 <div class="o-multi-select" data-o-component="o-multi-select">
   <select name="multiple" id="fruits" multiple>
@@ -106,7 +108,7 @@ const oMultiSelectElement = document.getElementById(
 oMultiSelect.init(oMultiSelectElement);
 ```
 
-### Events 
+### Events
 
 `o-multi-select` dispatches a custom event `oMultiSelect.OptionChange` that bubbles. It is triggered when an option gets selected or removed. The event data has the following interface:
 

--- a/components/o-multi-select/src/js/multi-select-options.js
+++ b/components/o-multi-select/src/js/multi-select-options.js
@@ -2,12 +2,12 @@
  * adds or removes the selection of a multi-select option in selected list.
  *
  * @param {HTMLElement} optionEl - The option element that was selected.
- * @param {string} option - The text content of the option that was selected.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {number} index - The index of the option that was selected.
  * @returns {void}
  */
 export function handleOptionSelect(optionEl, option, index) {
-	let alreadySelected = optionEl.classList.contains(
+	const alreadySelected = optionEl.classList.contains(
 		'o-multi-select-option__selected'
 	);
 	if (alreadySelected) {
@@ -32,7 +32,7 @@ export function handleOptionSelect(optionEl, option, index) {
  * Dispatches custom event with important details.
  *
  * @param {HTMLElement} optionEl - The option element that was selected.
- * @param {string} option - The text content of the option that was selected.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {boolean} selected - Determines if the element is selected or not.
  * @param {number} index - The index of the option that was selected.
  * @returns {void}
@@ -42,7 +42,7 @@ function handleCustomEvent(optionEl, option, selected, index) {
 		bubbles: true,
 		detail: {
 			optionElement: optionEl,
-			value: option,
+			value: option.value,
 			selected: selected,
 			index,
 			instance: this,
@@ -56,7 +56,7 @@ function handleCustomEvent(optionEl, option, selected, index) {
  *
  * @private
  * @param {HTMLElement} optionEl - The option element to remove.
- * @param {string} option - The text content of the option to remove.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {number} index - The index of the option to remove.
  * @returns {void}
  */
@@ -64,7 +64,7 @@ function removeOption(optionEl, option, index) {
 	optionEl.classList.remove('o-multi-select-option__selected');
 	optionEl.setAttribute('aria-selected', 'false');
 	this._numberOfSelectedOptions--;
-	const button = this._selectedOptions.querySelector(`#${option}-${index}`);
+	const button = this._selectedOptions.querySelector(`#${option.value}-${index}`);
 	button.parentElement.remove();
 	this._updateState();
 }
@@ -74,7 +74,7 @@ function removeOption(optionEl, option, index) {
  *
  * @private
  * @param {HTMLElement} optionEl - The option element to add.
- * @param {string} option - The text content of the option to add.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {number} index - The index of the option to add.
  * @returns {void}
  */
@@ -99,18 +99,18 @@ export function addSelectedOption(optionEl, option, index) {
  * Creates a button for a multi-select option.
  *
  * @private
- * @param {string} option - The text content of the option.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {number} index - The index of the option.
  * @returns {{ li: HTMLElement, button: HTMLElement }} An object containing the newly created <li> and <button> elements.
  */
 function createOptionButton(option, index) {
 	const li = document.createElement('li');
 	const button = document.createElement('button');
-	button.id = `${option}-${index}`;
+	button.id = `${option.value}-${index}`;
 	button.setAttribute('aria-label', ` remove ${option} `);
 	button.className = 'o-multi-select__selected-options-button';
 	button.type = 'button';
-	button.innerText = option;
+	button.innerText = option.label;
 	const span = document.createElement('span');
 	span.classList = 'o-icons-icon o-icons-icon--cross';
 	button.appendChild(span);
@@ -123,7 +123,7 @@ function createOptionButton(option, index) {
  * Creates an option element for a multi-select.
  *
  * @param {string} idBase - The base ID to use for the option element.
- * @param {string} option - The text content of the option.
+ * @param {{ label: string, value: string }} option - The text content and value of the option.
  * @param {number} index - The index of the option.
  * @param {boolean} [selected=false] - Whether the option should be selected.
  * @returns {HTMLElement} The newly created option element.
@@ -134,7 +134,7 @@ export function createOption(idBase, option, index, selected) {
 	optionEl.id = `${idBase}-${index}`;
 	optionEl.className = 'o-multi-select-option';
 	optionEl.setAttribute('aria-selected', selected);
-	optionEl.innerText = option;
+	optionEl.innerText = option.label;
 	const tickSpan = document.createElement('span');
 	tickSpan.className = 'o-multi-select-option-tick';
 	optionEl.appendChild(tickSpan);

--- a/components/o-multi-select/src/js/multi-select.js
+++ b/components/o-multi-select/src/js/multi-select.js
@@ -207,7 +207,7 @@ class MultiSelect {
 	_getCoreOptions() {
 		const options = this._coreWrapper.querySelectorAll('option');
 		this._coreOptions = options;
-		return [...options].map((option) => option.innerText);
+		return [...options].map((option) => ({ label: option.innerText, value: option.value }));
 	}
 
 	/**

--- a/components/o-multi-select/src/tsx/multi-select.tsx
+++ b/components/o-multi-select/src/tsx/multi-select.tsx
@@ -1,5 +1,6 @@
 type MultiSelectType = {
 	label: string;
+	value?: string;
 	selected: boolean;
 };
 
@@ -21,7 +22,7 @@ export function MultiSelect({
 		<span className="o-multi-select" data-o-component="o-multi-select">
 			<select name={id} id={id} multiple={true} value={selectedOptionsValues} required={required}>
 				{multiSelectOptions.map(option => (
-					<option key={option.label} value={option.label}>
+					<option key={option.value || option.label} value={option.value || option.label}>
 						{option.label}
 					</option>
 				))}

--- a/components/o-multi-select/stories/multi-select.stories.tsx
+++ b/components/o-multi-select/stories/multi-select.stories.tsx
@@ -32,7 +32,7 @@ export const MultiSelectDefault = args => {
 MultiSelectDefault.storyName = 'Multi Select';
 MultiSelectDefault.args = {
 	multiSelectOptions: [
-		{label: 'Apple', selected: false},
+		{label: 'Apple Pie', selected: false, value: 'apple-pie'},
 		{label: 'Banana', selected: false},
 		{label: 'Blueberry', selected: false},
 		{label: 'Boysenberry', selected: true},


### PR DESCRIPTION
## Describe your changes

Currently we use a string label to create the multiselect option elements. When one of these labels has a whitespace character, it cannot be removed, as querySelector doesn't find the element with the whitespace in the ID.

This change adds a new optional "key" to the TSX template (allowing users of the TSX to have a different value to the label), and ensure the value is used for creating the ID (rather than the label).

**Context: ** we want to use this in Spark for selecting categories for Specialist articles, however those categories sometimes have spaces (e.g. "Policy & Regulation"). Ideally, we'd use the category's UUID as the value, and the label as "Policy & Regulation").

## Issue ticket number and link
N/A

## Link to Figma designs
N/A

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
