### PR TITLE
fix:  do not affect nested expander elements

### DIFF
--- a/components/o-expander/src/js/expander-utility.js
+++ b/components/o-expander/src/js/expander-utility.js
@@ -112,6 +112,8 @@ class ExpanderUtility {
 		// Elements.
 		this.oExpanderElement = oExpanderElement;
 		this.contentElement = this.oExpanderElement.querySelector(this.options.selectors.content);
+		//Add data-o-component=o-expander in case it doesn't have it 
+		this.oExpanderElement.setAttribute('data-o-component','o-expander')
 		this.toggles = [].slice.apply(this.oExpanderElement.querySelectorAll(this.options.selectors.toggle)).filter((item) => 
 			//Do not get nested elements
 			item.closest('[data-o-component="o-expander"]') === this.oExpanderElement

--- a/components/o-expander/src/js/expander-utility.js
+++ b/components/o-expander/src/js/expander-utility.js
@@ -112,7 +112,10 @@ class ExpanderUtility {
 		// Elements.
 		this.oExpanderElement = oExpanderElement;
 		this.contentElement = this.oExpanderElement.querySelector(this.options.selectors.content);
-		this.toggles = [].slice.apply(this.oExpanderElement.querySelectorAll(this.options.selectors.toggle));
+		this.toggles = [].slice.apply(this.oExpanderElement.querySelectorAll(this.options.selectors.toggle)).filter((item) => 
+			//Do not get nested elements
+			item.closest('[data-o-component="o-expander"]') === this.oExpanderElement
+		);
 		if (!this.toggles.length) {
 			throw new Error(
 				'o-expander needs a toggle link or button. ' +

--- a/components/o-expander/src/js/expander-utility.js
+++ b/components/o-expander/src/js/expander-utility.js
@@ -31,6 +31,11 @@ class ExpanderUtility {
 			throw new Error('Expected an expander Element.');
 		}
 
+		//Do not initialised if it was already initiated
+		if(oExpanderElement?.oExpander?.initialized){
+			return;
+		}
+
 		// Error if no options are given.
 		if (typeof opts !== 'object') {
 			throw new Error(`Expected an \`opts\` object, found type of "${typeof opts}".`);
@@ -149,11 +154,16 @@ class ExpanderUtility {
 			document.body.addEventListener('oViewport.resize', () => this.apply());
 		}
 
+		
 		// Add a class to indicate the expander is initialised, which
 		// may be styled against for progressive enhancement (we shouldn't hide
 		// content when the expander fails to load).
 		this.oExpanderElement.classList.add(this.options.classnames.initialized);
-
+		this.initialized = true;
+		
+		//Add property oExpander to the main element referencing this object
+		oExpanderElement.oExpander = this;
+		
 		// Apply the configured expander.
 		this.apply(true);
 

--- a/components/o-expander/src/js/expander.js
+++ b/components/o-expander/src/js/expander.js
@@ -62,10 +62,11 @@ class Expander extends ExpanderUtility {
 		if (!(rootEl instanceof HTMLElement)) {
 			rootEl = document.querySelector(rootEl);
 		}
-		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-expander]')) {
-			return new Expander(rootEl, opts);
+		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-expander]') && !rootEl?.oExpander?.initialized) {
+			//if the element has a oExpander initiated already return that instance instead of creating a new one
+			return rootEl?.oExpander || new Expander(rootEl, opts);
 		}
-		return Array.from(rootEl.querySelectorAll('[data-o-component="o-expander"]'), rootEl => new Expander(rootEl, opts));
+		return Array.from(rootEl.querySelectorAll('[data-o-component="o-expander"]'), rootEl =>  rootEl?.oExpander || new Expander(rootEl, opts));
 	}
 
 	/**

--- a/components/o-expander/stories/nested-expander.stories.tsx
+++ b/components/o-expander/stories/nested-expander.stories.tsx
@@ -1,0 +1,46 @@
+import {Expander} from '../src/tsx/expander';
+import javascript from '../main.js';
+import './expander.scss';
+import {useEffect} from 'react';
+
+export const NestedExpander = ({children, ...args}) => {
+	useEffect(() => void javascript.init(), []);
+	return (
+		<Expander {...args} header={<h3>First Expander</h3>}>
+			<p>Details of first expander</p>
+			<ul>
+				<li>one</li>
+				<li>two</li>
+				<li>three</li>
+				<li>four</li>
+			</ul>
+			<button className="o-expander__toggle">Secondary toggler button first expander</button>
+			<div className="innerExpanderItem">
+				<Expander {...args} header={<h3>Second Expander</h3>}>
+				<p>Second expander details</p>
+				<ul>
+					<li>ten</li>
+					<li>eleven</li>
+					<li>twelve</li>
+					<li>thirteen</li>
+				</ul>
+			</Expander>
+			</div>
+		</Expander>
+	);
+};
+
+export default {
+	title: 'Components/o-expander/nested',
+	component: NestedExpander,
+	parameters: {
+		html: {},
+	},
+	args: {
+
+	},
+};
+
+
+
+

--- a/components/o-expander/stories/nested-expander.stories.tsx
+++ b/components/o-expander/stories/nested-expander.stories.tsx
@@ -31,7 +31,7 @@ export const NestedExpander = ({children, ...args}) => {
 };
 
 export default {
-	title: 'Components/o-expander/nested',
+	title: 'Components/o-expander',
 	component: NestedExpander,
 	parameters: {
 		html: {},

--- a/components/o-expander/test/initialization.test.js
+++ b/components/o-expander/test/initialization.test.js
@@ -86,4 +86,13 @@ describe("Expander", () => {
 			done();
 		}, 100);
 	});
+
+	it("should not initialise more than once a component and return first instance always", () => {
+		fixtures.simple();
+		const expanders = Expander.init();
+		const expanders2 = Expander.init();
+		expanders.forEach((expander, index) => {
+			proclaim.equal(expander,expanders2[index])
+		});
+	});
 });


### PR DESCRIPTION
Expander was affecting to toggler buttons inside nested o-expander elements.
With this fix we exclude elements that are nested in other expander element.

I've added an example in storybook so we can test that scenario. Let me know if this is not needed

[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-1976)

## Checklist before requesting a review
- [ ] I have applied `percy` label on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
