### PR TITLE
fix: reference parentNode in o-header-services navigation

### DIFF
--- a/components/o-header-services/src/tsx/header-services.tsx
+++ b/components/o-header-services/src/tsx/header-services.tsx
@@ -4,7 +4,7 @@ import {
 	SecondaryNavProps,
 	NavItem,
 	ListItem,
-} from "./navs";
+} from './navs';
 
 type TitleProps = {
 	title: string;
@@ -17,7 +17,7 @@ type TitleProps = {
 
 interface HeaderServicesProps extends TitleProps {
 	secondaryNavData?: SecondaryNavProps;
-	theme?: "b2b" | "b2c";
+	theme?: 'b2b' | 'b2c';
 	bleeedHeader?: boolean;
 	relatedContentAlwaysVisible?: boolean;
 }
@@ -33,14 +33,13 @@ export function HeaderServices({
 	bleeedHeader,
 	relatedContentAlwaysVisible,
 }: HeaderServicesProps) {
-	const classNames = ["o-header-services"];
+	const classNames = ['o-header-services'];
 	theme && classNames.push(`o-header-services--${theme}`);
-	bleeedHeader && classNames.push("o-header-services--bleed");
+	bleeedHeader && classNames.push('o-header-services--bleed');
 	return (
 		<header
-			className={classNames.join(" ")}
-			data-o-component="o-header-services"
-		>
+			className={classNames.join(' ')}
+			data-o-component="o-header-services">
 			<Title
 				title={title}
 				tagline={tagline}
@@ -49,7 +48,7 @@ export function HeaderServices({
 				primaryNavData={primaryNavData}
 				relatedContentAlwaysVisible={relatedContentAlwaysVisible}
 			/>
-			{primaryNavData && <PrimaryNav navItems={primaryNavData} />}
+			{/*{primaryNavData && <PrimaryNav navItems={primaryNavData} />}*/}
 			{secondaryNavData && <SecondaryNav {...secondaryNavData} />}
 		</header>
 	);
@@ -61,12 +60,15 @@ function Title({
 	titleUrl,
 	relatedContent,
 	primaryNavData,
-	relatedContentAlwaysVisible
+	relatedContentAlwaysVisible,
 }: TitleProps) {
-	const homeUrl = titleUrl || "/";
-	const hasHamburgerMenu = relatedContent?.length > 0 || primaryNavData;
-	const relatedClassNames = ['o-header-services__related-content']
-	relatedContentAlwaysVisible && relatedClassNames.push('o-header-services__related-content--always-visible')
+	const homeUrl = titleUrl || '/';
+	const hasHamburgerMenu = relatedContent?.length > 0 || !!primaryNavData;
+	const relatedClassNames = ['o-header-services__related-content'];
+	relatedContentAlwaysVisible &&
+		relatedClassNames.push(
+			'o-header-services__related-content--always-visible'
+		);
 	return (
 		<div className="o-header-services__top">
 			{hasHamburgerMenu && (
@@ -74,8 +76,7 @@ function Title({
 					<a
 						className="o-header-services__hamburger-icon"
 						href="#core-nav-fallback"
-						role="button"
-					>
+						role="button">
 						<span className="o-header-services__visually-hidden">
 							Open primary navigation
 						</span>
@@ -92,12 +93,14 @@ function Title({
 				)}
 			</div>
 			{relatedContent && (
-				<ul className={relatedClassNames.join(" ")}>
+				<ul className={relatedClassNames.join(' ')}>
 					{relatedContent.map((element, i) => {
-						if ("url" in element && "label" in element) {
-						return <li key={i}>
-							<a href={element.url}>{element.label}</a>
-						</li>
+						if ('url' in element && 'label' in element) {
+							return (
+								<li key={i}>
+									<a href={element.url}>{element.label}</a>
+								</li>
+							);
 						} else return element;
 					})}
 				</ul>

--- a/components/o-header-services/src/tsx/header-services.tsx
+++ b/components/o-header-services/src/tsx/header-services.tsx
@@ -48,7 +48,7 @@ export function HeaderServices({
 				primaryNavData={primaryNavData}
 				relatedContentAlwaysVisible={relatedContentAlwaysVisible}
 			/>
-			{/*{primaryNavData && <PrimaryNav navItems={primaryNavData} />}*/}
+			{primaryNavData && <PrimaryNav navItems={primaryNavData} />}
 			{secondaryNavData && <SecondaryNav {...secondaryNavData} />}
 		</header>
 	);

--- a/components/o-header-services/src/tsx/navs.tsx
+++ b/components/o-header-services/src/tsx/navs.tsx
@@ -109,7 +109,7 @@ function DropDown({
 				className="o-header-services__drop-down-button"
 				type="button"
 				name="button"
-				aria-label={`Toggle ${parent} dropdown menu`}></button>
+				aria-label={`Toggle ${parentName} dropdown menu`}></button>
 			<ul data-o-header-services-level="2" aria-hidden="true">
 				{dropdownItems.map((item, i) => {
 					const attr = item.current ? 'page' : undefined;


### PR DESCRIPTION
## Describe your changes

* simplify `hasHamburgerMenu`'s type to `boolean`
* reference `parentNode` instead of `parent` 

`hasHamburgerMenu`'s type was being inferred as `boolean | NavItem[]`. ~~Which was causing issues with how the storybook services were being displayed in the composition layer.~~

The true cause was that `parent` was being referenced instead of `parentNode`, no `parent` was in scope meaning the browser's `parent` was being referenced causing some issues.


## Issue ticket number and link
[OR-576](https://financialtimes.atlassian.net/browse/OR-576)

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-576]: https://financialtimes.atlassian.net/browse/OR-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ