### PR TITLE
docs: origami for nobody

### DIFF
--- a/apps/for-everyone-website/README.md
+++ b/apps/for-everyone-website/README.md
@@ -1,4 +1,4 @@
-# Origami For Everyone
+# Origami
 
 A new, in progress Origami website. It will:
 
@@ -8,7 +8,7 @@ A new, in progress Origami website. It will:
 
 ## Project Structure
 
-The Origami For Everyone website is [![built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build). The project structure looks like the following:
+The Origami website is [![built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build). The project structure looks like the following:
 
 ```
 .
@@ -25,7 +25,7 @@ The Origami For Everyone website is [![built with Starlight](https://astro.badg.
 └── tsconfig.json
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name. We use [Starlight's internationalisation features](https://starlight.astro.build/guides/i18n/) to present tailored content dependent on the selected brand. Brand specific content e.g. `src/content/docs/professional` takes precedence over  content at `src/content/docs/`.
+Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name. We use [Starlight's internationalisation features](https://starlight.astro.build/guides/i18n/) to present tailored content dependent on the selected brand. Brand specific content e.g. `src/content/docs/professional` takes precedence over content at `src/content/docs/`.
 
 Images can be added to `src/assets/` and embedded in Markdown with a relative link.
 

--- a/apps/for-everyone-website/astro.config.mjs
+++ b/apps/for-everyone-website/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
 	integrations: [
 		react(),
 		starlight({
-			title: 'Origami For Everyone',
+			title: 'Origami Design System',
 			locales: {
 				root: {
 					label: 'core',

--- a/apps/for-everyone-website/src/content/docs/about/faq.md
+++ b/apps/for-everyone-website/src/content/docs/about/faq.md
@@ -5,22 +5,28 @@ description: Frequently asked questions
 
 <details>
     <summary>
+        What is Origami – o3?
+    </summary>
+    "o3" refers to our new components, built from the ground up with new design guidelines, aligned designer and engineering tooling, and improved multi-brand support.
+</details>
+
+<details>
+    <summary>
+        What is Origami – o2?
+    </summary>
+    "o2" refers to our legacy components, these are widely used and will be maintained for the foreseeable future as we gradually move to new "o3" components and patterns. "o2" components lack meaningful design guidelines and design tools. We recommend designers use Storybook to explore what components are available and what variants they support.
+</details>
+
+<details>
+    <summary>
+        Can I use o3 guidelines / components / patterns today?
+    </summary>
+    Absolutely! We'd love you to. Teams across the FT Group have begun to use "o3" in production. Please reach out to the Origami team (<a href="https://financialtimes.slack.com/messages/origami-support">#origami-support</a>), so we can support you through early adoption as we refine "o3" and improve our documentation.
+</details>
+
+<details>
+    <summary>
         What is Origami For Everyone?
     </summary>
-    Origami For Everyone reimagines Origami with a renewed focus on: Design guidelines; aligned designer and engineering tooling; and multi-brand support. This includes all new components. Learn more on the <a href="/about/#origami-for-everyone">about page</a>.
+    Origami For Everyone referred to our proposal to reimagine Origami with a renewed focus on design guidelines; aligned designer and engineering tooling; and enhanced multi-brand support. As we begin to realise that vision with "o3" components and patterns, we no longer need to refer to Origami For Everyone.
 </details>
-
-<details>
-    <summary>
-        What is o2/o3?
-    </summary>
-    "o2" refers to our legacy components, these are widely used and will be maintained for the foreseeable future. "o3" refers to our new components, built from the ground up with new design guidelines, aligned designer and engineering tooling, and improved multi-brand support. Going forward we are moving away from o2/o3 language in favour of legacy/new Origami.
-</details>
-
-<details>
-    <summary>
-        Can I use new guidelines / components / patterns?
-    </summary>
-    Absolutely! We'd love you to. Please reach out to the Origami team (<a href="https://financialtimes.slack.com/messages/origami-support">#origami-support</a>), so we can support you through early adoption. We expect adoption to pick up more freely in Q2, after we have published Origami's <a href="https://www.figma.com/files/938480807921629744/team/1237702133754424766">new figma libraries</a> and improved technical documentation for our new components.
-</details>
-

--- a/apps/for-everyone-website/src/content/docs/about/index.md
+++ b/apps/for-everyone-website/src/content/docs/about/index.md
@@ -13,9 +13,9 @@ Origami is the FT's design system. This includes design guidelines, components, 
 
 Today, Origami is used to create ft.com, our apps, as well as internal tools, and increasingly other FT Group brands.
 
-## Origami For Everyone
+## Origami "o3"
 
-Origami For Everyone reimagines Origami with a renewed focus on:
+Origami "o3" delivers a reimagined Origami with a renewed focus on:
 
 1. Design guidelines, to support designers to prototype new products or features consistently, building on tried and tested approaches.
 2. Aligned designer and engineering tooling, for improved efficiency and alignment during handover from prototype to build.

--- a/apps/for-everyone-website/src/content/docs/index.mdx
+++ b/apps/for-everyone-website/src/content/docs/index.mdx
@@ -1,13 +1,13 @@
 ---
-title: Origami For Everyone
-description: The new Origami. Origami For Everyone will support the FT to create differentiated products, targeting different audiences, by scaling Origami to support more brands and platforms.
+title: Origami Design System
+description: The new Origami. Origami will support the FT to create differentiated products, targeting different audiences, by scaling Origami to support more brands and platforms.
 template: splash
 hero:
-  tagline: New Origami components. Rethought from the ground up, with aligned Figma libraries, design guidelines, and brand support powered by design tokens.
+  tagline: Origami helps us design & build digital products for brands across the FT Group. Explore our new user interface components and patterns. Rethought from the ground up, with aligned Figma libraries, design guidelines, and multi-brand support powered by design tokens.
   image:
     file: ../../assets/origami-logo.svg
   actions:
-    - text: Get started
+    - text: Components
       link: ./components/buttons
       icon: right-arrow
       variant: primary
@@ -16,22 +16,21 @@ hero:
       icon: external
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
-
-## Product Delivery Superpowers
+import {Card, CardGrid} from '@astrojs/starlight/components';
 
 <CardGrid>
-	<Card title="Validate ideas" icon="pencil">
-		A fully featured Figma library of all our components, with thorough documentation for patterns and design guidelines.
-		Mock-up prototypes quickly, saving time to focus on where you can add unique value.
+	<Card title="Mission" icon="rocket">
+		Unify and document the style and experience across the digital
+		products of every FT brand, leveraging the web platform to provide an
+		implementation of brand guidelines.
 	</Card>
-	<Card title="Rollout to production" icon="add-document">
-		Designers ❤️ engineers. New Figma and Origami integrations allow a designer to see a live, interactive component preview instantly. Integrations with Figma's Dev Mode mean a much smoother handover process, with fewer mistakes, and less back-and-fourth.
-	</Card>
-	<Card title="No more waiting" icon="setting">
-		No more Sass, or accidental Doom Scrolling from engineers as they wait for it to compile. Build times for Origami For Everyone are significantly reduced allowing engineers to quickly see the affect of their change and iterate.
-	</Card>
-	<Card title="Next level collaboration" icon="open-book">
-		Origami For Everyone improves support for brand and platform variations. We're working with the Specialist team to introduce a new brand, so we can collaborate together on shared components across groups.
-	</Card>
+	<Card title="Contact" icon="slack">
+		Origami is a shared project, built by teams across the FT. The core Origami team and our community of collaborators are here to help if you have questions or feedback:
+
+    	<ul>
+    		<li>Slack: <a href="https://financialtimes.slack.com/messages/origami-support">#origami-support</a></li>
+    		<li>Email:  <a href="mailto:origami.support@ft.com">origami.support@ft.com</a></li>
+    	</ul>
+    </Card>
+
 </CardGrid>


### PR DESCRIPTION
We aim to move origami-for-everyone.ft.com (now origami-beta.ft.com) to origami.ft.com, moving away from Origami For Everyone. That project name means different things to different people and is no longer required.

