### PR TITLE
Adjust o3-pagination styles, add mobile/'narrow' mode (OR-490)

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -360,19 +360,55 @@
 
 .o3-button-pagination {
 	display: flex;
-	gap: var(--o3-spacing-5xs);
+	container-type: inline-size;
+	gap: var(--o3-spacing-4xs);
 }
 
 .o3-button-pagination,
-.o3-button-pagination > .o3-button,
-.o3-button-pagination > .o3-button.o3-button-icon--icon-only {
-	--_o3-button-min-width: 36px;
+.o3-button-pagination>.o3-button,
+.o3-button-pagination>.o3-button.o3-button-icon--icon-only {
+	--_o3-button-min-width: 38px;
 }
 
 .o3-button-pagination--small,
-.o3-button-pagination--small > .o3-button.o3-button--small,
-.o3-button-pagination--small > .o3-button.o3-button-icon--icon-only {
+.o3-button-pagination--small>.o3-button.o3-button--small,
+.o3-button-pagination--small>.o3-button.o3-button-icon--icon-only {
 	--_o3-button-min-width: 24px;
+}
+
+@supports (container-type: inline-size) {
+	/*
+	 * If container is less than the width of 9 buttons (2 arrows + 7 total pages/ellipses),
+	 * hide some buttons for a 'narrow' view.
+	 *
+	 * Read as: calc(--_o3-button-min-width * 9 + var(--o3-spacing-4xs) * 8) + 24px padding
+	 */
+	@container (width < calc((38px * 9) + (0.5rem * 8) + 24px)) {
+		.o3-button-pagination:not(.o3-button-pagination--small)>.o3-button[data-hide-when-narrow="true"] {
+			display: none;
+		}
+	}
+
+	@container (width < calc((24px * 9) + (0.5rem * 8) + 24px)) {
+		.o3-button-pagination--small>.o3-button[data-hide-when-narrow="true"] {
+			display: none;
+		}
+	}
+}
+
+@supports not (container-type: inline-size) {
+	/*
+	 * 600px used as 'mobile' breakpoint according to Google's material design guidelines
+	 * (https://m2.material.io/design/layout/responsive-layout-grid.html#breakpoints)
+	 */
+	@media screen and (max-width:600px) {
+		.o3-button-pagination:not(.o3-button-pagination--small)>.o3-button[data-hide-when-narrow="true"] {
+			display: none;
+		}
+		.o3-button-pagination--small>.o3-button[data-hide-when-narrow="true"] {
+			display: none;
+		}
+	}
 }
 
 .o3-button-pagination__ellipsis {
@@ -383,10 +419,6 @@
 
 .o3-button-pagination--small .o3-button-pagination__ellipsis {
 	font-size: var(--o3-font-size-1);
-}
-
-.o3-button-pagination > .o3-button[disabled] {
-	visibility: hidden;
 }
 
 /* Grouped buttons */

--- a/components/o3-button/src/tsx/pagination.tsx
+++ b/components/o3-button/src/tsx/pagination.tsx
@@ -83,6 +83,48 @@ function splitPages(pages, currentPage) {
 	}
 }
 
+function getPagesInNarrowMode(pages, currentPage) {
+	const thirdPageNumberFromEnd = pages.length + 1 - 3;
+	const lastPageNumber = pages.length;
+	const numberOfPagesToShowAtATime = 5;
+
+	const pagesBetweenNumbers = (from, to) =>
+		pages.filter(page => page.number >= from && page.number <= to);
+
+	const pageMatchingNumber = pageNumber =>
+		pages.filter(page => page.number === pageNumber);
+
+	if (pages.length <= numberOfPagesToShowAtATime) {
+		return [...pages];
+	}
+
+	if (!currentPage) {
+		return [...pages.slice(0, numberOfPagesToShowAtATime)];
+	}
+
+	if (currentPage.number <= 3) {
+		return [
+			...pagesBetweenNumbers(1, 3),
+			...pageMatchingNumber(lastPageNumber),
+		];
+	}
+
+	if (currentPage.number >= thirdPageNumberFromEnd) {
+		return [
+			...pageMatchingNumber(1),
+			...pagesBetweenNumbers(thirdPageNumberFromEnd, lastPageNumber),
+		];
+	}
+
+	if (currentPage.number > 3) {
+		return [
+			...pageMatchingNumber(1),
+			...pageMatchingNumber(currentPage.number),
+			...pageMatchingNumber(lastPageNumber),
+		];
+	}
+}
+
 export function ButtonPagination({
 	size = '',
 	theme,
@@ -93,10 +135,14 @@ export function ButtonPagination({
 	const NextTag = nextPager.href ? LinkButton : Button;
 	const PreviousTag = previousPager.href ? LinkButton : Button;
 	const currentPage = pages.find(page => page.current);
-	const pagesToDisplayInGroups = splitPages(pages, currentPage);
+
+	const pagesToDisplayInGroupsWideMode = splitPages(pages, currentPage);
+	const pagesInNarrowMode = getPagesInNarrowMode(pages, currentPage);
+
 	const lastPageIsSelected = currentPage === pages[pages.length - 1];
 	const firstPageIsSelected = currentPage === pages[0];
-	const pageElementsInGroups = pagesToDisplayInGroups.map(pageGroup =>
+
+	const pageElementsInGroups = pagesToDisplayInGroupsWideMode!.map(pageGroup =>
 		pageGroup.map(page => {
 			const PageTag = page.href ? LinkButton : Button;
 
@@ -109,6 +155,10 @@ export function ButtonPagination({
 			}
 			if (page.onClick) {
 				pageAttributes['onClick'] = page.onClick;
+			}
+
+			if (!pagesInNarrowMode.includes(page)) {
+				pageAttributes['data-hide-when-narrow'] = 'true';
 			}
 
 			return (


### PR DESCRIPTION
## Describe your changes

This PR implements a few design changes to o3-button's pagination component, as well as adding a new 'mobile'/'narrow' mode which displays 2 fewer pages/ellipses in the component.

For more information about the design changes (mostly just sizing and padding tweaks), [see these Figma designs](https://www.figma.com/file/VVM0PixrY3IRZq2ZUTdWfU/branch/bqahQbKeVCXJVHXBwwDnPx/Core---Design-System?type=design&node-id=5463-1742&mode=design&t=Zbmi7Flkfu6RX3Uw-0).

The new narrow mode works by displaying 5 pages/ellipses between the < and > arrows, instead of 7. This is achieved by labelling 2 of the 7 pages with 'data-hide-when-narrow' attribute, [according to the different combinations of buttons we display depending on the currently-selected page](https://www.figma.com/file/VVM0PixrY3IRZq2ZUTdWfU/branch/bqahQbKeVCXJVHXBwwDnPx/Core---Design-System?type=design&node-id=5816-6923&mode=design&t=Zbmi7Flkfu6RX3Uw-0).

<img width="780" alt="image" src="https://github.com/Financial-Times/origami/assets/122021901/7160fb24-0a12-4588-ab16-9e557fe0ef39">

The pagination component will automatically remove these two 'hide-when-narrow' pages when the o3-pagination container's width drops below "9 * pagination block width + 8 * gap + 24px of a bit more padding".

This is achieved using container queries! If container queries aren't supported, we fall back to using a regular 600px media query.

### With container queries

https://github.com/Financial-Times/origami/assets/122021901/79bed5f3-32b3-4e8e-8bbe-507a726f24bd

### With a media query

(Those white flashes are from Storybook, they're nothing to do with the component!)

https://github.com/Financial-Times/origami/assets/122021901/48c25e1e-e4c1-4b2f-905c-3f48014d75fb

## Issue ticket number and link

**OR-490** (https://financialtimes.atlassian.net/browse/OR-490)

## Link to Figma designs

https://www.figma.com/file/VVM0PixrY3IRZq2ZUTdWfU/branch/bqahQbKeVCXJVHXBwwDnPx/Core---Design-System?type=design&node-id=5463-1742&mode=design&t=Zbmi7Flkfu6RX3Uw-0

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
