### PR TITLE
feat: o-tooltip opts.target can be HTMLElement

### DIFF
--- a/components/o-tooltip/src/js/tooltip.js
+++ b/components/o-tooltip/src/js/tooltip.js
@@ -123,7 +123,7 @@ class Tooltip {
 			Tooltip.throwError("tooltip.target is not set. An target for the tooltip to point at must be provided");
 		}
 
-		if (!typeof opts.target === 'string' || !opts.target instanceof HTMLElement) {
+		if (!(typeof opts.target === 'string') && !(opts.target instanceof HTMLElement)) {
 			Tooltip.throwError("tooltip.target is invalid, it must be either an ID selector string or HTMLElement");
 		}
 

--- a/components/o-tooltip/src/js/tooltip.js
+++ b/components/o-tooltip/src/js/tooltip.js
@@ -31,7 +31,7 @@ class Tooltip {
 
 		Tooltip._tooltips.set(this.tooltipEl, this);
 
-		this.targetNode = document.getElementById(this.opts.target);
+		this.targetNode = typeof this.opts.target === 'string' ? document.getElementById(this.opts.target) : this.opts.target;
 		this.target = new Tooltip.Target(this.targetNode);
 		this.tooltipPosition = this._getConfiguredTooltipPosition();
 		this.tooltipAlignment = null;
@@ -121,6 +121,10 @@ class Tooltip {
 
 		if (!opts.target) {
 			Tooltip.throwError("tooltip.target is not set. An target for the tooltip to point at must be provided");
+		}
+
+		if (!typeof opts.target === 'string' || !opts.target instanceof HTMLElement) {
+			Tooltip.throwError("tooltip.target is invalid, it must be either an ID selector string or HTMLElement");
 		}
 
 		// Check that the value of tooltip position is valid. Default to below.

--- a/components/o-tooltip/test/Tooltip.test.js
+++ b/components/o-tooltip/test/Tooltip.test.js
@@ -254,6 +254,12 @@ describe("Tooltip", () => {
 			const opts = Tooltip.checkOptions({"target": "#el"});
 			proclaim.isObject(opts);
 		});
+
+		it("does not error if HTMLElement is passed as opts.target", () => {
+			const targetEl = document.createElement('div');
+			Tooltip.checkOptions({target: targetEl});
+			proclaim.isFalse(throwStub.called);
+		})
 	});
 
 	describe('constructElement', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,7 +4731,7 @@
 		},
 		"components/o-autocomplete": {
 			"name": "@financial-times/o-autocomplete",
-			"version": "1.9.2",
+			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/accessible-autocomplete": "^3.1.0"
@@ -5648,7 +5648,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.11",
+			"version": "7.2.12",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -5690,7 +5690,7 @@
 		},
 		"components/o3-button": {
 			"name": "@financial-times/o3-button",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -5723,7 +5723,7 @@
 		},
 		"components/o3-typography": {
 			"name": "@financial-times/o3-typography",
-			"version": "0.1.1",
+			"version": "0.3.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"


### PR DESCRIPTION
## Describe your changes

This PR allows o-tooltip to receive a HTMLElement instead of an ID string, allowing for the usage patterns identified in the linked issue.

## Issue ticket number and link

#1609 

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [x] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
