### PR TITLE
fix: Correct font weight in Safari

### DIFF
--- a/apps/for-everyone-website/src/components/TypeScale.astro
+++ b/apps/for-everyone-website/src/components/TypeScale.astro
@@ -90,10 +90,9 @@ const typeScaleOrdered = Object.entries(typeScale).sort((a, b) => {
 
 <style>
 	@font-face {
-		src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=FinancierDisplay-VF&system_code=origami&font_format=woff2')
-			format('woff2');
+		src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=FinancierDisplay-VF&system_code=origami&font_format=woff2') format('woff2-variations');
 		font-family: 'financier display VF';
-		font-weight: 300 400 500 700 800;
+		font-weight: 300 800;
 		font-style: normal;
 	}
 	.token-sample {

--- a/components/o3-foundation/fonts.css
+++ b/components/o3-foundation/fonts.css
@@ -1,9 +1,9 @@
 /* Default Font styles */
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=Metric2-VF&system_code=origami&font_format=woff2')
-		format('woff2');
+		format('woff2-variations');
 	font-family: 'metric 2 VF';
-	font-weight: 300 400 500 700 800;
+	font-weight: 300 800;
 	font-style: normal;
 	font-display: swap;
 }

--- a/components/o3-foundation/src/css/brands/core.css
+++ b/components/o3-foundation/src/css/brands/core.css
@@ -1,12 +1,11 @@
 @import '../tokens/core/_variables.css';
 @import '../../../main.css';
 
-
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Medium&system_code=origami&version=1.12')
-		format('woff2');
-	font-family: var(--o3-font-family-financier-display);
-	font-weight: 400;
+		format('woff2-variations');
+	font-family: 'financier display VF';
+	font-weight: 300 800;
 	font-style: normal;
 	font-display: swap;
 }

--- a/components/o3-foundation/src/css/brands/sustainable-views.css
+++ b/components/o3-foundation/src/css/brands/sustainable-views.css
@@ -1,12 +1,11 @@
 @import '../tokens/sustainable-views/_variables.css';
 @import '../../../main.css';
 
-
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Medium&system_code=origami&version=1.12')
-		format('woff2');
-	font-family: var(--o3-font-family-financier-display);
-	font-weight: 400;
+		format('woff2-variations');
+	font-family: 'financier display VF';
+	font-weight: 300 800;
 	font-style: normal;
 	font-display: swap;
 }


### PR DESCRIPTION
1. Set format to `woff2-variations`, to indicate we are using a VF.
2. Do not use CSS Custom Property in `@font-face`, it is not supported.
3. Set `font-weight` range in `@font-face`. A list of values is invalid.