### PR TITLE
feat: removing spacing of first subnav button

### DIFF
--- a/components/o-header/README.md
+++ b/components/o-header/README.md
@@ -119,7 +119,7 @@ State | Major Version | Last Minor Release | Migration guide |
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-header/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-header/src/scss/features/_subnav.scss
+++ b/components/o-header/src/scss/features/_subnav.scss
@@ -14,6 +14,7 @@
 			// height *needs* setting so we can hide scrollbars.
 			// This is the content height of .o-header__subnav-content
 			height: $_o-header-subnav-height-base;
+
 			@include oGridRespondTo('M') {
 				height: $_o-header-subnav-height-medium;
 			}
@@ -52,17 +53,21 @@
 		// to avoid positioning subnavs relative. This is so absolute children of the subnav are
 		// positioned relative to their closest positioned ancestor `o-header__container`.
 		// An example benefit is o-tooltip support against sub nav items.
-		& + &:not(.o-header__subnav-list--right) .o-header__subnav-item {
+		&+&:not(.o-header__subnav-list--right) .o-header__subnav-item {
 			&:first-child {
 				@include _oHeaderItemSeparatorContent();
-				&:before {
-					top: 50%;
-					margin-top: - $_o-header-subnav-height-base * div($_o-header-item-separator-percentage-height, 2);
-					height: $_o-header-subnav-height-base * $_o-header-item-separator-percentage-height;
-					@include oGridRespondTo('M') { // stylelint-disable-line max-nesting-depth
-						margin-top: - $_o-header-subnav-height-medium * div($_o-header-item-separator-percentage-height, 2);
-						height: $_o-header-subnav-height-medium * $_o-header-item-separator-percentage-height;
-					}
+
+			}
+
+			&:first-child:before {
+				top: 50%;
+				margin-top: - $_o-header-subnav-height-base * div($_o-header-item-separator-percentage-height, 2);
+				height: $_o-header-subnav-height-base * $_o-header-item-separator-percentage-height;
+
+				@include oGridRespondTo('M') {
+					// stylelint-disable-line max-nesting-depth
+					margin-top: - $_o-header-subnav-height-medium * div($_o-header-item-separator-percentage-height, 2);
+					height: $_o-header-subnav-height-medium * $_o-header-item-separator-percentage-height;
 				}
 			}
 		}
@@ -72,6 +77,10 @@
 		position: relative;
 		display: inline-block;
 		padding-left: 8px;
+
+		&:first-child {
+			padding-left: 0;
+		}
 
 		.o-header__subnav-list--children & {
 			padding-left: 16px;
@@ -109,6 +118,7 @@
 		color: _oHeaderGet('subnav-link');
 		display: inline-block;
 		padding: 12px 0;
+
 		@include oGridRespondTo('M') {
 			padding: 8px 0;
 		}
@@ -123,6 +133,7 @@
 	.o-header__subnav-link--right {
 		float: right;
 		display: none;
+
 		@include oGridRespondTo('M') {
 			display: block;
 		}


### PR DESCRIPTION
## Describe your changes
I have noticed the beginning of the nav items are not aligned with the beginning of the header. This PR includes a very small CSS change to fix this spacing issue.

Before:
![Screenshot 2024-03-15 at 15 32 18](https://github.com/Financial-Times/origami/assets/40343797/9778a02d-c2e8-40bd-beda-f68cf134c676)
(Notice how "WORLD" does not line up with "HOME")

After:
![Screenshot 2024-03-15 at 15 31 38](https://github.com/Financial-Times/origami/assets/40343797/8cf74a18-5e0b-4234-84d7-f0bdf622c770)


## Issue ticket number and link
n/a

## Link to Figma designs
n/a

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
