### PR TITLE
OR-556: introduce body small

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,7 +34,8 @@ jobs:
         uses: chromaui/action@v11
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBaseDir: ./apps/o3-storybook
+          workingDir: ./apps/o3-storybook
+          storybookBaseDir: ./
           exitOnceUploaded: true
           onlyChanged: true
           autoAcceptChanges: 'main' # 👈 Option to accept all changes on main

--- a/components/o3-typography/body.css
+++ b/components/o3-typography/body.css
@@ -1,8 +1,7 @@
 .o3-typography-body {
-	font-family: MetricWeb, sans-serif;
 	font-weight: var(--o3-typography-use-case-body-s-font-weight);
-	font-size: var(--o3-typography-use-case-body-s-font-size);
-	line-height: var(--o3-typography-use-case-body-s-line-height);
+	font-size: var(--o3-font-size-0);
+	line-height: var(--o3-font-lineheight-0);
 	margin: 0 0 var(--o3-spacing-s);
 	color: var(--_o3-typography-body-color);
 }

--- a/components/o3-typography/body.css
+++ b/components/o3-typography/body.css
@@ -6,6 +6,11 @@
 	color: var(--_o3-typography-body-color);
 }
 
+.o3-typography-body--small {
+		font-size: var(--o3-font-size-negative-1);
+		line-height: var(--o3-font-lineheight-negative-1);
+}
+
 .o3-typography-body[data-o3-theme="inverse"] {
 	color: var(--_o3-typography-body-inverse-color);
 }

--- a/components/o3-typography/src/tsx/body.tsx
+++ b/components/o3-typography/src/tsx/body.tsx
@@ -1,12 +1,18 @@
 import {getStyleAttributes, StyleArguments} from './getStyleAttributes';
 
-export const Body: React.FC<
-	{children: React.ReactNode; style?: 'italic'} & StyleArguments
-> = ({children, theme, style}) => {
-	const classes = ['o3-typography', 'o3-typography-body', 'o4'];
+type BodyProps = {
+	children: React.ReactNode;
+	style?: 'italic';
+	size?: 'small';
+} & StyleArguments;
+export const Body: React.FC<BodyProps> = ({children, theme, style, size}) => {
+	const classes = ['o3-typography', 'o3-typography-body'];
 
 	if (style === 'italic') {
 		classes.push('o3-typography-italic');
+	}
+	if (size === 'small') {
+		classes.push('o3-typography-body--small');
 	}
 
 	return (

--- a/components/o3-typography/stories/core/body.stories.tsx
+++ b/components/o3-typography/stories/core/body.stories.tsx
@@ -16,12 +16,6 @@ export default {
 	parameters: {
 		backgrounds: {default: 'paper'},
 	},
-	style: {
-		options: ['regular', 'italic'],
-		control: {
-			type: 'radio',
-		},
-	},
 } as Meta;
 
 export const BodyStory = TypographyStories.BodyTemplate;

--- a/components/o3-typography/stories/core/professional/body.stories.tsx
+++ b/components/o3-typography/stories/core/professional/body.stories.tsx
@@ -16,12 +16,6 @@ export default {
 	parameters: {
 		backgrounds: {default: 'paper'},
 	},
-	style: {
-		options: ['regular', 'italic'],
-		control: {
-			type: 'radio',
-		},
-	},
 } as Meta;
 
 export const BodyStory = TypographyStories.BodyTemplate;

--- a/components/o3-typography/stories/story-templates.tsx
+++ b/components/o3-typography/stories/story-templates.tsx
@@ -32,11 +32,17 @@ const BodyStory = {
 				type: 'radio',
 			},
 		},
+		size: {
+			options: ['regular', 'small'],
+			control: {
+				type: 'radio',
+			},
+		},
 	},
 	render: args => {
 		return (
 			<>
-				<Body theme={args.theme} style={args.style}>
+				<Body theme={args.theme} style={args.style} size={args.size}>
 					Body - Lorem ipsum dolor sit amet, consectetur adipisicing elit.{' '}
 					<Link href="#" theme={args.theme}>
 						Link


### PR DESCRIPTION
## Describe your changes
* introduce O3 Typography Body small.
* remove duplicated argtypes from O3 Typography Body stories.
* Align O3 Typography Body sizing to what is used in design.

## Issue ticket number and link
[OR-556](https://financialtimes.atlassian.net/browse/OR-556?atlOrigin=eyJpIjoiOWI3YjFmYzhkMzY5NGMxYWJmOWRlZGJlNWU5Nzc0ZmQiLCJwIjoiaiJ9)

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-556]: https://financialtimes.atlassian.net/browse/OR-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ