### PR TITLE
Remove o3-clearfix due to it causing the build to output broken css

### DIFF
--- a/components/o3-foundation/README.md
+++ b/components/o3-foundation/README.md
@@ -80,7 +80,6 @@ For other elements, such as links, text, and multiline text, we use focus as an 
 `o3-foundation` provides a set of helper classes to help with common tasks. The list of helper classes includes:
 
 - `o3-visually-hidden`: Hides an element visually, but leaves it available to screen readers
-- `o3-clearfix`: Clears floats on the current element
 - `o3-box-sizing-border-box`: Applies `box-sizing: border-box` to the current element and all its children
 
 ## Migration

--- a/components/o3-foundation/normalise.css
+++ b/components/o3-foundation/normalise.css
@@ -131,22 +131,6 @@ input::-moz-focus-inner {
 	white-space: nowrap;
 }
 
-/* Clearfix styles on the current element */
-.o3-clearfix::after {
-	zoom: 1;
-
-	:before,
-	:after {
-		content: '';
-		display: table;
-		/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
-		display: flex;
-	}
-	:after {
-		clear: both;
-	}
-}
-
 /* Adds box sizing to current and all children elements */
 .o3-box-sizing-border-box {
 	box-sizing: border-box;


### PR DESCRIPTION
## What does this change?

- We're removing the `.o3-clearfix` style definition from our `o3-foundation` package because it was outputting invalid CSS.
  - This was causing an error when attempting to transpile the package using the `sass-loader` package in NextJS as part of the work in this pull request: https://github.com/Financial-Times/pro-central-banking/pull/134
- Removing the class in question was preferred due to the clearfix technique being rarely used these days. The functionality can be added back in the future if needed. 
- A search across the FT org was carried out and there are no known usages of the `.o3-clearfix` class.