### PR TITLE
fix: o3-button, ensure icons remain with forced colours

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -413,6 +413,16 @@
 	background-color: currentColor;
 }
 
+/*
+	Ensure iconography is maintained when forced colours is enabled.
+	E.g. Windows High Contrast Mode
+ */
+@media (forced-colors: active) {
+	.o3-button-icon::before {
+		mask-image: var(--o3-button-icon);
+	}
+}
+
 .o3-button-icon:not(.o3-button-icon--icon-only)::before {
 	margin-right: var(--o3-spacing-4xs);
 }


### PR DESCRIPTION
Windows High Contrast mode, for example, removes masks. We used to handle this with a MS specific vendor prefix, but I believe we can use the standard now. https://github.com/Financial-Times/origami/blob/15e56104c821871b520f1db969259544e1bc99ea/components/o-icons/src/scss/_mixins.scss#L51