### PR TITLE
feat: ci-2129 o-date allow users to set text case

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ brew install rg
    npm install
    ```
 
-3. Run the storybook. This will server storybook on <http://localhost:6969>, and open your web browser :)
+3. Run the storybook. This will server storybook on <http://localhost:6006>, and open your web browser :)
 
    ```shell
    npm run storybook

--- a/components/o-date/README.md
+++ b/components/o-date/README.md
@@ -51,9 +51,7 @@ Note: There used to be `time-ago-abbreviated` and `time-ago-abbreviated-limit-4-
 
 The formatted date defaults to all lower case (https://github.com/Financial-Times/ft-date-format/blob/master/index.js), e.g. `'an hour ago`.
 
-Set the `data-o-date-text-case` attribute to customise the case of the `time` element text:
-- `sentence`: capitalise only the first letter (e.g. `'An hour ago'`).
-- `upper`: capitalise all the letters (e.g. `'AN HOUR AGO'`).
+Set `data-o-date-text-case=sentence` attribute on the `time` element to capitalise only the first letter of the text (e.g. `'An hour ago'`).
 
 ### Copy Options
 

--- a/components/o-date/README.md
+++ b/components/o-date/README.md
@@ -47,6 +47,14 @@ Set the `data-o-date-format` attribute to customise how the `time` element is pr
 
 Note: There used to be `time-ago-abbreviated` and `time-ago-abbreviated-limit-4-hours` options which are now both deprecated. These options still work but no longer show an abbreviated date. They will be removed in a future major version.
 
+#### Text case
+
+The formatted date defaults to all lower case (https://github.com/Financial-Times/ft-date-format/blob/master/index.js), e.g. `'an hour ago`.
+
+Set the `data-o-date-text-case` attribute to customise the case of the `time` element text:
+- `sentence`: capitalise only the first letter (e.g. `'An hour ago'`).
+- `upper`: capitalise all the letters (e.g. `'AN HOUR AGO'`).
+
 ### Copy Options
 
 By default `o-date` will replace the contents of the `time` element with the formatted date. To include extra content alongside the formatted date add an element with the `data-o-date-printer` attribute. `o-date` will output the formatted date within the `data-o-date-printer` element and will not change other child elements.

--- a/components/o-date/src/js/date.js
+++ b/components/o-date/src/js/date.js
@@ -190,8 +190,6 @@ class ODate {
 
 		if (textCase === 'sentence') {
 			formattedDate = `${formattedDate.charAt(0).toUpperCase()}${formattedDate.substring(1)}`;
-		} else if (textCase === 'upper') {
-			formattedDate = formattedDate.toUpperCase();
 		}
 
 		// To avoid triggering a parent live region unnecessarily

--- a/components/o-date/src/js/date.js
+++ b/components/o-date/src/js/date.js
@@ -159,6 +159,9 @@ class ODate {
 		const format = printer.getAttribute('data-o-date-format') ||
 			this.el.getAttribute('data-o-date-format');
 
+		const textCase =  printer.getAttribute('data-o-date-text-case') ||
+		this.el.getAttribute('data-o-date-text-case');
+
 		let formattedDate;
 
 		if (format === 'today-or-yesterday-or-nothing') {
@@ -183,6 +186,12 @@ class ODate {
 			formattedDate = ftDateFormat.format(date, format);
 		} else {
 			formattedDate = ftDateFormat.ftTime(date);
+		}
+
+		if (textCase === 'sentence') {
+			formattedDate = `${formattedDate.charAt(0).toUpperCase()}${formattedDate.substring(1)}`;
+		} else if (textCase === 'upper') {
+			formattedDate = formattedDate.toUpperCase();
 		}
 
 		// To avoid triggering a parent live region unnecessarily

--- a/components/o-date/src/tsx/date.tsx
+++ b/components/o-date/src/tsx/date.tsx
@@ -11,14 +11,20 @@ export type DateFormat =
 	// from https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
 	| (string & {});
 
+export type DateTextCase =
+	| 'sentence'
+	| 'upper'
+
 export interface DateProps {
 	dateTime: string;
 	format?: DateFormat;
+	textCase?: DateTextCase;
 }
 
 export function Date({
 	dateTime,
 	format,
+	textCase,
 	children,
 }: React.PropsWithChildren<DateProps>): JSX.Element {
 	return (
@@ -26,7 +32,8 @@ export function Date({
 			data-o-component="o-date"
 			className="o-date"
 			dateTime={dateTime}
-			data-o-date-format={format}>
+			data-o-date-format={format}
+			data-o-date-text-case={textCase}>
 			{children}
 		</time>
 	);
@@ -34,14 +41,16 @@ export function Date({
 
 export interface DatePrinterProps {
 	format?: DateFormat;
+	textCase?: DateTextCase;
 }
 
 export function DatePrinter({
 	format,
+	textCase,
 	children,
 }: React.PropsWithChildren<DatePrinterProps>): JSX.Element {
 	return (
-		<span data-o-date-printer data-o-date-format={format}>
+		<span data-o-date-printer data-o-date-format={format} data-o-date-text-case={textCase}>
 			{children}
 		</span>
 	);

--- a/components/o-date/src/tsx/date.tsx
+++ b/components/o-date/src/tsx/date.tsx
@@ -13,7 +13,6 @@ export type DateFormat =
 
 export type DateTextCase =
 	| 'sentence'
-	| 'upper'
 
 export interface DateProps {
 	dateTime: string;

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -32,6 +32,21 @@ export default {
 				'time-ago-no-seconds',
 			],
 		},
+		textCase: {
+			options: [
+				null,
+				'sentence',
+				'upper'
+			],
+			control: {
+				type: 'select',
+				labels: {
+					'null': 'Default',
+					'sentence': 'Sentence',
+					'upper': 'Upper'
+				},
+			}
+		}
 	},
 	parameters: {controls: {sort: 'requiredFirst'}},
 } as ComponentMeta<typeof ODate>;

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -35,15 +35,13 @@ export default {
 		textCase: {
 			options: [
 				null,
-				'sentence',
-				'upper'
+				'sentence'
 			],
 			control: {
 				type: 'select',
 				labels: {
 					'null': 'Default',
-					'sentence': 'Sentence',
-					'upper': 'Upper'
+					'sentence': 'Sentence'
 				},
 			}
 		}

--- a/components/o-date/test/markup.test.js
+++ b/components/o-date/test/markup.test.js
@@ -139,6 +139,38 @@ describe('o-date DOM', () => {
 			});
 		});
 
+		describe('today-or-yesterday-or-nothing with sentence text case', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
+				mockDateElement.dataset.oDateTextCase = 'sentence';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, 'Today');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('today-or-yesterday-or-nothing with upper text case', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
+				mockDateElement.dataset.oDateTextCase = 'upper';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, 'TODAY');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
 		describe('date-only', () => {
 			beforeEach(() => {
 				mockDateElement.dataset.odateformat = 'date-only';

--- a/components/o-date/test/markup.test.js
+++ b/components/o-date/test/markup.test.js
@@ -155,22 +155,6 @@ describe('o-date DOM', () => {
 			});
 		});
 
-		describe('today-or-yesterday-or-nothing with upper text case', () => {
-			beforeEach(() => {
-				mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
-				mockDateElement.dataset.oDateTextCase = 'upper';
-				new ODate(mockDateElement);
-			});
-
-			it('renders the date in the element', () => {
-				proclaim.equal(mockDateElement.innerHTML, 'TODAY');
-			});
-
-			it('adds a title attribute containing the full date', () => {
-				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
-			});
-		});
-
 		describe('date-only', () => {
 			beforeEach(() => {
 				mockDateElement.dataset.odateformat = 'date-only';


### PR DESCRIPTION
## Describe your changes

An additional optional setting in o-date config to allow users to specify either sentence case or upper case for the text produced by using a data attribute.

## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?assignee=5be57e310e625003a46e9693&selectedIssue=CI-2129

https://financialtimes.slack.com/archives/C02FU5ARJ/p1709116210339189

## Link to Figma designs
N/A

Before
![Screenshot 2024-03-01 at 14 46 44](https://github.com/Financial-Times/origami/assets/996106/5aac1596-227b-4bbb-98d0-96e4b44b28d6)

After
![Screenshot 2024-03-01 at 14 47 01](https://github.com/Financial-Times/origami/assets/996106/ad705fe2-ec46-431f-a41f-a7620a1541de)


## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [X] If it is a new feature, I have added thorough tests.
- [X] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
