### PR TITLE
feat: add post modifier to teaser

### DIFF
--- a/components/o-teaser/README.md
+++ b/components/o-teaser/README.md
@@ -130,6 +130,7 @@ Additional modifiers:
 - `stacked`: moves the image to the top of the teaser
 - `opinion`: changes the tag colour to blue
 - `live`: change background to red and position of elements to make the teaser stand out
+- `post`: set liveblog post styles
 
 #### Large teasers
 

--- a/components/o-teaser/src/scss/themes/_small.scss
+++ b/components/o-teaser/src/scss/themes/_small.scss
@@ -20,6 +20,14 @@
 			display: none;
 		}
 	}
+
+	&.o-teaser--post {
+		@include _oTeaserPost;
+	}
+
+	&.o-teaser--post.o-teaser--opinion{
+		@include _oTeaserPostOpinion;
+	}
 }
 
 /// Small teaser styles for a stacked image
@@ -51,5 +59,110 @@
 		order: 2;
 		padding-left: oGridGutter(M);
 		padding-right: inherit;
+	}
+}
+
+
+
+@mixin _oTeaserPost {
+	border-bottom: 0;
+	.o-teaser__meta {
+		margin-bottom: oSpacingByName('s2');
+	}
+	.o-teaser__tag-prefix {
+		@include oTypographySans($scale: 0, $weight: 'semibold');
+		color: oColorsByName('claret');
+		margin-right: oSpacingByName('s1');
+	}
+	.o-teaser__tag {
+		@include oTypographySans($scale: 0, $weight: 'regular');
+		color: oColorsByName('claret');
+	}
+	.o-teaser__standfirst {
+		display: none;
+	}
+	.o-teaser__image-placeholder {
+		width: 100%;
+		height: auto;
+		padding: 0 !important; // this is for override some javascript assignment
+		display: flex;
+		img {
+			width: 100%;
+		}
+	}
+	.o-teaser__timestamp {
+		display: none;
+	}
+	.o-teaser__content {
+		background: oColorsByName('wheat');
+		padding: oSpacingByName('s3');
+		box-sizing: border-box;
+		a {
+			text-decoration: none;
+		}
+	}
+	.o-teaser__image-container {
+		a {
+			width: 100%;
+		}
+
+		background: oColorsByName('wheat');
+		display: flex;
+		flex: 1 0 50%;
+		width: 100%;
+		padding: 0;
+	}
+	.o-teaser__content {
+		flex: 1 0 50%;
+	}
+
+	.o-teaser__heading,
+	.o-teaser__heading a {
+		color: oColorsByName('black');
+		@include oTypographyDisplay($scale: 2, $weight: 'medium');
+	}
+
+	@include oGridRespondTo($until: S) {
+		flex-direction: column;
+		.o-teaser__image-container {
+			display: block;
+			width: 100%;
+			padding: 0;
+		}
+	}
+}
+
+@mixin _oTeaserPostOpinion {
+	@include _oTeaserPost;
+	.o-teaser__content {
+		background: oColorsByName('sky');
+	}
+	.o-teaser__heading:before {
+		@include oIconsContent(
+			'speech-left',
+			oColorsByName('oxford'),
+			30,
+			$iconset-version: 1
+		);
+		content: '';
+		height: 13px;
+		position: relative;
+		background-size: cover;
+		margin-left: -5px;
+	}
+	.o-teaser__tag {
+		color: oColorsByName('oxford');
+	}
+	.o-teaser__tag-prefix {
+		color: oColorsByName('oxford');
+	}
+
+	@include oGridRespondTo($until: S) {
+		flex-direction: column;
+		.o-teaser__image-container {
+			display: block;
+			width: 100%;
+			padding: 0;
+		}
 	}
 }

--- a/components/o-teaser/src/scss/themes/_small.scss
+++ b/components/o-teaser/src/scss/themes/_small.scss
@@ -84,7 +84,7 @@
 	.o-teaser__image-placeholder {
 		width: 100%;
 		height: auto;
-		padding: 0 !important; // this is for override some javascript assignment
+		padding: 0 ;
 		display: flex;
 		img {
 			width: 100%;

--- a/components/o-teaser/src/scss/themes/_small.scss
+++ b/components/o-teaser/src/scss/themes/_small.scss
@@ -118,8 +118,8 @@
 
 	.o-teaser__heading,
 	.o-teaser__heading a {
-		color: oColorsByName('black');
 		@include oTypographyDisplay($scale: 2, $weight: 'medium');
+		color: oColorsByName('black');
 	}
 
 	@include oGridRespondTo($until: S) {

--- a/components/o-teaser/src/tsx/image.tsx
+++ b/components/o-teaser/src/tsx/image.tsx
@@ -5,11 +5,9 @@ import {Image} from './props';
 
 const aspectRatio = ({width, height}: {width: number; height: number}) => {
 	if (typeof width === 'number' && typeof height === 'number') {
-		const ratio = (100 / width) * height;
-		return ratio.toFixed(4) + '%';
+		return { aspectRatio: `${width}/${height}`} as React.CSSProperties;
 	}
-
-	return 0;
+	return {} as React.CSSProperties;
 };
 
 const NormalImage = ({src}) => (
@@ -68,7 +66,7 @@ export default ({
 				}}>
 				<div
 					className="o-teaser__image-placeholder"
-					style={{paddingBottom: aspectRatio(image)}}>
+					style={{...aspectRatio(image)}}>
 					<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
 				</div>
 			</Link>

--- a/components/o-teaser/stories/arg-types.ts
+++ b/components/o-teaser/stories/arg-types.ts
@@ -21,6 +21,7 @@ const ModifierMapping = {
 	'Hero image': 'hero-image',
 	'Top story landscape': 'landscape',
 	'Top story big': 'big-story',
+	'Live blog post': 'post'
 };
 
 export const argTypes = {


### PR DESCRIPTION
add post modifier , meant to be used in live blog posts.
At the moment affects the styles if the teaser has the layout small

This PR change the way to solve [CLS](https://web.dev/articles/cls) by using aspect ratio instead of padding property as it was using

[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2167)

![image](https://github.com/Financial-Times/origami/assets/102036944/ee1cdbcb-73b9-4f79-8fc3-57e26ca7a0b5)


## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [x] I have updated relevant env variables in Doppler.
