### PR TITLE
feat: Add o-autocomplete configurable highlighting

### DIFF
--- a/components/o-autocomplete/src/js/autocomplete.js
+++ b/components/o-autocomplete/src/js/autocomplete.js
@@ -16,18 +16,19 @@ import accessibleAutocomplete from '@financial-times/accessible-autocomplete';
 /**
  * @param {string} suggestion - Text which is going to be suggested to the user
  * @param {string} query - Text which was typed into the autocomplete text input field by the user
+ * @param {boolean} isMatchHighlighted - Boolean to determine whether matching or non-matching characters should be highlighted.
  * @returns {CharacterHighlight[]} An array of arrays which contain two items, the first is the character in the suggestion, the second is a boolean which indicates whether the character should be highlighted.
  */
-function highlightSuggestion(suggestion, query) {
+function highlightSuggestion(suggestion, query, isMatchHighlighted) {
 	const result = suggestion.split('');
 
 	const matchIndex = suggestion.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
 	return result.map(function(character, index) {
-		let shouldHighlight = true;
+		let shouldHighlight = !isMatchHighlighted;
 		const hasMatched = matchIndex > -1;
 		const characterIsWithinMatch = index >= matchIndex && index <= matchIndex + query.length - 1;
 		if (hasMatched && characterIsWithinMatch) {
-			shouldHighlight = false;
+			shouldHighlight = isMatchHighlighted;
 		}
 		return [character, shouldHighlight];
 	});
@@ -182,6 +183,7 @@ function initClearButton(instance) {
  * @property {MapOptionToSuggestedValue} [mapOptionToSuggestedValue] - Function which transforms a suggestion before rendering.
  * @property {onConfirm} [onConfirm] - Function which is called when the user selects an option
  * @property {SuggestionTemplate} [suggestionTemplate] - Function to override how a suggestion item is rendered.
+ * @property {boolean} [isMatchHighlighted] - Boolean to determine whether matching or non-matching characters should be highlighted.
  * @property {boolean} [autoselect] - Boolean to specify whether first option in suggestions list is highlighted.
  */
 
@@ -209,6 +211,9 @@ class Autocomplete {
 		}
 		if (opts.suggestionTemplate) {
 			this.options.suggestionTemplate = opts.suggestionTemplate;
+		}
+		if (opts.isMatchHighlighted) {
+			this.options.isMatchHighlighted = Boolean(opts.isMatchHighlighted);
 		}
 		if (opts.autoselect) {
 			this.options.autoselect = opts.autoselect;
@@ -293,10 +298,17 @@ class Autocomplete {
 					 * @returns {string|undefined} HTML string to represent a single suggestion.
 					 */
 					suggestion: (option, query) => {
+						const isMatchHighlighted = this.options.isMatchHighlighted || false;
+
 						// If the suggestionTemplate override option is provided,
 						// use that to render the suggestion.
 						if(typeof this.options.suggestionTemplate === 'function') {
-							return this.options.suggestionTemplate(option, query);
+							return this.options.suggestionTemplate(
+								option,
+								query,
+								highlightSuggestion,
+								isMatchHighlighted
+							);
 						}
 						if (typeof option === 'object') {
 							// If the `mapOptionToSuggestedValue` function is defined
@@ -315,7 +327,7 @@ class Autocomplete {
 							throw new Error(`The option trying to be displayed as a suggestion is not a string, it is "${typeof option}". o-autocomplete can only display strings as suggestions. Define a \`mapOptionToSuggestedValue\` function to convert the option into a string to be used as the suggestion.`);
 						}
 
-						return this.suggestionTemplate(option);
+						return this.suggestionTemplate(option, isMatchHighlighted);
 					},
 					/**
 					 * Used when a suggestion is selected, the return value of this will be used as the value for the input element.
@@ -387,15 +399,20 @@ class Autocomplete {
 	 * Used when rendering suggestions, the return value of this will be used as the innerHTML for a single suggestion.
 	 *
 	 * @param {string} suggestedValue The suggestion to apply the template with.
+	 * @param {boolean} isMatchHighlighted Boolean to determine whether matching or non-matching characters should be highlighted.
 	 * @returns {string} HTML string to be represent a single suggestion.
 	 */
-	suggestionTemplate (suggestedValue) {
+	suggestionTemplate (suggestedValue, isMatchHighlighted) {
 		// o-autocomplete has a UI design to highlight characters in the suggestions.
 		const input = this.autocompleteEl.querySelector('input');
 		/**
 		 * @type {CharacterHighlight[]} An array of arrays which contain two items, the first is the character in the suggestion, the second is a boolean which indicates whether the character should be highlighted.
 		 */
-		const characters = highlightSuggestion(suggestedValue, input ? input.value : suggestedValue);
+		const characters = highlightSuggestion(
+			suggestedValue,
+			input ? input.value : suggestedValue,
+			isMatchHighlighted
+		);
 
 		let output = '';
 		for (const [character, shoudHighlight] of characters) {


### PR DESCRIPTION
## Describe your changes

This PR applies changes so that custom `suggestionTemplate` callbacks provided as an option when instantiating an instance of `oAutocomplete` will now receive two additional arguments:
- `highlightSuggestion()` — as declared [here](https://github.com/Financial-Times/origami/blob/55a9552fedef246e152623690efa2d441fef9dea/components/o-autocomplete/src/js/autocomplete.js#L21-L34)
- `isMatchHighlighted` — a boolean to determine whether matching or non-matching characters should be highlighted, which in turn is passed as an argument to the `highlightSuggestion()` function within a custom `suggestionTemplate()` function (that has been passed as an option when instantiating an instance of `oAutocomplete`) or within the [native `suggestionTemplate()` function](https://github.com/Financial-Times/origami/blob/55a9552fedef246e152623690efa2d441fef9dea/components/o-autocomplete/src/js/autocomplete.js#L392-L412)

In the scenario of a custom `suggestionTemplate`, I'm not sure if it's a code smell or anti-pattern that the `isMatchHighlighted` value is passed at instantiation and then reappears via the `suggestionTemplate()` callback where there is technically no compulsion to use that value as intended, i.e. given `suggestionTemplate()` is custom, the `isMatchHighlighted` value could be declared within that function, making its presence as a parameter redundant. However, it seems far neater to declare up-front at time of instantiation all the configuration that dictates how you would like the component to behave.

I would also a prefer a better variable name than `isMatchHighlighted` — set to `true` it makes sense, though when set to `false` it implies that it will simply not highlight matched characters (and by inference, that it will highlight nothing at all) rather than expressing that it _will_ highlight the characters that are not a match. Naming is hard…

### Scenario 1

Custom `suggestionTemplate` with highlights applied to options where it matches query

- `suggestionTemplate` option is provided
- `isMatchHighlighted` option is provided with a value of `true`

```js
function suggestionTemplate (option, query, highlightSuggestion, isMatchHighlighted) {
	…
}

new oAutocomplete(oAutocompleteElement, {
	suggestionTemplate,
	isMatchHighlighted: true,
	…
});
```

![1](https://github.com/Financial-Times/origami/assets/10484515/f13f9a7e-b979-4365-9484-6657b78fac8a)

---

### Scenario 2

Custom `suggestionTemplate` with highlights applied to options where it does NOT match query

- `suggestionTemplate` option is provided
- `isMatchHighlighted` option is NOT provided (or is provided with a value of `false`)

```js
function suggestionTemplate (option, query, highlightSuggestion, isMatchHighlighted) {
	…
}

new oAutocomplete(oAutocompleteElement, {
	suggestionTemplate,
	…
});
```

OR

```js
function suggestionTemplate (option, query, highlightSuggestion, isMatchHighlighted) {
	…
}

new oAutocomplete(oAutocompleteElement, {
	suggestionTemplate,
	isMatchHighlighted: false,
	…
});
```

![2](https://github.com/Financial-Times/origami/assets/10484515/9901cc59-b4cd-4f05-b4fa-012b75cc965c)

---

### Scenario 3

o-autocomplete native `suggestionTemplate` with highlights applied to options where it matches query

- `suggestionTemplate` option is NOT provided
- `isMatchHighlighted` option is provided with a value of `true`

```js
new oAutocomplete(oAutocompleteElement, {
	isMatchHighlighted: true,
	…
});
```

![3](https://github.com/Financial-Times/origami/assets/10484515/7ad72b97-e0a8-48d6-9eac-224005b74b9f)

---

### Scenario 4

o-autocomplete native `suggestionTemplate` with highlights applied to options where it does NOT match query

- `suggestionTemplate` option is NOT provided
- `isMatchHighlighted` option is NOT provided (or is provided with a value of `false`)

```js
new oAutocomplete(oAutocompleteElement, {
	…
});
```

OR

```js
new oAutocomplete(oAutocompleteElement, {
	isMatchHighlighted: false,
	…
});
```

![4](https://github.com/Financial-Times/origami/assets/10484515/c930ef2f-9936-40f7-900f-fe6957cdfbfa)

---

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
