### PR TITLE
Add 'internal' brand to for-everyone site

### DIFF
--- a/apps/dictionary/tokens/internal/base/color.json
+++ b/apps/dictionary/tokens/internal/base/color.json
@@ -4,47 +4,91 @@
       "palette": {
         "black": {
           "type": "color",
-          "value": "#000"
+          "value": "#000",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ]
         },
         "white": {
           "value": "#fff",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ]
         },
         "oxford": {
           "value": "#0F5499",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ]
         },
         "teal": {
           "value": "#0D7680",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ]
         },
         "slate": {
           "value": "#262A33",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ]
         },
         "slate-white-5": {
           "value": "#F4F4F5",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ]
         },
         "slate-white-15": {
           "value": "#DEDFE0",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ]
         },
         "lemon": {
           "value": "#FFEC1A",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ]
         },
         "jade": {
           "value": "#00994d",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ]
         },
         "mandarin": {
           "value": "#F83",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ]
         },
         "crimson": {
           "value": "#c00",
-          "type": "color"
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ]
         },
         "black-5": {
           "value": "#F2F2F2",

--- a/apps/for-everyone-website/README.md
+++ b/apps/for-everyone-website/README.md
@@ -37,6 +37,13 @@ We use [Starlight's internationalisation features](https://starlight.astro.build
 
 This also means search is brand specific. Typically, this feature relies on the `lang` html attribute to correctly search only content for the selected language. We have applied that to brands using a [private subtag](https://datatracker.ietf.org/doc/html/rfc4646#section-4.5) e.g. `lang="en-GB-x-prof"`. Note that all subtags have a maximum length of 8 characters and whitespace is not permitted, we must therefore appreciate brands here.
 
+### Add A New Brand
+
+- Add a new 'locale' to `astro.config.mjs` for the new brand
+- Update `src/components/ContentPanel.astro` to map the 'locale' to brand CSS class.
+- Copy content from an existing brand, switching out the brand-specific CSS file import for that component, and updating the Figma and Storybook links.
+- Copy other documentation mdx files that contain brand-specific content or styles, and edit according to your brand.
+
 ## Commands
 
 All commands are run from the root of the project, from a terminal:

--- a/apps/for-everyone-website/astro.config.mjs
+++ b/apps/for-everyone-website/astro.config.mjs
@@ -26,6 +26,10 @@ export default defineConfig({
 				  label: 'sustainable views',
 				  lang: 'en-GB-x-sv',
 				},
+				'internal': {
+				  label: 'internal',
+				  lang: 'en-GB-x-internal',
+				},
 			},
 			components: {
 				Hero: './src/components/Hero.astro',

--- a/apps/for-everyone-website/src/components/ContentPanel.astro
+++ b/apps/for-everyone-website/src/components/ContentPanel.astro
@@ -6,6 +6,8 @@ function getBrandClassFromLocale(lang: string) {
 			return "o3-brand-professional"
 		case "en-GB-x-sv":
 			return "o3-brand-sustainable-views"
+		case "en-GB-x-internal":
+			return "o3-brand-internal"
 		case "en-GB-x-core":
 		default:
 			return "o3-brand-core"

--- a/apps/for-everyone-website/src/content/docs/internal/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/internal/components/buttons.mdx
@@ -1,0 +1,112 @@
+---
+title: Buttons
+description: Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
+---
+import { Button } from '@financial-times/o3-button';
+import '@financial-times/o3-button/css/internal.css';
+import {renderToString} from 'react-dom/server';
+import { Code } from 'astro:components';
+import { default as ButtonAnatomy } from '../../../../components/ButtonAnatomy.astro';
+import {Content as ButtonGuidelines} from '../../../../content-partial/docs/components/buttons-guidelines.mdx';
+
+
+export function Preview ({component: Component, componentProps } = props) {
+    const ComponentInstance = Component(componentProps);
+    const componentHtml = renderToString(ComponentInstance);
+    const componentJSX = `<${Component.name} ${Object.entries(componentProps).map(p => `${p[0]}="${p[1]}"`).join(' ')} />`;
+    const inverse = componentProps['theme'] === 'inverse';
+    return <>
+        <div style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${inverse ? 'background-color: black' : ''}`}>
+        <Component {...componentProps} />
+        </div>
+        <a style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"href={`https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story/core-internal-o3-${Component.name.toLowerCase()}--${Component.name.toLowerCase()}&args=${Object.entries(componentProps).map(p => `${p[0]}:${p[1]};`).join('')}`}>Open in StoryBook</a> | <a style="display: inline-block; margin: var(--o3-spacing-2xs) 0;" href="https://www.figma.com/file/H9vTWZgEzqzTtX689nwq4R/Internal---Design-System?type=design&node-id=2819-133&mode=design&t=kSGXDAsaMo9vsgY3-0">Open in Figma</a>
+        <details>
+            <summary>code</summary>
+            <Code code={componentJSX} lang="jsx" theme="css-variables" />
+            <Code code={componentHtml} lang="html" theme="css-variables" />
+        </details>
+        <hr />
+    </>
+}
+
+Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
+
+## Anatomy
+
+The button component contains two required elements and one optional element.
+
+<ButtonAnatomy />
+
+1. <strong>Icon (optional)</strong>: Most buttons don't need an icon. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
+1. <strong>Label</strong>: Text that explains the result of selecting the button. Use action verbs or phrases to tell the user what will happen next.
+1. <strong>Container</strong>: has minimum width of 80px for standard buttons and 64px for small buttons.
+
+## Usage Guidelines
+
+<ButtonGuidelines />
+
+## Icons
+
+Buttons may be used with icons, without icons, or only icons.
+
+### Without icon
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
+
+### With icon
+
+When icons are used, these are always left aligned.
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search"}} />
+
+### Only icon
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", icon: "search", iconOnly: true }} />
+
+## Sizes
+
+The button comes in two sizes: standard and small.
+
+### Standard
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
+
+### Small
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse", size: "small" }} />
+
+## Types
+
+There are three types of buttons to support different contexts.
+
+### Primary
+
+The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />
+
+### Secondary
+
+For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
+
+<Preview component={Button} componentProps={{label: "Hello", type: "secondary", theme: "inverse" }} />
+
+### Ghost
+
+For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
+
+<Preview component={Button} componentProps={{label: "Hello", type: "ghost", theme: "inverse" }} />
+
+## Themes
+
+Each button type supports the following themes.
+
+### Standard
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary" }} />
+
+### Inverse
+
+An alternative theme for use on dark backgrounds.
+
+<Preview component={Button} componentProps={{label: "Hello", type: "primary", theme: "inverse" }} />

--- a/apps/for-everyone-website/src/content/docs/internal/guides/colours.mdx
+++ b/apps/for-everyone-website/src/content/docs/internal/guides/colours.mdx
@@ -7,7 +7,7 @@ import Palette from '../../../../components/Palette.astro';
 
 ## Primary Palette
 
-These are the FT primary brand colours. They are established colours that make up the FT corporate identity and FT brand. FT pink and FT grey are not used for digital UI, but may be helpful for use alongside FT branded static assets such as the FT logo. For example, FT Pink could be used to prevent a flash of the wrong colour as a logo loads.
+These are based on a subsection of FT primary brand colours. They are established colours that make up the FT corporate identity and FT brand.
 
 <Palette brand='internal' type="palette" palette="primary" />
 

--- a/apps/for-everyone-website/src/content/docs/internal/guides/colours.mdx
+++ b/apps/for-everyone-website/src/content/docs/internal/guides/colours.mdx
@@ -1,0 +1,26 @@
+---
+title: Colours
+description: A guide in my new Starlight docs site
+---
+
+import Palette from '../../../../components/Palette.astro';
+
+## Primary Palette
+
+These are the FT primary brand colours. They are established colours that make up the FT corporate identity and FT brand. FT pink and FT grey are not used for digital UI, but may be helpful for use alongside FT branded static assets such as the FT logo. For example, FT Pink could be used to prevent a flash of the wrong colour as a logo loads.
+
+<Palette brand='internal' type="palette" palette="primary" />
+
+## Secondary Palette
+
+Secondary colours provide visual hierarchy to differentiate content and are brand identifiers of the FT.
+
+<Palette brand='internal' type="palette" palette="secondary" />
+
+## Tertiary Palette
+
+<Palette brand='internal' type="palette" palette="tertiary" />
+
+## Usecases
+
+<Palette brand='internal' type="use-case" />

--- a/libraries/o3-tooling-token/build/internal/_variables.js
+++ b/libraries/o3-tooling-token/build/internal/_variables.js
@@ -4,6 +4,10 @@ export default {
 		"value": "#000",
 		"originalValue": "#000",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"primary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -18,6 +22,10 @@ export default {
 		"value": "#fff",
 		"originalValue": "#fff",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"primary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -32,6 +40,10 @@ export default {
 		"value": "#0F5499",
 		"originalValue": "#0F5499",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"primary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -46,6 +58,10 @@ export default {
 		"value": "#0D7680",
 		"originalValue": "#0D7680",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"primary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -60,6 +76,10 @@ export default {
 		"value": "#262A33",
 		"originalValue": "#262A33",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"secondary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -74,6 +94,10 @@ export default {
 		"value": "#F4F4F5",
 		"originalValue": "#F4F4F5",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"secondary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -88,6 +112,10 @@ export default {
 		"value": "#DEDFE0",
 		"originalValue": "#DEDFE0",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"secondary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -102,6 +130,10 @@ export default {
 		"value": "#FFEC1A",
 		"originalValue": "#FFEC1A",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"secondary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -116,6 +148,10 @@ export default {
 		"value": "#00994d",
 		"originalValue": "#00994d",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"tertiary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -130,6 +166,10 @@ export default {
 		"value": "#F83",
 		"originalValue": "#F83",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"tertiary"
+		],
 		"path": [
 				"o3",
 				"color",
@@ -144,6 +184,10 @@ export default {
 		"value": "#c00",
 		"originalValue": "#c00",
 		"type": "color",
+		"origamiKeys": [
+				"palette",
+				"tertiary"
+		],
 		"path": [
 				"o3",
 				"color",


### PR DESCRIPTION
> [!NOTE]  
> This PR is a draft pending an exploration into a better and less-duplicate-y approach to supporting brands in the site

## Describe your changes

This PR adds the 'internal' brand to the for-everyone website, making it available as an option in the brand picker.

The steps for adding a new brand are as follows:

* Add a new 'locale' to `astro.config.mjs` for the new brand
* Tell the `ContentPanel` component which CSS file to load when this language/brand is set as active
* Copy all components over from an existing brand, switching out the brand-specific CSS file import for that component, and updating the Figma and Storybook links
* Copy other documentation mdx files that contain brand-specific content or styles that have to be manually set

👆 _Of these, that last step could absolutely be improved!_