### PR TITLE
O3 Button | Big button support, custom font-weight

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -8,7 +8,7 @@
 	--_o3-button-inline-padding-start: var(--o3-spacing-4xs);
 	--_o3-button-inline-padding-end: var(--o3-spacing-4xs);
 
-	--_o3-button-font-size: var(--o3-font-size-negative-1);
+	--_o3-button-font-size: var(--o3-font-size-0);
 	--_o3-button-lineheight: var(--o3-font-lineheight-negative-1);
 
 	--_o3-button-border-size: 1px;
@@ -16,10 +16,11 @@
 		var(--_o3-button-min-height) - (var(--_o3-button-block-padding) * 2)
 	);
 
+	--_o3-button-font-weight: var(--o3-font-weight-semibold);
+
 	min-width: var(--_o3-button-min-width);
 	min-height: var(--_o3-button-min-height);
-	padding: 0 var(--_o3-button-inline-padding-end) 0
-		var(--_o3-button-inline-padding-start);
+	padding: 0 var(--_o3-button-inline-padding-end) 0 var(--_o3-button-inline-padding-start);
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -27,7 +28,7 @@
 	vertical-align: middle;
 	font-size: var(--_o3-button-font-size);
 	line-height: var(--_o3-button-lineheight);
-	font-weight: 450;
+	font-weight: var(--_o3-button-font-weight);
 	font-family: var(--o3-font-family-metric), sans-serif;
 	border: var(--_o3-button-border-size) solid transparent;
 	text-align: center;
@@ -47,7 +48,6 @@
 .o3-button[disabled].o3-button--hide-disabled {
 	visibility: hidden;
 }
-
 
 /* PRIMARY */
 
@@ -289,13 +289,12 @@
 	}
 }
 
-/* BIG BUTTON */
+/* SMALL BUTTON */
 
 .o3-button.o3-button--small {
 	--_o3-button-min-width: 60px;
 	--_o3-button-min-height: 28px;
 
-	--_o3-button-block-padding: var(--o3-spacing-5xs);
 	--_o3-button-inline-padding-start: var(--o3-spacing-4xs);
 	--_o3-button-inline-padding-end: var(--o3-spacing-4xs);
 

--- a/components/o3-button/stories/core/button.stories.tsx
+++ b/components/o3-button/stories/core/button.stories.tsx
@@ -36,3 +36,4 @@ LinkAsButton.parameters = {
 };
 export const GroupedButtons = ButtonStories.GroupedButtons;
 export const Pagination = PaginationTemplate;
+export const SmallButton = ButtonStories.SmallButton;

--- a/components/o3-button/stories/core/professional/button.stories.tsx
+++ b/components/o3-button/stories/core/professional/button.stories.tsx
@@ -44,3 +44,4 @@ LinkAsButton.parameters = {
 };
 export const GroupedButtons = ButtonStories.GroupedButtons;
 export const Pagination = PaginationTemplate;
+export const SmallButton = ButtonStories.SmallButton;

--- a/components/o3-button/stories/internal/button.stories.tsx
+++ b/components/o3-button/stories/internal/button.stories.tsx
@@ -24,3 +24,4 @@ export const Button = ButtonStories.Button;
 export const LinkAsButton = ButtonStories.LinkAsButton;
 export const GroupedButtons = ButtonStories.GroupedButtons;
 export const Pagination = PaginationTemplate;
+export const SmallButton = ButtonStories.SmallButton;

--- a/components/o3-button/stories/story-templates.tsx
+++ b/components/o3-button/stories/story-templates.tsx
@@ -57,6 +57,17 @@ export const Button: ButtonStory = {
 	},
 };
 
+
+export const SmallButton: ButtonStory = {
+	...ButtonTemplate,
+	args: {
+		label: 'Small button',
+		type: 'primary',
+		disabled: false,
+		size: 'small',
+	},
+};
+
 export const LinkAsButton: LinkButtonStory = {
 	...LinkButtonTemplate,
 	args: {

--- a/components/o3-button/stories/sustainable-views/button.stories.tsx
+++ b/components/o3-button/stories/sustainable-views/button.stories.tsx
@@ -48,3 +48,5 @@ LinkAsButton.parameters = {
 export const GroupedButtons = ButtonStories.GroupedButtons;
 
 export const Pagination = PaginationTemplate;
+
+export const SmallButton = ButtonStories.SmallButton;

--- a/components/o3-button/stories/whitelabel/button.stories.tsx
+++ b/components/o3-button/stories/whitelabel/button.stories.tsx
@@ -38,3 +38,4 @@ LinkAsButton.parameters = {
 };
 export const GroupedButtons = ButtonStories.GroupedButtons;
 export const Pagination = PaginationTemplate;
+export const SmallButton = ButtonStories.SmallButton;


### PR DESCRIPTION
## What does this change?

As part of migrating https://github.com/Financial-Times/pro-central-banking to `o3-button` in https://github.com/Financial-Times/pro-central-banking/pull/137 I needed to port across the existing `*--big` modifier for buttons and allow the setting of custom font-weights and padding.

- Sets up stories for `small` buttons in Storybook
- Allow customisation of `font-weight`
- Set `font-weight` to `700`
- Change `font-size` to `1rem`