### PR TITLE
docs: replace registry links

### DIFF
--- a/components/o-icons/README.md
+++ b/components/o-icons/README.md
@@ -1,6 +1,6 @@
 # o-icons
 
-Helper Sass for the [fticons](http://registry.origami.ft.com/components/fticons) image set.
+Helper Sass for the [fticons](https://o2.origami.ft.com/?path=/story/o2-core_components-o-icons--icons&globals=backgrounds:!undefined) image set.
 
 - [o-icons](#o-icons)
 	- [Usage](#usage)
@@ -29,7 +29,7 @@ There are a few ways to get icons from `fticons`:
 
 ## Markup
 
-To add an icon apply the `o-icons-icon` class to a `span`, along with the modifier class for your specific icon e.g. `o-icons-icon--arrow-down`. See the [registry demos](https://registry.origami.ft.com/components/o-icons) for a full list of icons.
+To add an icon apply the `o-icons-icon` class to a `span`, along with the modifier class for your specific icon e.g. `o-icons-icon--arrow-down`. See the [storybook demos](https://o2.origami.ft.com/?path=/story/o2-core_components-o-icons--icons) for a full list of icons.
 
 ```html
 <span class="o-icons-icon o-icons-icon--arrow-down"></span>
@@ -47,7 +47,7 @@ If you would like to use an icon at a different dimension or colour, use `o-icon
 
 Use `oIconsContent` to output the styles for an icon of a given size and colour.
 
-The `$color` argument should be set using an [o-colors](https://registry.origami.ft.com/components/o-colors) Sass function such as `oColorsByName`, but may be set to any hex value.
+The `$color` argument should be set using an [o-colors](https://o2.origami.ft.com/?path=/docs/o2-core_components-o-colors-readme--docs&globals=backgrounds:!undefined) Sass function such as `oColorsByName`, but may be set to any hex value.
 
 ```scss
 // Use o-colors so you can use colors from the Origami palette.


### PR DESCRIPTION
## Describe your changes
Links inside o-icons readme were still pointing to registry. These have now been updated to point to Storybook.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
