### PR TITLE
fix: ci-2234 check for tagName for comparison

### DIFF
--- a/libraries/ftdomdelegate/main.js
+++ b/libraries/ftdomdelegate/main.js
@@ -425,7 +425,7 @@ Delegate.prototype.fire = function (event, target, listener) {
  * @returns boolean
  */
 function matchesTag(tagName, element) {
-	return tagName.toLowerCase() === element.tagName.toLowerCase();
+	return tagName.toLowerCase() === (element.tagName && element.tagName.toLowerCase());
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3269,7 +3269,7 @@
 		},
 		"components/o-layout": {
 			"name": "@financial-times/o-layout",
-			"version": "5.3.4",
+			"version": "5.4.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-buttons": "^7.8.0",
@@ -3833,7 +3833,7 @@
 		},
 		"components/o3-editorial-typography": {
 			"name": "@financial-times/o3-editorial-typography",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3844,7 +3844,7 @@
 		},
 		"components/o3-foundation": {
 			"name": "@financial-times/o3-foundation",
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3866,7 +3866,7 @@
 		},
 		"components/o3-typography": {
 			"name": "@financial-times/o3-typography",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"


### PR DESCRIPTION
## Describe your changes

This change allows us to apply delegation to an area of the page that applies a shadow root.

This checks for the existence of the `tagName` property on an element before running `lowerCase()` on it, as if this is undefined or null this will throw an error. If an element applies a shadow root, that will return as a document fragment when looping through the parent nodes, and these do not have the `tagName` property.


## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?assignee=5be57e310e625003a46e9693&selectedIssue=CI-2234

## Link to Figma designs
N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
