### PR TITLE
backstage: treat tokens not part of a theme set as an 'enabled' token…

### DIFF
--- a/apps/dictionary/scripts/build-config/utils.js
+++ b/apps/dictionary/scripts/build-config/utils.js
@@ -368,5 +368,5 @@ export function isTokenStudioSource(token) {
 
 	const theme = getTokensStudioThemeFromBrand(tokenSet);
 
-	return theme.selectedTokenSets[tokenSet] === 'source';
+	return theme ? theme.selectedTokenSets[tokenSet] === 'source' : false;
 }


### PR DESCRIPTION
…s studio set.

## Describe your changes

Our custom logic to find a tokens studio theme fails if a token file is not part of a theme. In this case, it will usually be a case for token sets such as utility tokens, where a brand does not appear in their file path.

This fix assumes that a non-branded inclusion of a set should appear as enabled when included in a theme.

## Issue ticket number and link
[OR-598](https://financialtimes.atlassian.net/browse/OR-598?atlOrigin=eyJpIjoiYzk3ZWMwZTQxNWE1NDVkZjg1ODE2NDc2MmI0NzRkNGQiLCJwIjoiaiJ9)
## Link to Figma designs

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-598]: https://financialtimes.atlassian.net/browse/OR-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ