### PR TITLE
Fix: moved trim from textContext label and onto the button

### DIFF
--- a/components/o-multi-select/src/js/multi-select-options.js
+++ b/components/o-multi-select/src/js/multi-select-options.js
@@ -64,7 +64,9 @@ function removeOption(optionEl, option, index) {
 	optionEl.classList.remove('o-multi-select-option__selected');
 	optionEl.setAttribute('aria-selected', 'false');
 	this._numberOfSelectedOptions--;
-	const button = this._selectedOptions.querySelector(`#${option.value}-${index}`);
+	const button = this._selectedOptions.querySelector(
+		`#${option.value}-${index}`
+	);
 	button.parentElement.remove();
 	this._updateState();
 }
@@ -110,7 +112,7 @@ function createOptionButton(option, index) {
 	button.setAttribute('aria-label', ` remove ${option.label} `);
 	button.className = 'o-multi-select__selected-options-button';
 	button.type = 'button';
-	button.textContent = option.label;
+	button.textContent = option.label.trim();
 	const span = document.createElement('span');
 	span.classList = 'o-icons-icon o-icons-icon--cross';
 	button.appendChild(span);
@@ -134,7 +136,7 @@ export function createOption(idBase, option, index, selected) {
 	optionEl.id = `${idBase}-${index}`;
 	optionEl.className = 'o-multi-select-option';
 	optionEl.setAttribute('aria-selected', selected);
-	optionEl.textContent = option.label.trim();
+	optionEl.textContent = option.label;
 	const tickSpan = document.createElement('span');
 	tickSpan.className = 'o-multi-select-option-tick';
 	optionEl.appendChild(tickSpan);


### PR DESCRIPTION
## Describe your changes
Removed trim from the optionEl.textContent and added it to the button.textContent line.

## Issue ticket number and link
Jira [ticket](https://financialtimes.atlassian.net/browse/SP-3623)
## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
