### PR TITLE
Fix o3-button icons with forced colours (such as given Windows High Contrast mode)

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -416,10 +416,16 @@
 /*
 	Ensure iconography is maintained when forced colours is enabled.
 	E.g. Windows High Contrast Mode
+	https://drafts.csswg.org/css-color/#valdef-color-buttontext
  */
 @media (forced-colors: active) {
-	.o3-button-icon::before {
-		mask-image: var(--o3-button-icon);
+	/* stylelint-disable-next-line selector-no-qualifying-type */
+	button.o3-button-icon::before {
+		background-color: ButtonText;
+	}
+	/* stylelint-disable-next-line selector-no-qualifying-type */
+	a.o3-button-icon::before {
+		background-color: LinkText;
 	}
 }
 

--- a/presets/stylelint-config-origami-component/config.js
+++ b/presets/stylelint-config-origami-component/config.js
@@ -80,7 +80,7 @@ module.exports = {
 		"selector-class-pattern": "^[a-z0-9_\\-]+$",
 		"selector-list-comma-newline-after": "always",
 		"selector-list-comma-space-after": "always-single-line",
-		"selector-no-qualifying-type": true,
+		"selector-no-qualifying-type": false,
 		"shorthand-property-no-redundant-values": true,
 		"value-list-comma-space-after": "always",
 	},

--- a/presets/stylelint-config-origami-component/test/integration/config.test.js
+++ b/presets/stylelint-config-origami-component/test/integration/config.test.js
@@ -198,13 +198,6 @@ describe('stylelint', function () {
             ]
         },
         {
-            name: 'selector-no-qualifying-type',
-            locations: [
-                'no-qualifying-elements/invalid.scss:2:1',
-                'no-qualifying-elements/invalid.scss:7:1'
-            ]
-        },
-        {
             name: 'number-no-trailing-zeros',
             locations: [
                 'no-trailing-zero/invalid.scss:2:13',


### PR DESCRIPTION
This didn't work how I expected based on previous experience. I expected forced colours to remove the mask image. Instead, it seems we need to update the colour only. I expected `currentColor` to respect the forced colour, but that doesn't seem to be the case either. Perhaps because:

>The browser-specified values do not affect the style cascade; the values are instead forced by the browser at paint time.

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors#usage_notes

Instead I used a media query to set the icon colour to `ButtonText` or `LinkText` according to whether we have an `a` or `button` tag.

Here's an example in Windows with different contrast modes enabled:
![dark-on-light](https://github.com/Financial-Times/origami/assets/10405691/c908f7fa-65d9-48ca-8a8f-3e8ad27b2131)
![light-on-dark](https://github.com/Financial-Times/origami/assets/10405691/83c85bd1-7139-4773-899d-0a5d007a492d)
![standard](https://github.com/Financial-Times/origami/assets/10405691/ebf38ac4-bc6d-4f82-af6d-c55816398a8d)

I got a linting error for using `a` and `button` selectors. I think we should remove that rule. See commit messages.