### PR TITLE
chore: Attempt to make release-please ignore the last bad release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
 	"bootstrap-sha": "4d52a27b6c08755d6c527723c2595ade3e024898",
-	"last-release-sha": "1b53b3b1e49955108622b839cfad0fa7d24c2a7b",
+	"last-release-sha": "2a939a8a8e202758b1cb18a94641af0241dccf03",
 	"packages": {
 		"components/ft-concept-button": {},
 		"components/g-audio": {},

--- a/scripts/regenerate-ci-config-files.js
+++ b/scripts/regenerate-ci-config-files.js
@@ -28,7 +28,7 @@ await del(['.github/workflows/percy-*.yml', '.github/workflows/test-*.yml']);
 let dotReleasePleaseManifest = {};
 let releasePleaseConfig = {
 	'bootstrap-sha': '4d52a27b6c08755d6c527723c2595ade3e024898',
-	'last-release-sha': '1b53b3b1e49955108622b839cfad0fa7d24c2a7b',
+	'last-release-sha': '2a939a8a8e202758b1cb18a94641af0241dccf03',
 	packages: {},
 };
 


### PR DESCRIPTION
https://github.com/googleapis/release-please/blob/cb106cd0b5ae5c3e2a3b015487dc615eba72b842/docs/manifest-releaser.md?plain=1#L134


Last time I regenerated from a template and enabled auto merge, resulting in 0 changes.
https://github.com/Financial-Times/origami/pull/1637/files