### PR TITLE
docs: Add fluid button documentation

### DIFF
--- a/apps/for-everyone-website/src/components/ButtonPreview.astro
+++ b/apps/for-everyone-website/src/components/ButtonPreview.astro
@@ -1,0 +1,68 @@
+---
+import {renderToString} from 'react-dom/server';
+const Component = Astro.props.component;
+const brand = Astro.props.brand;
+const componentProps = Astro.props.componentProps;
+const ComponentInstance = Component(componentProps);
+const componentHtml = renderToString(ComponentInstance);
+const componentJSX = `<${Component.name} ${Object.entries(componentProps)
+    .map(p => `${p[0]}="${p[1]}"`)
+    .join(' ')} />`;
+const inverse = componentProps['theme'] === 'inverse';
+import {Code} from 'astro:components';
+
+let figma = 'https://www.figma.com/files/938480807921629744/team/1237702133754424766/Origami-for-Everyone-(NEW)?fuid=840167457508775739';
+switch (brand) {
+    case 'core':
+        figma = 'https://www.figma.com/file/VVM0PixrY3IRZq2ZUTdWfU/%F0%9F%92%A0-Core---Design-System?type=design&node-id=4059-1949&mode=design&t=Coj8qOkQwGndrOew-4';
+        break;
+    case 'professional':
+        figma = 'https://www.figma.com/file/qfi6fTq5V05b0mnXw3F7q5/%F0%9F%92%A0-Professional---Design-System?type=design&node-id=3786-2499&mode=design&t=3k5iL1exswqY1yJz-4';
+        break;
+    case 'internal':
+        figma = 'https://www.figma.com/file/H9vTWZgEzqzTtX689nwq4R/Internal---Design-System?type=design&node-id=4316-309&mode=design&t=3k5iL1exswqY1yJz-4';
+        break;
+    case 'sustainable-views':
+        figma = 'https://www.figma.com/file/Y7u0SwIJ1mCNDE0dpzgHCJ/Sustainable-Views---Design-System?type=design&node-id=4039-410&mode=design&t=3k5iL1exswqY1yJz-4';
+        break;
+
+    default:
+        break;
+}
+
+let storybook = 'https://main--64faf6b1815b6c0106f82e74.chromatic.com/';
+if(brand) {
+    const storybookArgs = `${Component.name.toLowerCase()}&args=${Object.entries(
+            componentProps
+        ).map(p => `${p[0]}:${p[1]};`).join('')}`;
+    const storybookbase = 'https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story';
+    storybook = `${storybookbase}/${brand}-o3-${Component.name.toLowerCase()}--${storybookArgs}`
+
+    if(brand === 'professional') {
+        storybook = `${storybookbase}/core-${brand}-o3-${Component.name.toLowerCase()}--${storybookArgs}`
+    }
+}
+---
+<div>
+    <div
+        style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${
+            inverse ? 'background-color: black' : ''
+        }`}>
+        <Component {...componentProps} />
+    </div>
+    <a
+        style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
+        href={storybook}>
+        Open in StoryBook
+    </a> | <a
+        style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
+        href={figma}>
+        Open in Figma
+    </a>
+    <details>
+        <summary>code</summary>
+        <Code code={componentJSX} lang="jsx" theme="css-variables" />
+        <Code code={componentHtml} lang="html" theme="css-variables" />
+    </details>
+    <hr />
+</div>

--- a/apps/for-everyone-website/src/content-partial/docs/components/buttons-behaviour.mdx
+++ b/apps/for-everyone-website/src/content-partial/docs/components/buttons-behaviour.mdx
@@ -1,0 +1,13 @@
+import {default as Preview} from '../../../components/ButtonPreview.astro';
+import {Button} from '@financial-times/o3-button';
+
+### Width
+
+A button's width is dependant on the length of its content by default. Alternatively buttons may be "fluid", and stretch to fill the full width of their container.
+
+Use fluid buttons for smaller devices or containers e.g on mobile web or the app. We recommend buttons are fluid until around 400px, after which the button should be determined by the length of its content.
+
+<Preview
+	component={Button}
+	componentProps={{label: 'Fluid button', type: 'primary', fluid: true}}
+/>

--- a/apps/for-everyone-website/src/content-partial/docs/components/buttons-guidelines.mdx
+++ b/apps/for-everyone-website/src/content-partial/docs/components/buttons-guidelines.mdx
@@ -60,3 +60,40 @@ import {Button} from '@financial-times/o3-button';
     </Example>
 
 </Guideline>
+
+<Guideline summary="Don’t use full width buttons in wide containers" do={false}>
+    <div slot="description">
+		Instead use <a href="#width">fluid buttons</a>, which are full-width for small devices or containers up to around 400px width. Otherwise, button width should default to its content length.
+    </div>
+
+    <Example slot="examples" do={true}>
+    	<svg role="presentation" width="217" height="128" viewBox="0 0 217 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+    		<rect width="64.1379" height="127.741" rx="4" fill="#D9D9D9"/>
+    		<rect x="70.0172" width="146.983" height="88.7241" fill="#D9D9D9"/>
+    		<rect x="4.27588" y="112.242" width="55.5862" height="9.08621" fill="#0D7680"/>
+    		<rect x="76.431" y="71.0859" width="53.4483" height="11.2241" fill="#0D7680"/>
+    	</svg>
+    </Example>
+
+    <Example slot="examples" do={false}>
+    	<svg
+    		role="presentation"
+    		width="217"
+    		height="128"
+    		viewBox="0 0 217 128"
+    		fill="none"
+    		xmlns="http://www.w3.org/2000/svg">
+    		<rect width="64.1379" height="127.741" rx="4" fill="#D9D9D9" />
+    		<rect x="70.0172" width="146.983" height="88.7241" fill="#D9D9D9" />
+    		<rect
+    			x="4.27588"
+    			y="112.242"
+    			width="55.5862"
+    			height="9.08621"
+    			fill="#0D7680"
+    		/>
+    		<rect x="76" y="71" width="135" height="11" fill="#0D7680" />
+    	</svg>
+    </Example>
+
+</Guideline>

--- a/apps/for-everyone-website/src/content/docs/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/components/buttons.mdx
@@ -7,48 +7,10 @@ import {Button} from '@financial-times/o3-button';
 import '@financial-times/o3-button/css/whitelabel.css';
 import '@financial-times/o3-button/css/internal.css';
 import '@financial-times/o3-button/css/professional.css';
-import {renderToString} from 'react-dom/server';
-import {Code} from 'astro:components';
 import {default as ButtonAnatomy} from '../../../components/ButtonAnatomy.astro';
+import {default as Preview} from '../../../components/ButtonPreview.astro';
 import {Content as ButtonGuidelines} from '../../../content-partial/docs/components/buttons-guidelines.mdx';
-
-export function Preview({component: Component, componentProps} = props) {
-	const ComponentInstance = Component(componentProps);
-	const componentHtml = renderToString(ComponentInstance);
-	const componentJSX = `<${Component.name} ${Object.entries(componentProps)
-		.map(p => `${p[0]}="${p[1]}"`)
-		.join(' ')} />`;
-	const inverse = componentProps['theme'] === 'inverse';
-	return (
-		<>
-			<div
-				style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${
-					inverse ? 'background-color: black' : ''
-				}`}>
-				<Component {...componentProps} />
-			</div>
-			<a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href={`https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story/core-o3-${Component.name.toLowerCase()}--${Component.name.toLowerCase()}&args=${Object.entries(
-					componentProps
-				)
-					.map(p => `${p[0]}:${p[1]};`)
-					.join('')}`}>
-				Open in StoryBook
-			</a> | <a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href="https://www.figma.com/file/VVM0PixrY3IRZq2ZUTdWfU/Core---Design-System?type=design&node-id=2819-133&mode=design">
-				Open in Figma
-			</a>
-			<details>
-				<summary>code</summary>
-				<Code code={componentJSX} lang="jsx" theme="css-variables" />
-				<Code code={componentHtml} lang="html" theme="css-variables" />
-			</details>
-			<hr />
-		</>
-	);
-}
+import {Content as ButtonBehaviour} from '../../../content-partial/docs/components/buttons-behaviour.mdx';
 
 Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
 
@@ -70,6 +32,10 @@ The button component contains two required elements and one optional element.
 
 <ButtonGuidelines />
 
+## Behaviour
+
+<ButtonBehaviour />
+
 ## Icons
 
 Buttons may be used with icons, without icons, or only icons.
@@ -77,6 +43,7 @@ Buttons may be used with icons, without icons, or only icons.
 ### Without icon
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -86,6 +53,7 @@ Buttons may be used with icons, without icons, or only icons.
 When icons are used, these are always left aligned.
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', icon: 'search'}}
 />
@@ -93,6 +61,7 @@ When icons are used, these are always left aligned.
 ### Only icon
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -109,6 +78,7 @@ The button comes in two sizes: standard and small.
 ### Standard
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -116,6 +86,7 @@ The button comes in two sizes: standard and small.
 ### Small
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', size: 'small'}}
 />
@@ -129,6 +100,7 @@ There are three types of buttons to support different contexts.
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -138,6 +110,7 @@ The primary button is used for the most important calls to action on a page. Pri
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'secondary'}}
 />
@@ -146,7 +119,11 @@ For secondary actions on each page or used in conjunction with a primary button.
 
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
-<Preview component={Button} componentProps={{label: 'Hello', type: 'ghost'}} />
+<Preview
+	brand="core"
+	component={Button}
+	componentProps={{label: 'Hello', type: 'ghost'}}
+/>
 
 ## Themes
 
@@ -155,6 +132,7 @@ Each button type supports the following themes.
 ### Standard
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -164,6 +142,7 @@ Each button type supports the following themes.
 An alternative theme for use on dark backgrounds.
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -173,6 +152,7 @@ An alternative theme for use on dark backgrounds.
 Mono can be helpful where the standard theme distracts from other colour used, for example when placed near data visualisations.
 
 <Preview
+	brand="core"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'mono'}}
 />

--- a/apps/for-everyone-website/src/content/docs/internal/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/internal/components/buttons.mdx
@@ -5,48 +5,10 @@ description: Buttons are triggers that provide users with a call to action. Typi
 
 import {Button} from '@financial-times/o3-button';
 import '@financial-times/o3-button/css/internal.css';
-import {renderToString} from 'react-dom/server';
-import {Code} from 'astro:components';
 import {default as ButtonAnatomy} from '../../../../components/ButtonAnatomy.astro';
+import {default as Preview} from '../../../../components/ButtonPreview.astro';
 import {Content as ButtonGuidelines} from '../../../../content-partial/docs/components/buttons-guidelines.mdx';
-
-export function Preview({component: Component, componentProps} = props) {
-	const ComponentInstance = Component(componentProps);
-	const componentHtml = renderToString(ComponentInstance);
-	const componentJSX = `<${Component.name} ${Object.entries(componentProps)
-		.map(p => `${p[0]}="${p[1]}"`)
-		.join(' ')} />`;
-	const inverse = componentProps['theme'] === 'inverse';
-	return (
-		<>
-			<div
-				style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${
-					inverse ? 'background-color: black' : ''
-				}`}>
-				<Component {...componentProps} />
-			</div>
-			<a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href={`https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story/core-internal-o3-${Component.name.toLowerCase()}--${Component.name.toLowerCase()}&args=${Object.entries(
-					componentProps
-				)
-					.map(p => `${p[0]}:${p[1]};`)
-					.join('')}`}>
-				Open in StoryBook
-			</a> | <a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href="https://www.figma.com/file/H9vTWZgEzqzTtX689nwq4R/Internal---Design-System?type=design&node-id=2819-133&mode=design&t=kSGXDAsaMo9vsgY3-0">
-				Open in Figma
-			</a>
-			<details>
-				<summary>code</summary>
-				<Code code={componentJSX} lang="jsx" theme="css-variables" />
-				<Code code={componentHtml} lang="html" theme="css-variables" />
-			</details>
-			<hr />
-		</>
-	);
-}
+import {Content as ButtonBehaviour} from '../../../../content-partial/docs/components/buttons-behaviour.mdx';
 
 Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
 
@@ -68,6 +30,10 @@ The button component contains two required elements and one optional element.
 
 <ButtonGuidelines />
 
+## Behaviour
+
+<ButtonBehaviour />
+
 ## Icons
 
 Buttons may be used with icons, without icons, or only icons.
@@ -75,8 +41,9 @@ Buttons may be used with icons, without icons, or only icons.
 ### Without icon
 
 <Preview
+	brand="internal"
 	component={Button}
-	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
+	componentProps={{label: 'Hello', type: 'primary'}}
 />
 
 ### With icon
@@ -84,11 +51,11 @@ Buttons may be used with icons, without icons, or only icons.
 When icons are used, these are always left aligned.
 
 <Preview
+	brand="internal"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
 		type: 'primary',
-		theme: 'inverse',
 		icon: 'search',
 	}}
 />
@@ -96,11 +63,11 @@ When icons are used, these are always left aligned.
 ### Only icon
 
 <Preview
+	brand="internal"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
 		type: 'primary',
-		theme: 'inverse',
 		icon: 'search',
 		iconOnly: true,
 	}}
@@ -113,18 +80,19 @@ The button comes in two sizes: standard and small.
 ### Standard
 
 <Preview
+	brand="internal"
 	component={Button}
-	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
+	componentProps={{label: 'Hello', type: 'primary'}}
 />
 
 ### Small
 
 <Preview
+	brand="internal"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
 		type: 'primary',
-		theme: 'inverse',
 		size: 'small',
 	}}
 />
@@ -138,8 +106,9 @@ There are three types of buttons to support different contexts.
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
 <Preview
+	brand="internal"
 	component={Button}
-	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
+	componentProps={{label: 'Hello', type: 'primary'}}
 />
 
 ### Secondary
@@ -147,8 +116,9 @@ The primary button is used for the most important calls to action on a page. Pri
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
 <Preview
+	brand="internal"
 	component={Button}
-	componentProps={{label: 'Hello', type: 'secondary', theme: 'inverse'}}
+	componentProps={{label: 'Hello', type: 'secondary'}}
 />
 
 ### Ghost
@@ -156,8 +126,9 @@ For secondary actions on each page or used in conjunction with a primary button.
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
 <Preview
+	brand="internal"
 	component={Button}
-	componentProps={{label: 'Hello', type: 'ghost', theme: 'inverse'}}
+	componentProps={{label: 'Hello', type: 'ghost'}}
 />
 
 ## Themes
@@ -167,6 +138,7 @@ Each button type supports the following themes.
 ### Standard
 
 <Preview
+	brand="internal"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />

--- a/apps/for-everyone-website/src/content/docs/professional/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/professional/components/buttons.mdx
@@ -5,48 +5,10 @@ description: Buttons are triggers that provide users with a call to action. Typi
 
 import {Button} from '@financial-times/o3-button';
 import '@financial-times/o3-button/css/professional.css';
-import {renderToString} from 'react-dom/server';
-import {Code} from 'astro:components';
 import {default as ButtonAnatomy} from '../../../../components/ButtonAnatomy.astro';
+import {default as Preview} from '../../../../components/ButtonPreview.astro';
 import {Content as ButtonGuidelines} from '../../../../content-partial/docs/components/buttons-guidelines.mdx';
-
-export function Preview({component: Component, componentProps} = props) {
-	const ComponentInstance = Component(componentProps);
-	const componentHtml = renderToString(ComponentInstance);
-	const componentJSX = `<${Component.name} ${Object.entries(componentProps)
-		.map(p => `${p[0]}="${p[1]}"`)
-		.join(' ')} />`;
-	const inverse = componentProps['theme'] === 'inverse';
-	return (
-		<>
-			<div
-				style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${
-					inverse ? 'background-color: black' : ''
-				}`}>
-				<Component {...componentProps} />
-			</div>
-			<a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href={`https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story/core-professional-o3-${Component.name.toLowerCase()}--${Component.name.toLowerCase()}&args=${Object.entries(
-					componentProps
-				)
-					.map(p => `${p[0]}:${p[1]};`)
-					.join('')}`}>
-				Open in StoryBook
-			</a> | <a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href="https://www.figma.com/file/qfi6fTq5V05b0mnXw3F7q5/Professional---Design-System?type=design&node-id=3604-103&mode=design">
-				Open in Figma
-			</a>
-			<details>
-				<summary>code</summary>
-				<Code code={componentJSX} lang="jsx" theme="css-variables" />
-				<Code code={componentHtml} lang="html" theme="css-variables" />
-			</details>
-			<hr />
-		</>
-	);
-}
+import {Content as ButtonBehaviour} from '../../../../content-partial/docs/components/buttons-behaviour.mdx';
 
 Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
 
@@ -68,6 +30,10 @@ The button component contains two required elements and one optional element.
 
 <ButtonGuidelines />
 
+## Behaviour
+
+<ButtonBehaviour />
+
 ## Icons
 
 Buttons may be used with icons, without icons, or only icons.
@@ -75,6 +41,7 @@ Buttons may be used with icons, without icons, or only icons.
 ### Without icon
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -84,6 +51,7 @@ Buttons may be used with icons, without icons, or only icons.
 When icons are used, these are always left aligned.
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -96,6 +64,7 @@ When icons are used, these are always left aligned.
 ### Only icon
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -113,6 +82,7 @@ The button comes in two sizes: standard and small.
 ### Standard
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -120,6 +90,7 @@ The button comes in two sizes: standard and small.
 ### Small
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -138,6 +109,7 @@ There are three types of buttons to support different contexts.
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -147,6 +119,7 @@ The primary button is used for the most important calls to action on a page. Pri
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'secondary', theme: 'inverse'}}
 />
@@ -156,6 +129,7 @@ For secondary actions on each page or used in conjunction with a primary button.
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'ghost', theme: 'inverse'}}
 />
@@ -167,6 +141,7 @@ Each button type supports the following themes.
 ### Standard
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -176,6 +151,7 @@ Each button type supports the following themes.
 An alternative theme for use on dark backgrounds.
 
 <Preview
+	brand="professional"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />

--- a/apps/for-everyone-website/src/content/docs/sustainable-views/components/buttons.mdx
+++ b/apps/for-everyone-website/src/content/docs/sustainable-views/components/buttons.mdx
@@ -5,48 +5,10 @@ description: Buttons are triggers that provide users with a call to action. Typi
 
 import {Button} from '@financial-times/o3-button';
 import '@financial-times/o3-button/css/sustainable-views.css';
-import {renderToString} from 'react-dom/server';
-import {Code} from 'astro:components';
 import {default as ButtonAnatomy} from '../../../../components/ButtonAnatomy.astro';
+import {default as Preview} from '../../../../components/ButtonPreview.astro';
 import {Content as ButtonGuidelines} from '../../../../content-partial/docs/components/buttons-guidelines.mdx';
-
-export function Preview({component: Component, componentProps} = props) {
-	const ComponentInstance = Component(componentProps);
-	const componentHtml = renderToString(ComponentInstance);
-	const componentJSX = `<${Component.name} ${Object.entries(componentProps)
-		.map(p => `${p[0]}="${p[1]}"`)
-		.join(' ')} />`;
-	const inverse = componentProps['theme'] === 'inverse';
-	return (
-		<>
-			<div
-				style={`padding: var(--o3-spacing-2xs); margin-left: calc(var(--o3-spacing-2xs) * -1); ${
-					inverse ? 'background-color: black' : ''
-				}`}>
-				<Component {...componentProps} />
-			</div>
-			<a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href={`https://main--64faf6b1815b6c0106f82e74.chromatic.com/?path=/story/sustainable-views-o3-${Component.name.toLowerCase()}--${Component.name.toLowerCase()}&args=${Object.entries(
-					componentProps
-				)
-					.map(p => `${p[0]}:${p[1]};`)
-					.join('')}`}>
-				Open in StoryBook
-			</a> | <a
-				style="display: inline-block; margin: var(--o3-spacing-2xs) 0;"
-				href="https://www.figma.com/file/Y7u0SwIJ1mCNDE0dpzgHCJ/Sustainable-Views---Design-System?type=design&node-id=3604-103&mode=design">
-				Open in Figma
-			</a>
-			<details>
-				<summary>code</summary>
-				<Code code={componentJSX} lang="jsx" theme="css-variables" />
-				<Code code={componentHtml} lang="html" theme="css-variables" />
-			</details>
-			<hr />
-		</>
-	);
-}
+import {Content as ButtonBehaviour} from '../../../../content-partial/docs/components/buttons-behaviour.mdx';
 
 Buttons are triggers that provide users with a call to action. Typically allowing users to execute, choose, submit and confirm actions.
 
@@ -68,6 +30,10 @@ The button component contains two required elements and one optional element.
 
 <ButtonGuidelines />
 
+## Behaviour
+
+<ButtonBehaviour />
+
 ## Icons
 
 Buttons may be used with icons, without icons, or only icons.
@@ -75,6 +41,7 @@ Buttons may be used with icons, without icons, or only icons.
 ### Without icon
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -84,6 +51,7 @@ Buttons may be used with icons, without icons, or only icons.
 When icons are used, these are always left aligned.
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -96,6 +64,7 @@ When icons are used, these are always left aligned.
 ### Only icon
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -113,6 +82,7 @@ The button comes in two sizes: standard and small.
 ### Standard
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -120,6 +90,7 @@ The button comes in two sizes: standard and small.
 ### Small
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{
 		label: 'Hello',
@@ -138,6 +109,7 @@ There are three types of buttons to support different contexts.
 The primary button is used for the most important calls to action on a page. Primary buttons should only appear once per product area (not including the application header, modal dialogue, on-site messaging, or side panel).
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />
@@ -147,6 +119,7 @@ The primary button is used for the most important calls to action on a page. Pri
 For secondary actions on each page or used in conjunction with a primary button. As part of a pair, the secondary button’s function is to perform the negative action of the set, such as “Cancel” or “Back”.
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'secondary', theme: 'inverse'}}
 />
@@ -156,6 +129,7 @@ For secondary actions on each page or used in conjunction with a primary button.
 For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for ‘Save and continue’ the ghost button would be ‘Skip’.
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'ghost', theme: 'inverse'}}
 />
@@ -167,6 +141,7 @@ Each button type supports the following themes.
 ### Standard
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary'}}
 />
@@ -176,6 +151,7 @@ Each button type supports the following themes.
 An alternative theme for use on dark backgrounds.
 
 <Preview
+	brand="sustainable-views"
 	component={Button}
 	componentProps={{label: 'Hello', type: 'primary', theme: 'inverse'}}
 />

--- a/components/o3-button/README.md
+++ b/components/o3-button/README.md
@@ -7,6 +7,7 @@ o3-button includes button, button group, and pagination patterns. See our [desig
     - [Types](#types)
     - [Themes](#themes)
     - [Sizes](#sizes)
+    - [Fluid, full width](#fluid-full-width)
     - [Icons](#icons)
     - [Groups](#groups)
     - [Pagination](#pagination)
@@ -51,9 +52,9 @@ Themes may be applied on a parent element, for all components within to inherit.
 
 ```html
 <body data-o3-brand="professional" data-o3-theme="inverse">
- <button class="o3-button o3-button--primary">
-  Inverse professional button
- </button>
+	<button class="o3-button o3-button--primary">
+		Inverse professional button
+	</button>
 </body>
 ```
 
@@ -61,9 +62,9 @@ Or, themes may be applied specifically to a single button:
 
 ```html
 <body data-o3-brand="professional">
- <button class="o3-button o3-button--primary" data-o3-theme="inverse">
-  Inverse professional button
- </button>
+	<button class="o3-button o3-button--primary" data-o3-theme="inverse">
+		Inverse professional button
+	</button>
 </body>
 ```
 
@@ -72,7 +73,41 @@ Or, themes may be applied specifically to a single button:
 Apply the `o3-button--small` modifier class for a smaller button, as appropriate, inline with [design guidelines](https://origami-for-everyone.ft.com/components/buttons/#small).
 
 ```html
-<button class="o3-button o3-button--primary o3-button--small">Click Me</button>
+<button class="o3-button o3-button--primary o3-button--small">Click me</button>
+```
+
+### Fluid, full width
+
+Apply the `data-o3-fluid` data attribute to make buttons "fluid", and expand to the full width of their container. By default this applies only to small, mobile viewports. On larger viewports a fluid button's width is based on its content by default.
+
+```html
+<button class="o3-button o3-button--primary" data-o3-fluid>Click me</button>
+```
+
+For more control on when a button should be full width set the `--o3-button-fluid` CSS Custom Property. For example:
+
+Force buttons to always be full width, given they are a direct child of a "my-button-container" element.
+
+```css
+.my-button-container > .o3-button {
+	--o3-button-fluid: initial;
+}
+```
+
+Make buttons full width using a [container query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries), given a "my-button-container" parent element that is less than `500px` wide.
+
+```css
+.my-button-container {
+	container-type: inline-size;
+}
+
+@supports (container-type: inline-size) {
+	@container (width < 500px) {
+		.my-button-container > .o3-button {
+			--o3-button-fluid: initial;
+		}
+	}
+}
 ```
 
 ### Icons
@@ -99,14 +134,14 @@ A limited number of button icons are available. Limiting the number of icons kee
 
 ```html
 <button
- class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-down"
+	class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-down"
 >
- Down Arrow
+	Down Arrow
 </button>
 <button
- class="o3-button o3-button--secondary o3-button-icon o3-button-icon--download"
+	class="o3-button o3-button--secondary o3-button-icon o3-button-icon--download"
 >
- Download
+	Download
 </button>
 ```
 
@@ -116,9 +151,9 @@ If you would like your button to display only an icon, add the class `o3-button-
 
 ```html
 <button
- class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-down o3-button-icon--icon-only"
+	class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-down o3-button-icon--icon-only"
 >
- <span class="o3-button-icon__label"> Down Arrow </span>
+	<span class="o3-button-icon__label"> Down Arrow </span>
 </button>
 ```
 
@@ -130,15 +165,15 @@ After discussing together, we may decide a custom icon is the most appropriate o
 
 ```css
 .my-button-modifier-class {
- --o3-button-icon: url('data:image/svg+xml,[ENCODED_SVG_STRING]');
+	--o3-button-icon: url('data:image/svg+xml,[ENCODED_SVG_STRING]');
 }
 ```
 
 ```html
 <button
- class="o3-button o3-button--secondary o3-button-icon my-button-modifier-class"
+	class="o3-button o3-button--secondary o3-button-icon my-button-modifier-class"
 >
- My custom icon button
+	My custom icon button
 </button>
 ```
 
@@ -148,11 +183,11 @@ Wrap buttons in a container with `.o3-button-group` to group them together:
 
 ```html
 <div class="o3-button-group">
- <button class="o3-button o3-button--secondary" aria-selected="true">
-  One
- </button>
- <button class="o3-button o3-button--secondary">Two</button>
- <button class="o3-button o3-button--secondary">Three</button>
+	<button class="o3-button o3-button--secondary" aria-selected="true">
+		One
+	</button>
+	<button class="o3-button o3-button--secondary">Two</button>
+	<button class="o3-button o3-button--secondary">Three</button>
 </div>
 ```
 
@@ -166,69 +201,69 @@ We recommend using our JSX template where possible. Alternatively, you must re-i
 
 ```html
 <div class="o3-button-pagination">
- <a
-  href="#previous"
-  class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-left o3-button-icon--icon-only"
-  ><span class="o3-button-icon__label">previous</span></a
- ><a
-  href="#1"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="wide"
-  >1</a
- ><span data-o3-button-show-when="wide" class="o3-button-pagination__ellipsis"
-  >...</span
- ><a
-  href="#4"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="wide"
-  >4</a
- ><a
-  href="#5"
-  class="o3-button o3-button--secondary "
-  aria-current="page"
-  data-o3-button-show-when="wide"
-  >5</a
- ><a
-  href="#6"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="wide"
-  >6</a
- ><span data-o3-button-show-when="wide" class="o3-button-pagination__ellipsis"
-  >...</span
- ><a
-  href="#10"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="wide"
-  >10</a
- ><a
-  href="#1"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="narrow"
-  >1</a
- ><span
-  data-o3-button-show-when="narrow"
-  class="o3-button-pagination__ellipsis"
-  >...</span
- ><a
-  href="#5"
-  class="o3-button o3-button--secondary "
-  aria-current="page"
-  data-o3-button-show-when="narrow"
-  >5</a
- ><span
-  data-o3-button-show-when="narrow"
-  class="o3-button-pagination__ellipsis"
-  >...</span
- ><a
-  href="#10"
-  class="o3-button o3-button--secondary "
-  data-o3-button-show-when="narrow"
-  >10</a
- ><a
-  href="#next"
-  class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-right o3-button-icon--icon-only"
-  ><span class="o3-button-icon__label">next</span></a
- >
+	<a
+		href="#previous"
+		class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-left o3-button-icon--icon-only"
+		><span class="o3-button-icon__label">previous</span></a
+	><a
+		href="#1"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="wide"
+		>1</a
+	><span data-o3-button-show-when="wide" class="o3-button-pagination__ellipsis"
+		>...</span
+	><a
+		href="#4"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="wide"
+		>4</a
+	><a
+		href="#5"
+		class="o3-button o3-button--secondary "
+		aria-current="page"
+		data-o3-button-show-when="wide"
+		>5</a
+	><a
+		href="#6"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="wide"
+		>6</a
+	><span data-o3-button-show-when="wide" class="o3-button-pagination__ellipsis"
+		>...</span
+	><a
+		href="#10"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="wide"
+		>10</a
+	><a
+		href="#1"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="narrow"
+		>1</a
+	><span
+		data-o3-button-show-when="narrow"
+		class="o3-button-pagination__ellipsis"
+		>...</span
+	><a
+		href="#5"
+		class="o3-button o3-button--secondary "
+		aria-current="page"
+		data-o3-button-show-when="narrow"
+		>5</a
+	><span
+		data-o3-button-show-when="narrow"
+		class="o3-button-pagination__ellipsis"
+		>...</span
+	><a
+		href="#10"
+		class="o3-button o3-button--secondary "
+		data-o3-button-show-when="narrow"
+		>10</a
+	><a
+		href="#next"
+		class="o3-button o3-button--secondary o3-button-icon o3-button-icon--arrow-right o3-button-icon--icon-only"
+		><span class="o3-button-icon__label">next</span></a
+	>
 </div>
 ```
 
@@ -262,7 +297,7 @@ import {Button} from '@financial-times/o3-button/cjs';
 import '@financial-times/o3-button/css/[your brand].css';
 
 <div data-o3-brand="[your brand]">
- <Button label="Hello" type="primary" />
+	<Button label="Hello" type="primary" />
 </div>;
 ```
 
@@ -274,22 +309,22 @@ import {ButtonPagination} from '@financial-times/o3-button/cjs';
 import '@financial-times/o3-button/css/[your brand].css';
 
 <div data-o3-brand="[your brand]">
- <ButtonPagination
-  previousPager={{label: 'previous', href: '#previous'}}
-  nextPager={{label: 'next', href: '#next'}}
-  pages={[
-   {href: '#1', current: false, number: 1},
-   {href: '#2', current: false, number: 2},
-   {href: '#3', current: false, number: 3},
-   {href: '#4', current: false, number: 4},
-   {href: '#5', current: true, number: 5},
-   {href: '#6', current: false, number: 6},
-   {href: '#7', current: false, number: 7},
-   {href: '#8', current: false, number: 8},
-   {href: '#9', current: false, number: 9},
-   {href: '#10', current: false, number: 10},
-  ]}
- />
+	<ButtonPagination
+		previousPager={{label: 'previous', href: '#previous'}}
+		nextPager={{label: 'next', href: '#next'}}
+		pages={[
+			{href: '#1', current: false, number: 1},
+			{href: '#2', current: false, number: 2},
+			{href: '#3', current: false, number: 3},
+			{href: '#4', current: false, number: 4},
+			{href: '#5', current: true, number: 5},
+			{href: '#6', current: false, number: 6},
+			{href: '#7', current: false, number: 7},
+			{href: '#8', current: false, number: 8},
+			{href: '#9', current: false, number: 9},
+			{href: '#10', current: false, number: 10},
+		]}
+	/>
 </div>;
 ```
 

--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -17,6 +17,9 @@
 	--_o3-button-font-weight: var(--o3-font-weight-semibold);
 
 	min-width: var(--_o3-button-min-width);
+	/* Width based on content by default, until set to `inital` */
+	--o3-button-fluid: ;
+	width: var(--o3-button-fluid, 100%);
 	min-height: var(--_o3-button-min-height);
 	padding: 0 var(--_o3-button-inline-padding-end) 0
 		var(--_o3-button-inline-padding-start);
@@ -288,6 +291,13 @@
 	}
 }
 
+/* FLUID BUTTON */
+
+.o3-button[data-o3-fluid] {
+	@media screen and (max-width: 490px) {
+		--o3-button-fluid: initial;
+	}
+}
 /* SMALL BUTTON */
 
 .o3-button.o3-button--small {

--- a/components/o3-button/src/tsx/button.tsx
+++ b/components/o3-button/src/tsx/button.tsx
@@ -40,6 +40,7 @@ export function Button({
 	label,
 	type = 'secondary',
 	size = '',
+	fluid = false,
 	theme,
 	icon,
 	iconOnly = false,
@@ -53,6 +54,9 @@ export function Button({
 	delete attributes.className;
 	if (theme) {
 		attributes['data-o3-theme'] = theme;
+	}
+	if (fluid) {
+		attributes['data-o3-fluid'] = '';
 	}
 	return (
 		<button
@@ -79,6 +83,7 @@ export function LinkButton({
 	label,
 	type = 'secondary',
 	size = '',
+	fluid = false,
 	theme,
 	icon,
 	iconOnly = false,
@@ -93,6 +98,9 @@ export function LinkButton({
 	delete attributes.className;
 	if (theme) {
 		attributes['data-o3-theme'] = theme;
+	}
+	if (fluid) {
+		attributes['data-o3-fluid'] = '';
 	}
 	return (
 		<a

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -3,6 +3,7 @@ export interface ButtonProps {
 	label: string;
 	type: 'primary' | 'secondary' | 'ghost';
 	size?: 'small' | '';
+	fluid?: boolean;
 	theme?: 'inverse' | 'mono';
 	icon?:
 		| 'arrow-left'


### PR DESCRIPTION
I have abstracted the "Preview" component out. It still needs work, but is better.


![image](https://github.com/Financial-Times/origami/assets/10405691/db1d32b0-13ae-4a61-acc0-fd0007275429)

![image](https://github.com/Financial-Times/origami/assets/10405691/965d2c75-8321-4cb8-81d9-dfaa099a74c4)
