### PR TITLE
Correct o3 font and button font size

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -8,7 +8,7 @@
 	--_o3-button-inline-padding-start: var(--o3-spacing-4xs);
 	--_o3-button-inline-padding-end: var(--o3-spacing-4xs);
 
-	--_o3-button-font-size: var(--o3-font-size-0);
+	--_o3-button-font-size: var(--o3-font-size-negative-1);
 	--_o3-button-lineheight: var(--o3-font-lineheight-negative-1);
 
 	--_o3-button-border-size: 1px;
@@ -20,7 +20,8 @@
 
 	min-width: var(--_o3-button-min-width);
 	min-height: var(--_o3-button-min-height);
-	padding: 0 var(--_o3-button-inline-padding-end) 0 var(--_o3-button-inline-padding-start);
+	padding: 0 var(--_o3-button-inline-padding-end) 0
+		var(--_o3-button-inline-padding-start);
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;

--- a/components/o3-foundation/fonts.css
+++ b/components/o3-foundation/fonts.css
@@ -2,8 +2,8 @@
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=Metric2-VF&system_code=origami&font_format=woff2')
 		format('woff2');
-	font-family: var(--o3-font-family-metric);
-	font-weight: 400;
+	font-family: 'metric 2 VF';
+	font-weight: 300 400 500 700 800;
 	font-style: normal;
 	font-display: swap;
 }

--- a/components/o3-foundation/normalise.css
+++ b/components/o3-foundation/normalise.css
@@ -6,10 +6,6 @@ html,
 body {
 	margin: 0;
 	text-rendering: optimizeLegibility;
-}
-
-/* Adds font smoothing */
-.o3-font-smoothing {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
See commit messages for details. The below screenshot shows o3-button vs o-buttons

![Screenshot 2024-04-09 at 14 30 49](https://github.com/Financial-Times/origami/assets/10405691/843de389-8541-4ca2-a7fc-cd8d4f41747a)

Horizontal padding differences are a conscious design choice