### PR TITLE
fix: exclude o3 components from o2-chromatic deployments

### DIFF
--- a/.github/workflows/o2-chromatic.yml
+++ b/.github/workflows/o2-chromatic.yml
@@ -7,7 +7,8 @@ on:
       - "package.json"
       - "package-lock.json"
       - "apps/o2-storybook/**"
-      - "components/o-*/**"
+      - "components/**"
+      - "!components/o3-*/**"
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
## Describe your changes

Previous path filters would only allows components prefixed with `o-*` to trigger the Chromatic Github Actions script. Meaning changes to components such as `g-audio` or `ft-concept-button` would never trigger a new release.

This PR instead triggers on all changes within `components/` except directories prefixed with `o3-*`.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
