### PR TITLE
ADSDEV-1832 - fix: remove elements directly in o-video rather than el.removeChild(c…

### DIFF
--- a/components/o-video/src/js/ads.js
+++ b/components/o-video/src/js/ads.js
@@ -191,7 +191,7 @@ class VideoAds {
 
 		// Remove the preloading spinner
 		if (this.loadingStateEl) {
-			this.loadingStateEl.parentNode.removeChild(this.loadingStateEl);
+			this.loadingStateEl.remove()
 			this.loadingStateEl = null;
 		}
 
@@ -243,7 +243,7 @@ class VideoAds {
 
 		if (this.overlayEl) {
 			this.overlayEl.removeEventListener('click', this.playAdEventHandler);
-			this.video.containerEl.removeChild(this.overlayEl);
+			this.overlayEl.remove();
 		}
 		delete this.overlayEl;
 	}
@@ -354,10 +354,12 @@ class VideoAds {
 		if (this.adsManager) {
 			this.adsManager.destroy();
 		}
-		this.video.containerEl.removeChild(this.adContainerEl);
+		if (this.adContainerEl) {
+			this.adContainerEl.remove();
+		}
 		if (this.overlayEl) {
 			this.overlayEl.removeEventListener('click', this.playAdEventHandler);
-			this.video.containerEl.removeChild(this.overlayEl);
+			this.overlayEl.remove();
 			delete this.overlayEl;
 		}
 		if (this.video.placeholderEl) {
@@ -373,7 +375,9 @@ class VideoAds {
 	}
 
 	contentResumeRequestHandler() {
-		this.video.containerEl.removeChild(this.adContainerEl);
+		if (this.adContainerEl) {
+			this.adContainerEl.remove();
+		}
 		this.adsCompleted = true;
 		this.playUserVideo();
 	}

--- a/components/o-video/src/js/info.js
+++ b/components/o-video/src/js/info.js
@@ -49,7 +49,9 @@ class VideoInfo {
 	}
 
 	teardown () {
-		this.video.placeholderEl.removeChild(this.infoEl);
+		if (this.infoEl) {
+			this.infoEl.remove();
+		}
 
 		delete this.infoEl;
 		delete this.brandEl;

--- a/components/o-video/src/js/video.js
+++ b/components/o-video/src/js/video.js
@@ -303,7 +303,7 @@ class Video {
 
 		const existingTrackEl = this.videoEl.querySelector('track');
 		if (existingTrackEl) {
-			this.videoEl.removeChild(existingTrackEl);
+			existingTrackEl.remove();
 		}
 
 		if (this.videoData.captionsUrl) {
@@ -393,7 +393,7 @@ class Video {
 			this.addVideo();
 			this.videoEl.focus();
 
-			this.containerEl.removeChild(this.placeholderEl);
+			this.placeholderEl.remove();
 			if (this.infoPanel) {
 				this.infoPanel.teardown();
 			}


### PR DESCRIPTION
## Describe your changes
Replaces instances where we remove an element by using remove() directly, rather than el.removeChild(childEl). 

It relies on less assumptions about which node is a parent of which other ones and fixes an issue on the adErrorHandler where a removeEl statement would fail because the node we're trying to remove isn't a descendant of the node on which removeChild is called 


## Issue ticket number and link
https://financialtimes.atlassian.net/browse/ADSDEV-1832

## Link to Figma designs
N/A

## Checklist before requesting a review

- [x] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
