### PR TITLE
fix: Use textContent rather than innerText

### DIFF
--- a/components/o-multi-select/src/js/multi-select-options.js
+++ b/components/o-multi-select/src/js/multi-select-options.js
@@ -110,7 +110,7 @@ function createOptionButton(option, index) {
 	button.setAttribute('aria-label', ` remove ${option.label} `);
 	button.className = 'o-multi-select__selected-options-button';
 	button.type = 'button';
-	button.innerText = option.label;
+	button.textContent = option.label;
 	const span = document.createElement('span');
 	span.classList = 'o-icons-icon o-icons-icon--cross';
 	button.appendChild(span);
@@ -134,7 +134,7 @@ export function createOption(idBase, option, index, selected) {
 	optionEl.id = `${idBase}-${index}`;
 	optionEl.className = 'o-multi-select-option';
 	optionEl.setAttribute('aria-selected', selected);
-	optionEl.innerText = option.label;
+	optionEl.textContent = option.label;
 	const tickSpan = document.createElement('span');
 	tickSpan.className = 'o-multi-select-option-tick';
 	optionEl.appendChild(tickSpan);

--- a/components/o-multi-select/src/js/multi-select.js
+++ b/components/o-multi-select/src/js/multi-select.js
@@ -207,7 +207,7 @@ class MultiSelect {
 	_getCoreOptions() {
 		const options = this._coreWrapper.querySelectorAll('option');
 		this._coreOptions = options;
-		return [...options].map((option) => ({ label: option.innerText, value: option.value }));
+		return [...options].map((option) => ({ label: option.textContent, value: option.value }));
 	}
 
 	/**


### PR DESCRIPTION
## Describe your changes

I've been writing tests using react-testing-library for my usecase of the multiselect but have struggled because the option's innerText was undefined. Apparently innerText is not implemented in jsdom so this PR changes to use `textContent` instead.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
