### PR TITLE
fix: show pre-selected options in the select box and use option label…

### DIFF
--- a/components/o-multi-select/src/js/multi-select-options.js
+++ b/components/o-multi-select/src/js/multi-select-options.js
@@ -107,7 +107,7 @@ function createOptionButton(option, index) {
 	const li = document.createElement('li');
 	const button = document.createElement('button');
 	button.id = `${option.value}-${index}`;
-	button.setAttribute('aria-label', ` remove ${option} `);
+	button.setAttribute('aria-label', ` remove ${option.label} `);
 	button.className = 'o-multi-select__selected-options-button';
 	button.type = 'button';
 	button.innerText = option.label;

--- a/components/o-multi-select/src/tsx/multi-select.tsx
+++ b/components/o-multi-select/src/tsx/multi-select.tsx
@@ -16,7 +16,7 @@ export function MultiSelect({
 }) {
 	const selectedOptionsValues = multiSelectOptions
 		.filter(option => option.selected)
-		.map(option => option.label);
+		.map(option => option.value || option.label);
 
 	return (
 		<span className="o-multi-select" data-o-component="o-multi-select">

--- a/components/o-multi-select/stories/multi-select.stories.tsx
+++ b/components/o-multi-select/stories/multi-select.stories.tsx
@@ -34,6 +34,7 @@ MultiSelectDefault.args = {
 	multiSelectOptions: [
 		{label: 'Apple Pie', selected: false, value: 'apple-pie'},
 		{label: 'Banana', selected: false},
+		{label: 'Banana Split', selected: true, value: 'banana-split'},
 		{label: 'Blueberry', selected: false},
 		{label: 'Boysenberry', selected: true},
 		{label: 'Cherry', selected: false},


### PR DESCRIPTION
… for aria-label

Now that a value can be provided, that should be used when formatting the selectedOptionsValues rather than the label, otherwise the pre-selected options are not displayed correctly.

## Describe your changes
Following on from [this PR](https://github.com/Financial-Times/origami/pull/1379), we found that any pre-selected options that were providing a value as well as a label, were not being displayed correctly in the select box. 

This change fixes that by using the option's value, with the label as a fallback, when formatting the selectedOptionsValues before they are passed to the select element. 

It also fixes the aria-label which was showing `[object object]`.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
