### PR TITLE
Header myaccount updates

### DIFF
--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -1,5 +1,56 @@
 # Migration Guide
 
+## Migrating from v11 to v12
+
+o-header v12 includes markup changes in the top right menu, which are included in the top.tsx template within this component. Update your markup as described below or [use o-header's tsx template](https://github.com/Financial-Times/origami/tree/main/components/o-header/src/tsx).
+
+### Removal of the myFT link
+
+The myFT logo link is no longer required in the top right of the header as the myFT link is now part of the navigation in the row below.
+
+The following markup can be removed all together from all header types.
+
+```html
+<a
+	className="o-header__top-icon-link o-header__top-icon-link--myft"
+	id="o-header-top-link-myft"
+	href="/myft"
+	aria-label="My F T"
+>
+	<span className="o-header__visually-hidden">myFT</span>
+</a>
+```
+
+### Add the My Account & Sign in link
+
+In the same location of where the myFT logo link was removed we need to add a new link for accessing the users My Account or prompting them to Sign in.
+
+```html
+<a
+	className="o-header__top-myaccount"
+	href="/myaccount"
+>
+	<span>My Account</span>
+</a>
+```
+
+> [!NOTE]
+> This same markup is used for both the My Account and Sign in links. Your templates will need to be responsible for swapping the anchor text within the `<span>` and the `href` value
+
+
+When this is being used in the sticky header a `tabIndex` attribute should be added with a value of `-1`. This ensures that the link is not included in keyboard navigation.
+
+```html
+<a
+	className="o-header__top-myaccount"
+	href="/myaccount"
+	tabIndex="-1"
+>
+	<span>My Account</span>
+</a>
+```
+
+
 ## Migrating from v10 to v11
 
 o-header v11 includes markup changes in the drawer menu. Update your markup as described below or [use o-header's tsx template](https://github.com/Financial-Times/origami/tree/main/components/o-header/src/tsx).

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -131,20 +131,35 @@
 		}
 	}
 
-	.o-header__top-icon-link--myft {
+	.o-header__top-myaccount {
+		@include _oHeaderLink;
+		@include oTypographySans(0);
+		display: flex;
+		align-items: center;
+		position: relative;
+		padding: $_o-header-padding-y 0;
+
 		&:before {
-			@include _oHeaderBrandImage('brand-myft', _oHeaderGet('header-icon'), 52);
-			// this is not a very square icon
-			width: 35px;
-			// Remove the negative margin added for new icons which have additional padding
-			margin-top: 0;
+			@include oIconsContent('user', _oHeaderGet('header-icon'), $size: 32, $include-base-styles: false);
+			content: ' ';
+		}
 
-			@include oGridRespondTo('M') {
-				width: 44px;
-			}
+		&:after {
+			content: '';
+			position: absolute;
+			height: 4px;
+			width: calc(100% - 32px);
+			right: 0;
+			bottom: 8px;
+		}
 
-			@include oGridRespondTo('oHeaderL') {
-				width: 52px;
+		&:hover:after {
+			background-color: _oHeaderGet('link-hover-text');
+		}
+
+		span {
+			@include oGridRespondTo($until: 'M') {
+				@include oNormaliseVisuallyHidden;
 			}
 		}
 	}

--- a/components/o-header/src/tsx/Props.ts
+++ b/components/o-header/src/tsx/Props.ts
@@ -8,6 +8,8 @@ export type TNavMenuKeys =
 	| 'navbar-uk'
 	| 'navbar-right'
 	| 'navbar-right-anon'
+	| 'navbar-top-right'
+	| 'navbar-top-right-anon'
 	| 'navbar-simple'
 	| 'user';
 
@@ -19,6 +21,8 @@ export type TNavMenuKeysForEdition =
 	| 'navbar'
 	| 'navbar-right'
 	| 'navbar-right-anon'
+	| 'navbar-top-right'
+	| 'navbar-top-right-anon'
 	| 'navbar-simple'
 	| 'user';
 

--- a/components/o-header/src/tsx/header-default.tsx
+++ b/components/o-header/src/tsx/header-default.tsx
@@ -19,10 +19,12 @@ export function Header({
 	variant,
 	data,
 }: THeaderProps) {
-	const includeUserActionsNav = showUserNavigation && !userIsLoggedIn;
 	const includeSubNavigation =
 		showSubNavigation && (data.breadcrumb || data.subsections);
-	const userNavItems = includeUserActionsNav && data['navbar-right-anon'].items;
+
+	const userNavData = userIsLoggedIn ? data['navbar-top-right'] : data['navbar-top-right-anon'];
+	const userNavItems = userNavData.items;
+
 	const breadcrumb = data.breadcrumb;
 	const subsections = data.subsections;
 	const rightSubSection = data['subsections-right'];
@@ -31,7 +33,7 @@ export function Header({
 	const rightNavItems = data['navbar-right'].items;
 	return (
 		<>
-			{includeUserActionsNav && <UserActionsNav userNavItems={userNavItems} />}
+			{showUserNavigation && <UserActionsNav userNavItems={userNavItems} />}
 			<TopWrapper>
 				<TopColumnLeft />
 				<TopColumnCenter showLogoLink={showLogoLink} />

--- a/components/o-header/src/tsx/sticky.tsx
+++ b/components/o-header/src/tsx/sticky.tsx
@@ -4,6 +4,7 @@ import {
 	TopWrapper,
 	SubscribeButton,
 	TopColumnRightAnon,
+	TopColumnRight
 } from './top';
 
 export function StickyHeader({
@@ -12,8 +13,8 @@ export function StickyHeader({
 	userIsSubscribed,
 	data,
 }: THeaderProps) {
-	const includeUserActionsNav = showUserNavigation && !userIsLoggedIn;
-	const userNavItems = includeUserActionsNav && data['navbar-right-anon'].items;
+	const userNavData = userIsLoggedIn ? data['navbar-top-right'] : data['navbar-top-right-anon'];
+	const userNavItems = userNavData.items;
 	const navBarItems = data.navbar.items;
 	return (
 		<header
@@ -25,11 +26,11 @@ export function StickyHeader({
 			<TopWrapper>
 				<TopColumnLeft isSticky={true} />
 				<StickyTopColumnCenter navBarItems={navBarItems} />
-				<TopRightSTicky
-					userIsLoggedIn={userIsLoggedIn}
-					showUserNavigation={showUserNavigation}
-					userIsSubscribed={userIsSubscribed}
+				<TopColumnRight
+					variant="sticky"
 					userNavItems={userNavItems}
+					userIsLoggedIn={userIsLoggedIn}
+					userIsSubscribed={userIsSubscribed}
 				/>
 			</TopWrapper>
 			<StickySearch />
@@ -70,49 +71,6 @@ const Navigation = ({navBarItems}: {navBarItems: TNavMenuItem[]}) => (
 	</div>
 );
 
-function TopRightSTicky({
-	userIsLoggedIn,
-	showUserNavigation,
-	userIsSubscribed,
-	userNavItems,
-}: {
-	userIsLoggedIn: boolean;
-	showUserNavigation: boolean;
-	userIsSubscribed: boolean;
-	userNavItems: TNavMenuItem[];
-}) {
-	const subscribeAction = userNavItems?.[1];
-	let children;
-	if (userIsLoggedIn) {
-		return (
-			<div className="o-header__top-column o-header__top-column--right">
-				{userIsSubscribed && subscribeAction && (
-					<SubscribeButton variant="sticky" item={subscribeAction} />
-				)}
-				<MyFtSticky />
-			</div>
-		);
-	} else if (showUserNavigation) {
-		children = <TopColumnRightAnon items={userNavItems} variant="sticky" />;
-	}
-
-	return (
-		<div className="o-header__top-column o-header__top-column--right">
-			{children}
-		</div>
-	);
-}
-function MyFtSticky() {
-	return (
-		<a
-			className="o-header__top-icon-link o-header__top-icon-link--hide-s o-header__top-icon-link--myft"
-			href="/myft"
-			aria-label="My F T"
-			tabIndex={-1}>
-			<span className="o-header__visually-hidden">myFT</span>
-		</a>
-	);
-}
 const StickySearch = () => {
 	return (
 		<div

--- a/components/o-header/src/tsx/top.tsx
+++ b/components/o-header/src/tsx/top.tsx
@@ -121,6 +121,7 @@ const TopColumnRightLoggedIn = ({
 	userIsSubscribed: boolean;
 	variant: THeaderVariant;
 }) => {
+	const myAccountAction = items?.[0];
 	const subscribeAction = items?.[1];
 	return (
 		<div className="o-header__top-column o-header__top-column--right">
@@ -131,28 +132,33 @@ const TopColumnRightLoggedIn = ({
 					className="o-header__top-button--hide-m"
 				/>
 			)}
-			<MyFt className="" />
+
+			{myAccountAction && (
+				<MyAccountOrSignInLink
+					item={myAccountAction}
+					variant={variant}
+				/>
+			)}
 		</div>
 	);
 };
 
-const SignInLink = ({
+const MyAccountOrSignInLink = ({
 	item,
 	variant,
-	className,
 }: {
 	item: TNavMenuItem;
 	variant?: string;
-	className?: string;
 }) => {
 	const setTabIndex = variant === "sticky" ? { tabIndex: -1 } : null;
+
 	return (
 		<a
-			className={`o-header__top-link ${className}`}
+			className={`o-header__top-myaccount`}
 			href={item.url || undefined}
 			{...setTabIndex}
 		>
-			{item.label}
+			<span>{item.label}</span>
 		</a>
 	);
 };
@@ -199,24 +205,11 @@ export const TopColumnRightAnon = ({
 				/>
 			)}
 			{signInAction && (
-				<SignInLink
+				<MyAccountOrSignInLink
 					item={signInAction}
 					variant={variant}
-					className="o-header__top-link--hide-m"
 				/>
 			)}
-			<MyFt className="o-header__top-icon-link--show-m" />
 		</div>
 	);
 };
-
-const MyFt = ({ className }: { className?: string }) => (
-	<a
-		className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
-		id="o-header-top-link-myft"
-		href="/myft"
-		aria-label="My F T"
-	>
-		<span className="o-header__visually-hidden">myFT</span>
-	</a>
-);

--- a/components/o-header/stories/storybook-data/index.ts
+++ b/components/o-header/stories/storybook-data/index.ts
@@ -4,6 +4,8 @@ import actionsUK from './actionsUK'
 import editionsUK from './editionsUK'
 import navbarRight from './navbarRight'
 import navbarRightAnon from './navbarRightAnon'
+import navbarTopRight from './navbarTopRight'
+import navbarTopRightAnon from './navbarTopRightAnon'
 import navbarSimple from './navbarSimple'
 import navbarUK from './navbarUK'
 import subNavigation from './subNavigationUK'
@@ -30,6 +32,8 @@ const data: THeaderProps = {
     navbar: navbarUK,
     'navbar-right': navbarRight,
     'navbar-right-anon': navbarRightAnon,
+    'navbar-top-right': navbarTopRight,
+    'navbar-top-right-anon': navbarTopRightAnon,
     'navbar-simple': navbarSimple,
     subsections,
     'subsections-right': [],

--- a/components/o-header/stories/storybook-data/navbarTopRight.ts
+++ b/components/o-header/stories/storybook-data/navbarTopRight.ts
@@ -4,13 +4,13 @@ const data: TNavMenu = {
 	label: 'Navigation',
 	items: [
 		{
-			label: 'Portfolio',
-			url: 'https://markets.ft.com/data/portfolio/dashboard',
+			label: 'My Account',
+			url: '/myaccount',
 			submenu: null,
 		},
 		{
-			label: 'myFT Feed',
-			url: 'https://www.ft.com/myft',
+			label: 'Subscribe',
+			url: '/products?segmentId=#',
 			submenu: null,
 		},
 	],

--- a/components/o-header/stories/storybook-data/navbarTopRightAnon.ts
+++ b/components/o-header/stories/storybook-data/navbarTopRightAnon.ts
@@ -4,13 +4,13 @@ const data: TNavMenu = {
 	label: 'Navigation',
 	items: [
 		{
-			label: 'Portfolio',
-			url: 'https://markets.ft.com/data/portfolio/dashboard',
+			label: 'Sign In',
+			url: '/login?location=#',
 			submenu: null,
 		},
 		{
-			label: 'myFT Feed',
-			url: 'https://www.ft.com/myft',
+			label: 'Subscribe',
+			url: '/products?segmentId=#',
 			submenu: null,
 		},
 	],

--- a/components/o-header/stories/storybook-data/profile.ts
+++ b/components/o-header/stories/storybook-data/profile.ts
@@ -3,6 +3,8 @@ import drawerUK from './drawerUK'
 import editionsUK from './editionsUK'
 import navbarRight from './navbarRight'
 import navbarRightAnon from './navbarRightAnon'
+import navbarTopRight from './navbarTopRight'
+import navbarTopRightAnon from './navbarTopRightAnon'
 import navbarSimple from './navbarSimple'
 import navbarUK from './navbarUK'
 import subNavigation from './subNavigationProfile'
@@ -29,6 +31,8 @@ const data: THeaderProps = {
     navbar: navbarUK,
     'navbar-right': navbarRight,
     'navbar-right-anon': navbarRightAnon,
+    'navbar-top-right': navbarTopRight,
+    'navbar-top-right-anon': navbarTopRightAnon,
     'navbar-simple': navbarSimple,
     subsections,
     'subsections-right': [


### PR DESCRIPTION
# Description

Roll out the variant of the `experimentalAccountEntryTest` AB test as the default permanent behaviour

### Justification

In early 2024 the Retention team ran an AB test to try and improve the user experience of the header by trying to reduce confusion of the difference between Settings & Account and myFT. This test was successful so we are now rolling these changes out to all users. The changes that are relevant to this PR are

1. Add styling for the new My Account / Sign in link
2. Rename `Settings & Account` to `My Account`
3. Rename `myFT` to `myFT Feed`
4. Move My Account to the top right slot, replacing the myFT logo
5. Move myFT to the bottom right slot, replacing the old Settings & Account link

### Screenshots
 
 **Anonymous user - Previous layout**

![Screenshot of the FT header as seen by an anonymous user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/e4400267-c55c-4ad1-8ba7-d21db826423b)
 
  **Anonymous user - New layout**  
  
![Screenshot of the FT header as seen by an anonymous user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/70e9aa8b-6228-480f-97b2-37eba0ef1ab6)

  **Signed in user - Previous layout**
  
  
![Screenshot of the FT header as seen by an registered user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/210f0b4d-c815-4339-a436-a197fb6aa783)

  **Signed in user - New layout**
  
![Screenshot of the FT header as seen by an regustered user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/b24475f5-6c76-4e72-8499-ecb3d85ca6dc)


### Reviewer considerations

1. This relates to the following PRs
a.[ Original AB Test PR](https://github.com/Financial-Times/dotcom-page-kit/pull/1017)
b. [Origami navigation service data changes](https://github.com/Financial-Times/origami-navigation-service/pull/922)
4. You can see the data changes on https://next-navigation.ft.com/v2/menus


### Ticket
https://financialtimes.atlassian.net/browse/ACC-3083