### PR TITLE
chore: Correct o-autocomplete comment

### DIFF
--- a/components/o-autocomplete/src/js/autocomplete.js
+++ b/components/o-autocomplete/src/js/autocomplete.js
@@ -3,10 +3,6 @@
 // Below are the pull-requests to accessible-autocomplete which would fix the bugs:
 // https://github.com/alphagov/accessible-autocomplete/pull/491
 // If the above pull-requests are merged and published, then we can stop using our fork
-// though switching to alphagov/accessible-autocomplete will require that consumers
-// applying `aria-labelledby` to the `ul` element
-// via the `ariaLabelledBy` option (https://github.com/Financial-Times/accessible-autocomplete/pull/6)
-// instead do so via the `menuAttributes` option (https://github.com/alphagov/accessible-autocomplete/pull/591)
 import accessibleAutocomplete from '@financial-times/accessible-autocomplete';
 
 /**


### PR DESCRIPTION
## Describe your changes
This is a correction to changes introduced in https://github.com/Financial-Times/origami/pull/1524.

The deleted section of the comment became inaccurate when upgrading to `@financial-times/accessible-autocomplete` v3.0.0, which removed the `ariaLabelledBy` attribute in favour of the `menuAttributes` option. I raised this in a PR comment https://github.com/Financial-Times/origami/pull/1524/files#r1547450335, but forgot to re-raise it directly prior to the PR being merged.

## Issue ticket number and link
N/A

## Link to Figma designs
N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
