### PR TITLE
Force light mode in for-everyone site

### DIFF
--- a/apps/for-everyone-website/astro.config.mjs
+++ b/apps/for-everyone-website/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
 				LanguageSelect: './src/components/LanguageSelect.astro',
 				ContentPanel: './src/components/ContentPanel.astro',
 				ThemeSelect: './src/components/EmptyComponent.astro',
+				ThemeProvider: './src/components/ThemeProvider.astro',
 			},
 			customCss: [
 				'./src/styles/custom.css',

--- a/apps/for-everyone-website/src/components/ThemeProvider.astro
+++ b/apps/for-everyone-website/src/components/ThemeProvider.astro
@@ -1,0 +1,10 @@
+---
+// Starlight reads this data-theme attribute to show a light or dark theme.
+//
+// Starlight's stock ThemeProvider component will use the 'prefers-color-scheme' media query to set
+// this, but Origami doesn't support a dark mode yet, so we always set it to light.
+---
+
+<script is:inline>
+	document.documentElement.dataset.theme = 'light';
+</script>


### PR DESCRIPTION
## Describe your changes

The changes introduced in the last for-everyone PR (https://github.com/Financial-Times/origami/pull/1396) meant that Starlight loaded its stock `ThemeProvider` component, which will automatically set light or dark mode depending on the 'prefers-color-scheme' media query (essentially, whatever your machine's dark or light mode setting).

This PR fixes this, and uses a custom `ThemeProvider` that just tells Startlight to always show a light theme.e

## Issue ticket number and link

https://financialtimes.atlassian.net/browse/OR-482

## Link to Figma designs

N/A

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
