### PR TITLE
docs: add link to origami for nobody

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ If you'd like to make a proposal for a new component or anything else, go ahead 
 This repository houses many projects of different kinds. Most of them have
 READMEs of their own where you can learn more about them.
 
-### apps/website
+### apps/astro-website
 
 The [Origami website](./apps/website), served at <https://origami.ft.com>.
 
 ### apps/storybook
 
 [Origami's storybook](./apps/storybook), served at <https://origami.ft.com/storybook/>.
+
+### apps/for-everyone-website
+
+[Origami Design System](https://origami-for-everyone.ft.com/) documentation and usage guides.
 
 ### components and libraries
 


### PR DESCRIPTION
## Describe your changes

Add link to origami for everyone astro website. Because I keep forgetting it.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
