### PR TITLE
fix: transform fontFamily values when building tokens

### DIFF
--- a/apps/dictionary/scripts/build-config/utils.js
+++ b/apps/dictionary/scripts/build-config/utils.js
@@ -156,6 +156,7 @@ export function buildCSS({sources, destination, tokenFilter, parentSelector}) {
 					'ts/size/lineheight',
 					'ts/descriptionToComment',
 					'ts/typography/css/shorthand',
+					'ts/typography/css/fontFamily',
 					'ts/border/css/shorthand',
 					'ts/shadow/css/shorthand',
 					'ts/color/css/hexrgba',


### PR DESCRIPTION
Building tokens that include the `fontFamily` type previously did not correctly transform, resulting in the value being a string without quotes. Adding the Tokens Studio transform for this fixes this.

Below illustrates the issue:
**
![css custom properties incorrectly using a string value without quotes](https://github.com/Financial-Times/origami/assets/7166831/9af9e9d6-4d94-45a5-a2b9-6e0b6765241a)
**

## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
