### PR TITLE
fix: fix overlapping header on cross icon

### DIFF
--- a/components/o3-tooltip/main.css
+++ b/components/o3-tooltip/main.css
@@ -47,6 +47,7 @@ o3-tooltip-onboarding[no-title] .o3-tooltip-content {
 	font-size: var(--o3-font-size-0);
 	color: inherit;
 	margin-bottom: var(--o3-spacing-4xs);
+	padding-right: calc(var(--padding-right) + 5px); /* add extra 5px padding to create space between close button */
 }
 
 /* ARROW STYLES */

--- a/components/o3-tooltip/main.css
+++ b/components/o3-tooltip/main.css
@@ -42,6 +42,10 @@ o3-tooltip-onboarding[no-title] .o3-tooltip-content {
 	margin-right: var(--icon-button-size);
 }
 
+o3-tooltip-onboarding[no-title]  .o3-tooltip-content-title, o3-tooltip-toggle[no-title]  .o3-tooltip-content-title {
+	display: none;
+}
+
 .o3-tooltip-content-title {
 	font-weight: var(--o3-font-weight-semibold);
 	font-size: var(--o3-font-size-0);

--- a/components/o3-tooltip/main.css
+++ b/components/o3-tooltip/main.css
@@ -47,7 +47,7 @@ o3-tooltip-onboarding[no-title] .o3-tooltip-content {
 	font-size: var(--o3-font-size-0);
 	color: inherit;
 	margin-bottom: var(--o3-spacing-4xs);
-	padding-right: calc(var(--padding-right) + 5px); /* add extra 5px padding to create space between close button */
+	padding-right: calc(var(--padding-right) + var(--o3-spacing-5xs)); /* add extra 4px padding to create space between close button and heading title */
 }
 
 /* ARROW STYLES */

--- a/components/o3-tooltip/src/ts/tooltip.ts
+++ b/components/o3-tooltip/src/ts/tooltip.ts
@@ -43,7 +43,9 @@ export class ToolTip extends HTMLElement implements TooltipProps {
 
 	connectedCallback() {
 		this.content = this.getAttribute('content') as string;
-		this.title = this.getAttribute('title') as string;
+		if (this.hasAttribute('title')) {
+			this.title = this.getAttribute('title') as string;
+		}
 		this.contentId = this.getAttribute('content-id') as string;
 	}
 


### PR DESCRIPTION
## Describe your changes
add extra padding for the title so it does not obscure close button
## Issue ticket number and link
[OR-653](https://financialtimes.atlassian.net/browse/OR-653)



[OR-653]: https://financialtimes.atlassian.net/browse/OR-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ