### PR TITLE
docs: display g-audio demos in o2-storybook

### DIFF
--- a/components/g-audio/package.json
+++ b/components/g-audio/package.json
@@ -1,25 +1,26 @@
 {
-	"name": "@financial-times/g-audio",
-	"version": "2.0.2",
-	"description": "IG audio player component",
-	"keywords": [
-		"audio"
-	],
-	"browser": "main.js",
-	"type": "module",
-	"scripts": {
-		"start": "npx serve ./demos/local",
-		"build": "bash ../../scripts/component/build.bash",
-		"test": "bash ../../scripts/component/test.bash",
+  "name": "@financial-times/g-audio",
+  "version": "2.0.2",
+  "description": "IG audio player component",
+  "keywords": [
+    "audio"
+  ],
+  "browser": "main.js",
+  "type": "module",
+  "scripts": {
+    "start": "npx serve ./demos/local",
+    "build": "bash ../../scripts/component/build.bash",
+    "test": "bash ../../scripts/component/test.bash",
     "debug:js": "bash ../../scripts/component/debug-js.bash",
-		"lint": "bash ../../scripts/component/lint.bash",
-		"watch": "bash ../../scripts/component/watch.bash"
-	},
-	"engines": {
-		"npm": ">=7"
-	},
-	"peerDependencies": {
-		"@financial-times/o-icons": "^7.2.1"
-	},
-	"private": false
+    "lint": "bash ../../scripts/component/lint.bash",
+    "watch": "bash ../../scripts/component/watch.bash"
+  },
+  "engines": {
+    "node": "18.18.2",
+    "npm": ">7"
+  },
+  "peerDependencies": {
+    "@financial-times/o-icons": "^7.2.1"
+  },
+  "private": false
 }

--- a/components/g-audio/stories/block.stories.tsx
+++ b/components/g-audio/stories/block.stories.tsx
@@ -1,0 +1,26 @@
+
+export default {
+	title: 'Components/g-audio/Block',
+	args: {},
+	parameters: {
+		html: {},
+	},
+};
+
+export const Block = args => {
+
+	return (<>
+		<iframe
+			loading="lazy"
+			scrolling="yes"
+			allowTransparency="true"
+			src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=block&system_code=origami&brand=core"
+			title="Inline Live Demo"
+			style={{
+				height: 'calc(100vh - 3rem)',
+				'box-sizing': 'border-box',
+				border: '0',
+				width: '100%',
+			}}></iframe>
+	</>);
+}

--- a/components/g-audio/stories/inline.stories.tsx
+++ b/components/g-audio/stories/inline.stories.tsx
@@ -1,0 +1,26 @@
+
+export default {
+	title: 'Components/g-audio/Inline',
+	args: {},
+	parameters: {
+		html: {},
+	},
+};
+
+export const Inline = args => {
+
+	return (<>
+		<iframe
+			loading="lazy"
+			scrolling="yes"
+			allowTransparency="true"
+			src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=inline&system_code=origami&brand=core"
+			title="Inline Live Demo"
+			style={{
+				height: 'calc(100vh - 3rem)',
+				'box-sizing': 'border-box',
+				border: '0',
+				width: '100%',
+			}}></iframe>
+	</>);
+}

--- a/components/g-audio/stories/readme.stories.mdx
+++ b/components/g-audio/stories/readme.stories.mdx
@@ -1,0 +1,11 @@
+import {Meta, Markdown} from "@storybook/blocks";
+import Readme from '../README.md';
+
+<Meta
+	title="components/g-audio/Readme"
+/>
+
+
+<Markdown>
+	{Readme}
+</Markdown>


### PR DESCRIPTION
## Describe your changes
Moves registry demos for g-audio to O2 storybook.

The demos are iframed from the build service, this is the path of least resistance to get the demos in storybook.

## Issue ticket number and link
[OR-517](https://financialtimes.atlassian.net/browse/OR-517?atlOrigin=eyJpIjoiOGRmMzliMWYwODRiNDYwYjk0N2NkMDAzZTM2MDY0NGEiLCJwIjoiaiJ9)
## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-517]: https://financialtimes.atlassian.net/browse/OR-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ