### PR TITLE
backstage: fix component tokens building

### DIFF
--- a/apps/dictionary/scripts/build-config/build-component.js
+++ b/apps/dictionary/scripts/build-config/build-component.js
@@ -1,4 +1,9 @@
-import {buildCSS, getBrandNames, getBrandSources} from './utils.js';
+import {
+	buildCSS,
+	getBrandNames,
+	getBrandSources,
+	getComponentTokens,
+} from './utils.js';
 
 function buildComponentTokens(componentName) {
 	const brands = getBrandNames();
@@ -6,13 +11,14 @@ function buildComponentTokens(componentName) {
 	brands.forEach(brand => {
 		const sources = getBrandSources(brand);
 		const destination = `../../components/${componentName}/src/css/tokens/${brand}/${componentName}/_variables.css`;
-
+		const componentTokens = getComponentTokens(brand);
 		const brandSelector = `[data-o3-brand="${brand.split('/').slice(-1)}"]`;
 		const componentSelector = `.${componentName}`;
 		const parentSelector = `${brandSelector} ${componentSelector}`;
 
 		buildCSS({
-			sources,
+			includes: componentTokens,
+			sources: sources,
 			destination,
 			tokenFilter: token => {
 				return token.name.match(`^_?(${componentName})`);

--- a/apps/dictionary/scripts/build-config/build-component.js
+++ b/apps/dictionary/scripts/build-config/build-component.js
@@ -2,23 +2,23 @@ import {
 	buildCSS,
 	getBrandNames,
 	getBrandSources,
-	getComponentTokens,
+	getBrandIncludes,
 } from './utils.js';
 
 function buildComponentTokens(componentName) {
 	const brands = getBrandNames();
 
 	brands.forEach(brand => {
-		const sources = getBrandSources(brand);
+		const brandSources = getBrandSources(brand);
 		const destination = `../../components/${componentName}/src/css/tokens/${brand}/${componentName}/_variables.css`;
-		const componentTokens = getComponentTokens(brand);
+		const brandIncludes = getBrandIncludes(brand);
 		const brandSelector = `[data-o3-brand="${brand.split('/').slice(-1)}"]`;
 		const componentSelector = `.${componentName}`;
 		const parentSelector = `${brandSelector} ${componentSelector}`;
 
 		buildCSS({
-			includes: componentTokens,
-			sources: sources,
+			includes: brandIncludes,
+			sources: brandSources,
 			destination,
 			tokenFilter: token => {
 				return token.name.match(`^_?(${componentName})`);

--- a/apps/dictionary/scripts/build-config/utils.js
+++ b/apps/dictionary/scripts/build-config/utils.js
@@ -135,6 +135,7 @@ StyleDictionaryPackage.registerTransform({
 /**
  * @typedef {Object} CssBuildConfig - Configuration for building CSS from Token Studio design tokens.
  * @property {string[]} sources - The design token files to include.
+ * @property {string[]|undefined} includes - The component design token files to include.
  * @property {string} destination - The output file path.
  * @property {TokenFilter|undefined} [tokenFilter] - A function to filter tokens to include.
  * @property {string|undefined} [parentSelector] - A parent CSS selector for generated CSS.
@@ -144,9 +145,16 @@ StyleDictionaryPackage.registerTransform({
  * @param {CssBuildConfig} CssBuildConfig - A string param.
  * @returns {undefined}
  */
-export function buildCSS({sources, destination, tokenFilter, parentSelector}) {
+export function buildCSS({
+	sources,
+	includes,
+	destination,
+	tokenFilter,
+	parentSelector,
+}) {
 	const config = {
 		source: sources,
+		include: includes,
 		platforms: {
 			css: {
 				transformGroup: 'css',
@@ -288,6 +296,21 @@ export function getBrandSources(brand) {
 		);
 	});
 }
+
+export const getComponentTokens = brand => {
+	return getTokenStudioThemes().flatMap(theme => {
+		const selectedTokenSets = Object.keys(theme.selectedTokenSets);
+		const componentTokenSets = selectedTokenSets.filter(
+			tokenSet =>
+				theme.selectedTokenSets[tokenSet] === 'source' &&
+				tokenStudioThemeToBrand(theme) === brand
+		);
+
+		return componentTokenSets.map(tokenSet =>
+			path.join(basePath, `tokens/${tokenSet}.json`)
+		);
+	});
+};
 
 export function tokenIsSource(token) {
 	return token.isSource ? true : false;


### PR DESCRIPTION
## Describe your changes
Component tokens marked as 'source' in Tokens Studio were not included when building component tokens with style dictionary. Added as `includes` to our style dictionary config.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
