### PR TITLE
fix: ci-2084 new Coral notifications button needs overrides

### DIFF
--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -142,6 +142,9 @@
 		}
 
 		// there is a nested div with no static selector that is set to have a height of 24px, which breaks the bar design. this resets it.
+		.coral-tabBar-notifications {
+			padding: 2px 8px;
+		}
 		.coral-tabBar-notifications > div[class^="TabBar-notificationsIcon"] {
 			height: auto;
 		}

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -111,11 +111,11 @@
 			@include oTypographyLink($theme: ('base': 'teal-40', 'hover': 'teal-30'));
 		}
 
-
 		// top tab bar buttons
 		.coral-tabBar-comments,
 		.coral-tabBar-myProfile,
-		.coral-tabBar-configure {
+		.coral-tabBar-configure,
+		.coral-tabBar-notifications {
 			@include oButtonsContent($opts: (
 				'type': 'secondary'
 			));
@@ -139,6 +139,11 @@
 				border-top: 1px !important;
 				border-bottom: 1px solid oButtonsGetColor($state: 'default', $property: 'background', $type: 'primary') !important;
 			}
+		}
+
+		// there is a nested div with no static selector that is set to have a height of 24px, which breaks the bar design. this resets it.
+		.coral-tabBar-notifications > div[class^="TabBar-notificationsIcon"] {
+			height: auto;
 		}
 
 		.coral-tabBar-comments div i,


### PR DESCRIPTION
## Describe your changes
Coral UI has a new notifications button which has a specified height in pixels in a nest div, which is taller than the other buttons.

This resets the height of the div to auto, and amends the padding to get the item to the same height at the other tab buttons.

Currently:
![Screenshot 2024-02-21 at 11 35 02](https://github.com/Financial-Times/origami/assets/996106/9ccbfb58-43f7-4917-98c2-f015b739380b)

With changes:
![Screenshot 2024-02-21 at 11 39 02](https://github.com/Financial-Times/origami/assets/996106/f98fbae5-cdb6-4cc2-a2a0-05226414c5b1)


## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?issueParent=420949&selectedIssue=CI-2084


## Link to Figma designs
NA

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
