### PR TITLE
fix: remove type: module from o3-typography package

### DIFF
--- a/components/o3-typography/package.json
+++ b/components/o3-typography/package.json
@@ -12,7 +12,8 @@
 		"email": "origami.support@ft.com"
 	},
 	"license": "MIT",
-	"type": "module",
+	"main": "./cjs/index.js",
+	"module": "./esm/index.js",
 	"files": [
 		"cjs",
 		"esm",
@@ -21,9 +22,6 @@
 		"package.json",
 		"README.md"
 	],
-	"main": "./cjs/index.js",
-	"module": "./esm/index.js",
-	"types": "./build/types/index.d.ts",
 	"scripts": {
 		"build": "bash ../../scripts/component/build-o3.bash o3-typography"
 	},


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
