### PR TITLE
fix: target o3-typography wrapper descendants with direct 

### DIFF
--- a/components/o3-typography/body.css
+++ b/components/o3-typography/body.css
@@ -1,4 +1,5 @@
-.o3-typography-body {
+.o3-typography-body,
+.o3-typography-wrapper > p {
 	font-weight: var(--o3-typography-use-case-body-s-font-weight);
 	font-size: var(--o3-font-size-0);
 	line-height: var(--o3-font-lineheight-0);

--- a/components/o3-typography/body.css
+++ b/components/o3-typography/body.css
@@ -13,12 +13,13 @@
 }
 
 .o3-typography-body[data-o3-theme="inverse"],
-.o3-typography-wrapper:where([data-o3-theme="inverse"]) p {
+.o3-typography-wrapper:where([data-o3-theme="inverse"]) > p {
 	color: var(--_o3-typography-body-inverse-color);
 }
 
 .o3-typography-sub,
-.o3-typography-wrapper sub {
+.o3-typography-wrapper > sub,
+.o3-typography-wrapper > p > sub {
 	font-size: 0.666em;
 	position: static;
 	vertical-align: sub;
@@ -28,7 +29,8 @@
 }
 
 .o3-typography-sup,
-.o3-typography-wrapper sup {
+.o3-typography-wrapper > sup,
+.o3-typography-wrapper > p > sup {
 	font-size: 0.666em;
 	position: static;
 	vertical-align: super;

--- a/components/o3-typography/caption.css
+++ b/components/o3-typography/caption.css
@@ -1,5 +1,5 @@
 .o3-typography-caption,
-.o3-typography-wrapper figcaption {
+.o3-typography-wrapper > figcaption {
 	color: var(--_o3-typography-caption-color);
 	font-size: var(--o3-font-size-negative-1);
 	line-height: var(--o3-font-lineheight-negative-1);

--- a/components/o3-typography/footer.css
+++ b/components/o3-typography/footer.css
@@ -1,8 +1,9 @@
-.o3-typography-footer {
+.o3-typography-footer,
+.o3-typography-wrapper > footer {
 	color: var(--_o3-typography-footer-color);
 }
 
 .o3-typography-footer[data-o3-theme='inverse'],
-.o3-typography-wrapper:where([data-o3-theme='inverse']) footer {
+.o3-typography-wrapper:where([data-o3-theme='inverse']) > footer {
 	color: var(--_o3-typography-body-inverse-color);
 }

--- a/components/o3-typography/heading.css
+++ b/components/o3-typography/heading.css
@@ -1,5 +1,5 @@
 .o3-typography-heading--level-1,
-.o3-typography-wrapper h1 {
+.o3-typography-wrapper > h1 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-1-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-1-line-height);
@@ -7,7 +7,7 @@
 	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-2,
-.o3-typography-wrapper h2 {
+.o3-typography-wrapper > h2 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-2-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-2-line-height);
@@ -15,7 +15,7 @@
 	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-3,
-.o3-typography-wrapper h3 {
+.o3-typography-wrapper > h3 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-3-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-3-line-height);
@@ -23,7 +23,7 @@
 	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-4,
-.o3-typography-wrapper h4 {
+.o3-typography-wrapper > h4 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-4-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-4-line-height);
@@ -31,7 +31,7 @@
 	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-5,
-.o3-typography-wrapper h5 {
+.o3-typography-wrapper > h5 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-5-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-5-line-height);
@@ -39,7 +39,7 @@
 	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-6,
-.o3-typography-wrapper h6 {
+.o3-typography-wrapper > h6 {
 	--o3-typography-heading-font-size: var(--_o3-typography-heading-level-6-font-size);
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-6-line-height);
@@ -49,7 +49,7 @@
 
 
 .o3-typography-heading,
-.o3-typography-wrapper:is(h1, h2, h3, h4, h5, h6) {
+.o3-typography-wrapper > :is(h1, h2, h3, h4, h5, h6) {
 	margin: 0;
 	color: var(--o3-typography-heading-font-color);
 	font-family: FinancierDisplayWeb, serif;
@@ -59,6 +59,6 @@
 }
 
 .o3-typography-heading[data-o3-theme="inverse"],
-:where([data-o3-theme='inverse']) :is(h1, h2, h3, h4, h5, h6) {
+:where([data-o3-theme='inverse']).o3-typography-wrapper > :is(h1, h2, h3, h4, h5, h6) {
 	color: var(--_o3-typography-heading-inverse-color);
 }

--- a/components/o3-typography/link.css
+++ b/components/o3-typography/link.css
@@ -1,5 +1,6 @@
 .o3-typography-link,
-.o3-typography-wrapper a {
+.o3-typography-wrapper > a,
+.o3-typography-wrapper > p > a {
 	color: var(--_o3-typography-link-standard-color);
 	border-bottom-color: var(--_o3-typography-link-standard-bottom-color);
 	text-decoration-color: var(--_o3-typography-link-standard-bottom-color);
@@ -14,7 +15,8 @@
 }
 
 .o3-typography-link[data-o3-theme='inverse'],
-.o3-typography-wrapper:where([data-o3-theme='inverse']) a {
+.o3-typography-wrapper:where([data-o3-theme='inverse']) > a,
+.o3-typography-wrapper:where([data-o3-theme='inverse']) > p > a {
 	color: var(--_o3-typography-link-inverse-color);
 	border-bottom-color: var(--_o3-typography-link-inverse-bottom-color);
 	text-decoration-color: var(--_o3-typography-link-inverse-bottom-color);

--- a/components/o3-typography/list.css
+++ b/components/o3-typography/list.css
@@ -1,5 +1,5 @@
 :is(.o3-typography-ul, .o3-typography-ol),
-.o3-typography-wrapper :is(ul, ol) {
+.o3-typography-wrapper > :is(ul, ol) {
 	color: var(--_o3-typography-body-color);
 	margin: 0 0 var(--o3-spacing-3xs);
 	padding: 0;
@@ -20,7 +20,7 @@
 }
 
 .o3-typography-ul,
-.o3-typography-wrapper ul {
+.o3-typography-wrapper > ul {
 	> li {
 		&:before {
 			content: "\2022";
@@ -32,7 +32,7 @@
 }
 
 .o3-typography-ol,
-.o3-typography-wrapper ol {
+.o3-typography-wrapper > ol {
 	counter-reset: item;
 	> li {
 		&:before {
@@ -47,6 +47,6 @@
 }
 
 :is(.o3-typography-ul, .o3-typography-ol)[data-o3-theme='inverse'],
-.o3-typography-wrapper:where([data-o3-theme='inverse']) :is(ul, ol) {
+.o3-typography-wrapper:where([data-o3-theme='inverse']) > :is(ul, ol) {
 	color: var(--_o3-typography-body-inverse-color);
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
