### PR TITLE
fix: fix bug in expander tsx template

### DIFF
--- a/components/o-expander/src/tsx/expander.tsx
+++ b/components/o-expander/src/tsx/expander.tsx
@@ -24,7 +24,7 @@ export interface ExpanderProps {
 	expandedText?: string;
 }
 
-export function Expander({header = null, children, expanded}: ExpanderProps) {
+export function Expander({header = undefined, children, expanded}: ExpanderProps) {
 	return (
 		<div
 			data-o-component="o-expander"
@@ -32,10 +32,12 @@ export function Expander({header = null, children, expanded}: ExpanderProps) {
 			data-o-expander-shrink-to="hidden">
 			{header}
 			<button className="o-expander__toggle">
-				{expanded ?
-					'hide' :
-					`show ${<span className="o-expander__visually-hidden">(content will be added above button)</span>}`
-				}
+				{expanded ? 'hide' : 'show'}
+				{!expanded && (
+					<span className="o-expander__visually-hidden">
+						(content will be added above button)
+					</span>
+				)}
 			</button>
 			<div
 				className="o-expander__content"


### PR DESCRIPTION
## Describe your changes
This PR resolves a bug related to displaying `[object object]` on the `o-expander` storybook example.

## Issue ticket number and link
[OR-632](https://financialtimes.atlassian.net/browse/OR-623)

## Checklist before requesting a review
- [x] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review.

[OR-632]: https://financialtimes.atlassian.net/browse/OR-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ