### PR TITLE
Set aria-modal according to `opts.modal` (o-overlay)

### DIFF
--- a/components/o-overlay/src/js/overlay.js
+++ b/components/o-overlay/src/js/overlay.js
@@ -269,7 +269,8 @@ class Overlay {
 		}
 
 		wrapperEl.setAttribute('role', 'dialog');
-		wrapperEl.setAttribute('aria-modal', 'true');
+		wrapperEl.setAttribute('aria-modal', this.opts.modal ? 'true' : 'false');
+
 		if (this.opts.zindex) {
 			wrapperEl.style.zIndex = this.opts.zindex;
 		}


### PR DESCRIPTION
## Describe your changes

[As MDN explains](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal), non-modal dialogs (which o-overlay creates when the 'modal' option is set to false) shouldn't have `aria-modal=true`.

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-overlay or `chromatic` label for o3-overlay on my PR before merging and after review.
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
