### PR TITLE
fix: remove background color sky when opinoion on teaser with post mo…

### DIFF
--- a/components/o-teaser/src/scss/themes/_small.scss
+++ b/components/o-teaser/src/scss/themes/_small.scss
@@ -134,9 +134,7 @@
 
 @mixin _oTeaserPostOpinion {
 	@include _oTeaserPost;
-	.o-teaser__content {
-		background: oColorsByName('sky');
-	}
+	
 	.o-teaser__heading:before {
 		@include oIconsContent(
 			'speech-left',


### PR DESCRIPTION
change background of teaser with post modifier when isOpinion according with designs of the ticket
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2167)

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
