### PR TITLE
fix: ci-2030 report button text color change on aria-pressed

### DIFF
--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -238,7 +238,6 @@
 			&:hover {
 				border-color: transparent !important;
 			}
-
 			span,
 			i {
 				color: oColorsByName('teal-50');
@@ -550,6 +549,9 @@
 			color: var(--palette-text-000) !important;
 			background: var(--palette-primary-500) !important;
 			border: 0;
+			& span, & i {
+				color: var(--palette-text-000) !important;
+			}
 		}
 
 		.coral-featuredComment-content {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,7 +1576,8 @@
 			"name": "@financial-times/g-audio",
 			"version": "2.0.2",
 			"engines": {
-				"npm": ">=7"
+				"node": "18.18.2",
+				"npm": ">7"
 			},
 			"peerDependencies": {
 				"@financial-times/o-icons": "^7.2.1"


### PR DESCRIPTION
## Describe your changes

o-comments coral-talk-iframe SASS file

As per https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?issueParent=420949&selectedIssue=CI-2030, if you press the Report button in the comments section, and its state becomes aria-pressed="true", the background goes teal but it is not making the text white, and therefore you have teal text on a teal background. This because there is another selector for `span` and `i` (line 241-244) that keeps the color as teal. This change ensures that nested `span` and `i` also get the right colors.

## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?issueParent=420949&selectedIssue=CI-2030

## Link to Figma designs
NA bug fix

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
