### PR TITLE
Backstage/add font styling to typography

### DIFF
--- a/components/o3-typography/heading.css
+++ b/components/o3-typography/heading.css
@@ -4,7 +4,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-1-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-1-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-2,
 .o3-typography-wrapper > h2 {
@@ -12,7 +11,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-2-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-2-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-3,
 .o3-typography-wrapper > h3 {
@@ -20,7 +18,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-3-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-3-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-4,
 .o3-typography-wrapper > h4 {
@@ -28,7 +25,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-4-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-4-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-5,
 .o3-typography-wrapper > h5 {
@@ -36,7 +32,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-5-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-5-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 .o3-typography-heading--level-6,
 .o3-typography-wrapper > h6 {
@@ -44,7 +39,6 @@
 	--o3-typography-heading-font-color: var(--_o3-typography-heading-color);
 	--o3-typography-heading-line-height: var(--_o3-typography-heading-level-6-line-height);
 	--o3-typography-heading-font-weight: var(--_o3-typography-heading-level-6-font-weight);
-	--o3-typography-heading-font-family: var(--o3-typography-use-case-heading1-font-family);
 }
 
 
@@ -52,7 +46,6 @@
 .o3-typography-wrapper > :is(h1, h2, h3, h4, h5, h6) {
 	margin: 0;
 	color: var(--o3-typography-heading-font-color);
-	font-family: FinancierDisplayWeb, serif;
 	font-size: var(--o3-typography-heading-font-size);
 	line-height: var(--o3-typography-heading-line-height);
 	font-weight: var(--o3-typography-heading-font-weight);

--- a/components/o3-typography/main.css
+++ b/components/o3-typography/main.css
@@ -13,3 +13,6 @@
 	font-style: italic;
 }
 
+[class^='o3-typography'] {
+	font-family: var(--o3-font-family-metric);
+}


### PR DESCRIPTION
## Describe your changes

* Uses Metric on o3-typography components
* removes some unecessary `font-face` and other font declarations from o3-typography

**Before**
<img width="1193" alt="image" src="https://github.com/Financial-Times/origami/assets/7166831/9699e0e9-f960-4a02-8e85-d352000cbac5">

**After**

<img width="796" alt="image" src="https://github.com/Financial-Times/origami/assets/7166831/0e84e8f0-1813-4006-b92a-424c43b54991">


## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
