### PR TITLE
fix: pagination improvements

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -104,9 +104,9 @@
 }
 
 .o3-button.o3-button--primary:active,
-.o3-button--primary[aria-selected='true'],
-.o3-button--primary[aria-current],
-.o3-button--primary[aria-pressed='true'] {
+.o3-button.o3-button--primary[aria-selected='true'],
+.o3-button.o3-button--primary[aria-current],
+.o3-button.o3-button--primary[aria-pressed='true'] {
 	color: var(--_o3-button-primary-standard-active-color);
 	background-color: var(--_o3-button-primary-standard-active-background);
 	border-color: var(--_o3-button-primary-standard-active-border);
@@ -132,9 +132,9 @@
 }
 
 .o3-button.o3-button--primary.o3-button--inverse:active,
-.o3-button--primary.o3-button--inverse[aria-selected='true'],
-.o3-button--primary.o3-button--inverse[aria-current],
-.o3-button--primary.o3-button--inverse[aria-pressed='true'] {
+.o3-button.o3-button--primary.o3-button--inverse[aria-selected='true'],
+.o3-button.o3-button--primary.o3-button--inverse[aria-current],
+.o3-button.o3-button--primary.o3-button--inverse[aria-pressed='true'] {
 	color: var(--_o3-button-primary-inverse-active-color);
 	background-color: var(--_o3-button-primary-inverse-active-background);
 	border-color: var(--_o3-button-primary-inverse-active-border);
@@ -161,9 +161,9 @@
 }
 
 .o3-button.o3-button--primary.o3-button--mono:active,
-.o3-button--primary.o3-button--mono[aria-selected='true'],
-.o3-button--primary.o3-button--mono[aria-current],
-.o3-button--primary.o3-button--mono[aria-pressed='true'] {
+.o3-button.o3-button--primary.o3-button--mono[aria-selected='true'],
+.o3-button.o3-button--primary.o3-button--mono[aria-current],
+.o3-button.o3-button--primary.o3-button--mono[aria-pressed='true'] {
 	color: var(--_o3-button-primary-mono-active-color);
 	background-color: var(--_o3-button-primary-mono-active-background);
 	border-color: var(--_o3-button-primary-mono-active-border);
@@ -189,9 +189,9 @@
 }
 
 .o3-button.o3-button--secondary:active,
-.o3-button--secondary[aria-selected='true'],
-.o3-button--secondary[aria-current],
-.o3-button--secondary[aria-pressed='true'] {
+.o3-button.o3-button--secondary[aria-selected='true'],
+.o3-button.o3-button--secondary[aria-current],
+.o3-button.o3-button--secondary[aria-pressed='true'] {
 	color: var(--_o3-button-secondary-standard-active-color);
 	background-color: var(--_o3-button-secondary-standard-active-background);
 	border-color: var(--_o3-button-secondary-standard-active-border);
@@ -218,9 +218,9 @@
 }
 
 .o3-button.o3-button--secondary.o3-button--inverse:active,
-.o3-button--secondary.o3-button--inverse[aria-selected='true'],
-.o3-button--secondary.o3-button--inverse[aria-current],
-.o3-button--secondary.o3-button--inverse[aria-pressed='true'] {
+.o3-button.o3-button--secondary.o3-button--inverse[aria-selected='true'],
+.o3-button.o3-button--secondary.o3-button--inverse[aria-current],
+.o3-button.o3-button--secondary.o3-button--inverse[aria-pressed='true'] {
 	color: var(--_o3-button-secondary-inverse-active-color);
 	background-color: var(--_o3-button-secondary-inverse-active-background);
 	border-color: var(--_o3-button-secondary-inverse-active-border);
@@ -247,9 +247,9 @@
 }
 
 .o3-button.o3-button--secondary.o3-button--mono:active,
-.o3-button--secondary.o3-button--mono[aria-selected='true'],
-.o3-button--secondary.o3-button--mono[aria-current],
-.o3-button--secondary.o3-button--mono[aria-pressed='true'] {
+.o3-button.o3-button--secondary.o3-button--mono[aria-selected='true'],
+.o3-button.o3-button--secondary.o3-button--mono[aria-current],
+.o3-button.o3-button--secondary.o3-button--mono[aria-pressed='true'] {
 	color: var(--_o3-button-secondary-mono-active-color);
 	background-color: var(--_o3-button-secondary-mono-active-background);
 	border-color: var(--_o3-button-secondary-mono-active-border);
@@ -276,9 +276,9 @@
 }
 
 .o3-button.o3-button--ghost:active,
-.o3-button--ghost[aria-selected='true'],
-.o3-button--ghost[aria-current],
-.o3-button--ghost[aria-pressed='true'] {
+.o3-button.o3-button--ghost[aria-selected='true'],
+.o3-button.o3-button--ghost[aria-current],
+.o3-button.o3-button--ghost[aria-pressed='true'] {
 	color: var(--_o3-button-ghost-standard-active-color);
 	background-color: var(--_o3-button-ghost-standard-active-background);
 	border-color: var(--_o3-button-ghost-standard-active-border);
@@ -305,9 +305,9 @@
 }
 
 .o3-button.o3-button--ghost.o3-button--inverse:active,
-.o3-button--ghost.o3-button--inverse[aria-selected='true'],
-.o3-button--ghost.o3-button--inverse[aria-current],
-.o3-button--ghost.o3-button--inverse[aria-pressed='true'] {
+.o3-button.o3-button--ghost.o3-button--inverse[aria-selected='true'],
+.o3-button.o3-button--ghost.o3-button--inverse[aria-current],
+.o3-button.o3-button--ghost.o3-button--inverse[aria-pressed='true'] {
 	color: var(--_o3-button-ghost-inverse-active-color);
 	background-color: var(--_o3-button-ghost-inverse-active-background);
 	border-color: var(--_o3-button-ghost-inverse-active-border);
@@ -334,9 +334,9 @@
 }
 
 .o3-button.o3-button--ghost.o3-button--mono:active,
-.o3-button--ghost.o3-button--mono[aria-selected='true'],
-.o3-button--ghost.o3-button--mono[aria-current],
-.o3-button--ghost.o3-button--mono[aria-pressed='true'] {
+.o3-button.o3-button--ghost.o3-button--mono[aria-selected='true'],
+.o3-button.o3-button--ghost.o3-button--mono[aria-current],
+.o3-button.o3-button--ghost.o3-button--mono[aria-pressed='true'] {
 	color: var(--_o3-button-ghost-mono-active-color);
 	background-color: var(--_o3-button-ghost-mono-active-background);
 	border-color: var(--_o3-button-ghost-mono-active-border);
@@ -371,12 +371,6 @@
 	--_o3-button-min-width: 38px;
 }
 
-.o3-button-pagination--small,
-.o3-button-pagination--small>.o3-button.o3-button--small,
-.o3-button-pagination--small>.o3-button.o3-button-icon--icon-only {
-	--_o3-button-min-width: 24px;
-}
-
 @supports (container-type: inline-size) {
 	/*
 	 * If container is less than the width of 9 buttons (2 arrows + 7 total pages/ellipses),
@@ -384,14 +378,13 @@
 	 *
 	 * Read as: calc(--_o3-button-min-width * 9 + var(--o3-spacing-4xs) * 8) + 24px padding
 	 */
-	@container (width < calc((38px * 9) + (0.5rem * 8) + 24px)) {
-		.o3-button-pagination:not(.o3-button-pagination--small)>.o3-button[data-hide-when-narrow="true"] {
+	@container (width <= calc((38px * 9) + (0.5rem * 8) + 24px)) {
+		.o3-button-pagination > [data-o3-button-show-when="wide"] {
 			display: none;
 		}
 	}
-
-	@container (width < calc((24px * 9) + (0.5rem * 8) + 24px)) {
-		.o3-button-pagination--small>.o3-button[data-hide-when-narrow="true"] {
+	@container (width > calc((38px * 9) + (0.5rem * 8) + 24px)) {
+		.o3-button-pagination > [data-o3-button-show-when="narrow"] {
 			display: none;
 		}
 	}
@@ -399,14 +392,16 @@
 
 @supports not (container-type: inline-size) {
 	/*
-	 * 600px used as 'mobile' breakpoint according to Google's material design guidelines
-	 * (https://m2.material.io/design/layout/responsive-layout-grid.html#breakpoints)
+	 * 740px aligns with our legacy o-grid M layout
+	 * (https://registry.origami.ft.com/components/o-grid@6.1.7/readme?brand=core#Readme)
 	 */
-	@media screen and (max-width:600px) {
-		.o3-button-pagination:not(.o3-button-pagination--small)>.o3-button[data-hide-when-narrow="true"] {
+	 @media screen and (max-width: 740px) {
+		.o3-button-pagination > [data-o3-button-show-when="wide"] {
 			display: none;
 		}
-		.o3-button-pagination--small>.o3-button[data-hide-when-narrow="true"] {
+	}
+	 @media screen and (min-width: 741px) {
+		.o3-button-pagination > [data-o3-button-show-when="narrow"] {
 			display: none;
 		}
 	}
@@ -416,10 +411,6 @@
 	font-size: var(--o3-font-size-3);
 	text-align: center;
 	min-width: var(--_o3-button-min-width);
-}
-
-.o3-button-pagination--small .o3-button-pagination__ellipsis {
-	font-size: var(--o3-font-size-1);
 }
 
 /* Grouped buttons */

--- a/components/o3-button/stories/pagination-template.tsx
+++ b/components/o3-button/stories/pagination-template.tsx
@@ -11,7 +11,7 @@ type PaginationStory = Omit<StoryObj, 'args'> & {
 const ButtonPaginationTemplate: TemplateType = {
 	...TemplateSBConfig,
 	parameters: {
-		controls: {include: ['size', 'theme']},
+		controls: {include: ['theme']},
 	},
 	render: args => {
 		const configuredCurrentPage = args.pages.find(page => page.current);


### PR DESCRIPTION
- Fix pages displayed on mobile when there are between 5-7 pages.
- Remove small pagination option. We do not recommend this.
- Use legacy o-grid values for media queries, for now.
- Correct specificity of selected buttons.

before/after
![Capture-2024-02-02-112634](https://github.com/Financial-Times/origami/assets/10405691/58a26d55-53ca-4ca2-b8f3-bc0dae810f47)
![Capture-2024-02-02-112233](https://github.com/Financial-Times/origami/assets/10405691/936e07a3-e05a-42b9-a143-72d5962b9195)
