### PR TITLE
fix: ci-2084 SASS was outputting more styles for & than expected

### DIFF
--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -142,13 +142,13 @@
 		}
 
 		// there is a nested div with no static selector that is set to have a height of 24px, which breaks the bar design. this resets it.
-		// the other buttons have icons that show up alongside the text at narrower widths, whereas this just has the icon, so the padding needs increased to match them in that situation
 		.coral-tabBar-notifications {
 			padding: 2px 8px;
-			.coral-width-lt-sm &,
-			.coral-width-lte-sm & {
-				padding: 17px 8px;
-			}
+		}
+		// the other buttons have icons that show up alongside the text at narrower widths, whereas this just has the icon, so the padding needs increased to match them in that situation
+		.coral-width-lt-sm .coral-tabBar-notifications,
+		.coral-width-lte-sm .coral-tabBar-notifications {
+			padding: 17px 8px;
 		}
 
 		/* stylelint-disable-next-line selector-no-qualifying-type */


### PR DESCRIPTION
## Describe your changes
This is a follow-up to https://github.com/Financial-Times/origami/pull/1450 - the `&` resulted in a lot more selectors being pulled through than I expected, so I've gone to something more static

## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?assignee=5be57e310e625003a46e9693&selectedIssue=CI-2084

## Link to Figma designs
N/A

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
