### PR TITLE
fix: allow targeting to be passed as an option in o-video instances

### DIFF
--- a/components/o-video/README.md
+++ b/components/o-video/README.md
@@ -96,7 +96,11 @@ Where `opts` is an optional object with properties
 - `showCaptions` `[Boolean]` whether or not to add captions to the video. Defaults to `true`.
 - `data` `[Object]` JSON object representing a [response from next-media-api](https://next-media-api.ft.com/v1/eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526). If used, the component will not make a call to the API and use this data instead.
 - `systemcode` `[String]` a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems) for the project using `o-video`.
-- `targeting` `[Object]` object containing the targeting data used to configure, serve and track video ads. If targeting is passed as an option but is missing properties, it will use the properties set in the `defaultTargeting` object instead.
+- `targeting` `[Object]` object containing the targeting data used to configure, serve and track video ads. If targeting is passed as an option but is missing properties, it will use the properties set in the `defaultTargeting` object instead. here is what each property on the targeting object affects:
+	- `site:` refers to the ad unit that contains the line items for video creatives (part of the ad request).
+	- `position:` sets the `pos` param on the ad request which is used to target video ads similar to how `pos: native` is used to target partner content.
+	- `sizes:` also added to ad request to specify video ad sizes to be returned.
+	- `videoId:` added to targeting as a param for targeting ads at a specific video.
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 

--- a/components/o-video/README.md
+++ b/components/o-video/README.md
@@ -96,6 +96,7 @@ Where `opts` is an optional object with properties
 - `showCaptions` `[Boolean]` whether or not to add captions to the video. Defaults to `true`.
 - `data` `[Object]` JSON object representing a [response from next-media-api](https://next-media-api.ft.com/v1/eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526). If used, the component will not make a call to the API and use this data instead.
 - `systemcode` `[String]` a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems) for the project using `o-video`.
+- `targeting` `[Object]` object containing the targeting data used to configure, serve and track video ads. If targeting is passed as an option but is missing properties, it will use the properties set in the `defaultTargeting` object instead.
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 

--- a/components/o-video/src/js/video.js
+++ b/components/o-video/src/js/video.js
@@ -186,13 +186,13 @@ class Video {
 		}
 
 		const defaultTargeting = {
-            site: '/5887/ft.com',
-            position: 'video',
-            sizes: '592x333|400x225',
-            videoId: this.opts.id
-        };
+			site: '/5887/ft.com',
+			position: 'video',
+			sizes: '592x333|400x225',
+			videoId: this.opts.id
+		};
 
-        this.targeting = Object.assign({}, defaultTargeting, this.opts.targeting);
+		this.targeting = Object.assign({}, defaultTargeting, this.opts.targeting);
 
 		if (this.opts.advertising) {
 			this.videoAds = new VideoAds(this);

--- a/components/o-video/src/js/video.js
+++ b/components/o-video/src/js/video.js
@@ -185,12 +185,14 @@ class Video {
 			this.opts.classes.push('o-video__video');
 		}
 
-		this.targeting = {
-			site: '/5887/ft.com',
-			position: 'video',
-			sizes: '592x333|400x225',
-			videoId: this.opts.id
-		};
+		const defaultTargeting = {
+            site: '/5887/ft.com',
+            position: 'video',
+            sizes: '592x333|400x225',
+            videoId: this.opts.id
+        };
+
+        this.targeting = Object.assign({}, defaultTargeting, this.opts.targeting);
 
 		if (this.opts.advertising) {
 			this.videoAds = new VideoAds(this);


### PR DESCRIPTION
## Describe your changes
This PR allows the targeting property of the Video class to be passed in as an option when creating new o-video instances. currently when attempting to modify the targeting object in an instance class it requires two steps, creating a new instance variable and then accessing the targeting object on this variable. This change will allow for single step changes to be made when attempting to modify the properties of the targeting object. see (https://github.com/Financial-Times/next-article/pull/5507)

## Issue ticket number and link
https://financialtimes.atlassian.net/browse/ADSDEV-1830

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
