### PR TITLE
docs: correct case for example buttons

### DIFF
--- a/apps/for-everyone-website/src/content/docs/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/components/buttons.mdx
@@ -53,17 +53,17 @@ Buttons may be used with icons, without icons, or only icons.
 
 ### Without icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### With icon
 
 When icons are used, these are always left aligned.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", icon: "search"}} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", icon: "search"}} />
 
 ### Only icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", icon: "search", iconOnly: true }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", icon: "search", iconOnly: true }} />
 
 ## Sizes
 
@@ -71,11 +71,11 @@ The button comes in two sizes: standard and small.
 
 ### Standard
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### Small
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", size: "small" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", size: "small" }} />
 
 ## Types
 
@@ -85,35 +85,35 @@ There are three types of buttons to support different contexts.
 
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### Secondary
 
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
-<Preview component={Button} componentProps={{label: "hello", type: "secondary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "secondary" }} />
 
 ### Ghost
 
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
-<Preview component={Button} componentProps={{label: "hello", type: "ghost" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "ghost" }} />
 
 ## Themes
 
 Each button type supports the following themes.
 
 ### Standard
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### Inverse
 
 An alternative theme for use on dark backgrounds.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### Mono
 
 Mono can be helpful where the standard theme distracts from other colour used, for example when placed near data visualisations.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "mono" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "mono" }} />

--- a/apps/for-everyone-website/src/content/docs/professional/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/professional/components/buttons.mdx
@@ -51,17 +51,17 @@ Buttons may be used with icons, without icons, or only icons.
 
 ### Without icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### With icon
 
 When icons are used, these are always left aligned.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", icon: "search"}} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search"}} />
 
 ### Only icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", icon: "search", iconOnly: true }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search", iconOnly: true }} />
 
 ## Sizes
 
@@ -69,11 +69,11 @@ The button comes in two sizes: standard and small.
 
 ### Standard
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### Small
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", size: "small" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", size: "small" }} />
 
 ## Types
 
@@ -83,19 +83,19 @@ There are three types of buttons to support different contexts.
 
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### Secondary
 
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
-<Preview component={Button} componentProps={{label: "hello", type: "secondary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "secondary", theme: "inverse" }} />
 
 ### Ghost
 
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
-<Preview component={Button} componentProps={{label: "hello", type: "ghost", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "ghost", theme: "inverse" }} />
 
 ## Themes
 
@@ -103,10 +103,10 @@ Each button type supports the following themes.
 
 ### Standard
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### Inverse
 
 An alternative theme for use on dark backgrounds.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />

--- a/apps/for-everyone-website/src/content/docs/sustainable-views/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/sustainable-views/components/buttons.mdx
@@ -51,17 +51,17 @@ Buttons may be used with icons, without icons, or only icons.
 
 ### Without icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### With icon
 
 When icons are used, these are always left aligned.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", icon: "search"}} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search"}} />
 
 ### Only icon
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", icon: "search", iconOnly: true }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search", iconOnly: true }} />
 
 ## Sizes
 
@@ -69,11 +69,11 @@ The button comes in two sizes: standard and small.
 
 ### Standard
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### Small
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse", size: "small" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", size: "small" }} />
 
 ## Types
 
@@ -83,19 +83,19 @@ There are three types of buttons to support different contexts.
 
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
 
 ### Secondary
 
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
-<Preview component={Button} componentProps={{label: "hello", type: "secondary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "secondary", theme: "inverse" }} />
 
 ### Ghost
 
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
-<Preview component={Button} componentProps={{label: "hello", type: "ghost", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "ghost", theme: "inverse" }} />
 
 ## Themes
 
@@ -103,10 +103,10 @@ Each button type supports the following themes.
 
 ### Standard
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
 
 ### Inverse
 
 An alternative theme for use on dark backgrounds.
 
-<Preview component={Button} componentProps={{label: "hello", type: "primary", theme: "inverse" }} />
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />


### PR DESCRIPTION
## Describe your changes
Changes `hello` to `Hello` on example buttons to match the documentation rules on casing

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
