### PR TITLE
fix: set o3 use case link inverse text colour

### DIFF
--- a/apps/dictionary/tokens/core/use-case/color.json
+++ b/apps/dictionary/tokens/core/use-case/color.json
@@ -32,7 +32,17 @@
               "type": "color"
             },
             "hover": {
-              "value": "CCCCC",
+              "value": "#d4d4d6",
+              "type": "color"
+            }
+          },
+          "underline": {
+            "@": {
+              "value": "#ffffffff",
+              "type": "color"
+            },
+            "hover": {
+              "value": "#d4d4d6",
               "type": "color"
             }
           }

--- a/apps/dictionary/tokens/core/use-case/color.json
+++ b/apps/dictionary/tokens/core/use-case/color.json
@@ -28,7 +28,7 @@
         "link-inverse": {
           "text": {
             "@": {
-              "value": "#",
+              "value": "#ffffffff",
               "type": "color"
             },
             "hover": {

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -71,7 +71,7 @@
   --o3-color-use-case-link-text-hover: var(--o3-color-palette-teal-30);
   --o3-color-use-case-link-underline: #CFD8D1;
   --o3-color-use-case-link-underline-hover: #9EC0BD;
-  --o3-color-use-case-link-inverse-text: #;
+  --o3-color-use-case-link-inverse-text: #ffffffff;
   --o3-color-use-case-link-inverse-text-hover: CCCCC;
   --o3-color-use-case-page-background: var(--o3-color-palette-paper);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -72,7 +72,9 @@
   --o3-color-use-case-link-underline: #CFD8D1;
   --o3-color-use-case-link-underline-hover: #9EC0BD;
   --o3-color-use-case-link-inverse-text: #ffffffff;
-  --o3-color-use-case-link-inverse-text-hover: CCCCC;
+  --o3-color-use-case-link-inverse-text-hover: #d4d4d6;
+  --o3-color-use-case-link-inverse-underline: #ffffffff;
+  --o3-color-use-case-link-inverse-underline-hover: #d4d4d6;
   --o3-color-use-case-page-background: var(--o3-color-palette-paper);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -9,9 +9,9 @@
   --o3-color-use-case-link-underline: #CFD8D1;
   --o3-color-use-case-link-underline-hover: #9EC0BD;
   --o3-color-use-case-link-inverse-text: #ffffffff;
-  --o3-color-use-case-link-inverse-text-hover: CCCCC;
-  --o3-color-use-case-link-inverse-underline: var(--o3-color-palette-mint);
-  --o3-color-use-case-link-inverse-underline-hover: var(--o3-color-palette-mint-70);
+  --o3-color-use-case-link-inverse-text-hover: #d4d4d6;
+  --o3-color-use-case-link-inverse-underline: #ffffffff;
+  --o3-color-use-case-link-inverse-underline-hover: #d4d4d6;
   --o3-color-use-case-page-background: var(--o3-color-palette-paper);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -8,7 +8,7 @@
   --o3-color-use-case-link-text-hover: var(--o3-color-palette-teal-30);
   --o3-color-use-case-link-underline: #CFD8D1;
   --o3-color-use-case-link-underline-hover: #9EC0BD;
-  --o3-color-use-case-link-inverse-text: #;
+  --o3-color-use-case-link-inverse-text: #ffffffff;
   --o3-color-use-case-link-inverse-text-hover: CCCCC;
   --o3-color-use-case-link-inverse-underline: var(--o3-color-palette-mint);
   --o3-color-use-case-link-inverse-underline-hover: var(--o3-color-palette-mint-70);


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
