### PR TITLE
fix: fix new session behavior for o-tracking

### DIFF
--- a/libraries/o-tracking/src/javascript/core/session.js
+++ b/libraries/o-tracking/src/javascript/core/session.js
@@ -43,10 +43,14 @@ function getSession() {
 	if (s) {
 		const d = new Date().valueOf();
 		const exp = parseInt(s.expiry, 10);
-
+		
 		// If current session is active.
 		if (exp >= d) {
 			session = s.value;
+		} else {
+			// session has expired, generate a new one
+			session = guid();
+			isNew = true;
 		}
 	}
 

--- a/libraries/o-tracking/test/core/session.test.js
+++ b/libraries/o-tracking/test/core/session.test.js
@@ -38,4 +38,27 @@ describe('Core.Session', function () {
 		});
 	});
 
+	describe('getSession()', function() {
+		it('should generate new session if current has expired', function(done) {
+			const session = initSession({expires: 1});
+			// force a session write
+			getSession();
+			setTimeout(function() {
+				const newSession = getSession();
+				proclaim.notEqual(session.id, newSession.id);
+				done();
+			}, 2)
+		});
+
+		it('should mark session as new when generating new session due to expiration', function(done) {
+			initSession({expires: 1});
+			// force a session write
+			getSession();
+			setTimeout(function() {
+				const newSession = getSession();
+				proclaim.isTrue(newSession.isNew);
+				done();
+			}, 2)
+		})
+	})
 });


### PR DESCRIPTION
## Describe your changes
Change the behavior of current internal session tracking to actually generate a new session and set the `isNew` flag whenever the current one expires.

## Issue ticket number and link
[DATA-9210](https://financialtimes.atlassian.net/browse/DATA-9210)


[DATA-9210]: https://financialtimes.atlassian.net/browse/DATA-9210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ