### PR TITLE
fix: small button icon size and icon-only ratio (square)

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -306,6 +306,7 @@
 
 	--_o3-button-inline-padding-start: var(--o3-spacing-4xs);
 	--_o3-button-inline-padding-end: var(--o3-spacing-4xs);
+	--_o3-button-block-padding: var(--o3-spacing-5xs);
 
 	--_o3-button-font-size: var(--o3-font-size-negative-2);
 	--_o3-button-lineheight: var(--o3-font-lineheight-negative-2);
@@ -434,7 +435,7 @@
 }
 
 .o3-button-icon.o3-button-icon--icon-only {
-	--_o3-button-min-width: 40px;
+	--_o3-button-min-width: var(--_o3-button-min-height);
 	--_o3-button-inline-padding-start: 0;
 	--_o3-button-inline-padding-end: 0;
 }

--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -3,8 +3,8 @@
 	--_o3-button-min-height: 40px;
 
 	--_o3-button-block-padding: var(--o3-spacing-4xs);
-	--_o3-button-inline-padding-start: var(--o3-spacing-4xs);
-	--_o3-button-inline-padding-end: var(--o3-spacing-4xs);
+	--_o3-button-inline-padding-start: var(--o3-spacing-2xs);
+	--_o3-button-inline-padding-end: var(--o3-spacing-2xs);
 
 	--_o3-button-font-size: var(--o3-font-size-negative-1);
 	--_o3-button-lineheight: var(--o3-font-lineheight-negative-1);


### PR DESCRIPTION
Before / After:
![Screenshot 2024-05-20 at 11 54 06](https://github.com/Financial-Times/origami/assets/10405691/7efa8349-a4c6-4a8c-9c5d-81e6800bfccf)

Small, icon only button now aligns with our designs:
- Square
- 20px icon

![Screenshot 2024-05-20 at 11 54 24](https://github.com/Financial-Times/origami/assets/10405691/175b2324-6a3d-4719-892e-b12d20616ce3)
