### PR TITLE
fix: fix failing release please

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -16,30 +16,4 @@ for (let key in outputs) {
 		await $`npm run build -w ${workspace} --if-present`
 	}
 	await $`npm publish -w ${workspace} --access public`
-	let pkgjson = await readPackage({cwd: workspace})
-	let {statusCode, body} = await request(
-		"https://origami-repo-data.ft.com/v1/queue",
-		{
-			maxRedirections: 100,
-			headers: {
-				"content-type": "application/json",
-				"x-api-key": REPO_DATA_KEY,
-				"x-api-secret": REPO_DATA_SECRET,
-			},
-			method: "POST",
-			body: JSON.stringify({
-				packageName: pkgjson.name,
-				version: pkgjson.version,
-				type: "npm",
-			}),
-		}
-	)
-
-	for await (let data of body) {
-		process.stdout.write(data)
-	}
-
-	if (statusCode < 200 || statusCode >= 300) {
-		throw statusCode
-	}
 }


### PR DESCRIPTION
## Describe your changes
[release please started failing](https://github.com/Financial-Times/origami/actions/runs/8470256633/job/23207548734) last week. The packages were released but CI still failed. It seems that this was an issue with deprecating origami repo data. This PR removes part of the code that makes a request to origami repo data and this should fix the last failing part of the CI.