### PR TITLE
feat: add feature onlySubscribers on comments

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -268,23 +268,22 @@ class Stream {
 	
 			const customMessageContainer = document.createElement("section");
 			customMessageContainer.classList.add('coral-custom-message-content','coral');
-			
 			const messageRegistered = `
 			<h3>Commenting is only available to readers with FT subscription</h3>
-				<p class="warning">
+				<p>
 					<a href='https://subs.ft.com/products'>Subscribe</a> to join the conversation.
 				</p>
 			`;
 
 			const messageForAnonymous = `
 			<h3>Commenting is only available to readers with FT subscription</h3>
-				<p class="warning">
+				<p>
 					Please <a href='./'>login</a> or <a href='https://subs.ft.com/products'>subscribe</a> to join the conversation.
 				</p>
 			`;
 			const messageForTrial = `
 			<h3>You are still in a trial period</h3>
-				<p class="warning">
+				<p>
 					View our full <a href='https://subs.ft.com/products'>subscription packages</a> to join the conversation.
 				</p>
 			`;

--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -16,7 +16,7 @@ class Stream {
 		this.eventSeenTimes = {};
 		this.useStagingEnvironment = Boolean(opts.useStagingEnvironment);
 		this.isSubscribed = false;
-		this.isTrial = false;
+		this.isTrialist = false;
 		this.onlySubscribers = opts.onlySubscribers;
 	}
 
@@ -42,7 +42,7 @@ class Stream {
 			}
 		}
 		else if(this.onlySubscribers){
-			this.renderNotSingedInMessage();
+			this.renderNotSignedInMessage();
 		}
 	}
 
@@ -53,9 +53,6 @@ class Stream {
 
 		if (displayName) {
 			fetchOptions.displayName = displayName;
-		}
-		if(this.onlySubscribers){
-			fetchOptions.onlySubscribers = this.onlySubscribers;
 		}
 
 		return auth.fetchJsonWebToken(fetchOptions)
@@ -68,7 +65,7 @@ class Stream {
 					this.userHasValidSession = response.userHasValidSession;
 				}
 				this.isSubscribed = response?.isSubscribed;
-				this.isTrial = response?.isTrial;
+				this.isTrialist = response?.isTrialist;
 				this.isRegistered = response?.isRegistered;
 			})
 			.catch(() => {
@@ -261,24 +258,28 @@ class Stream {
 		};
 	}
 
-	renderNotSingedInMessage () {
+	renderNotSignedInMessage () {
+			if(this.isSubscribed){
+				return;
+			}
+
 			const shadowRoot = this.streamEl.querySelector("#coral-shadow-container").shadowRoot;
 			const coralContainer = shadowRoot.querySelector("#coral");
-			coralContainer.setAttribute('data-not-sign-in' , true);
+			coralContainer.setAttribute('data-user-not-signed-in' , true);
 	
 			const customMessageContainer = document.createElement("section");
-			customMessageContainer.classList.add('coral-custom-message-content','coral');
+			customMessageContainer.classList.add('coral__custom-message-content','coral');
 			const messageRegistered = `
 			<h3>Commenting is only available to readers with FT subscription</h3>
 				<p>
 					<a href='https://subs.ft.com/products'>Subscribe</a> to join the conversation.
 				</p>
 			`;
-
+			const currentUrlEscaped = encodeURIComponent(window.location.href);
 			const messageForAnonymous = `
 			<h3>Commenting is only available to readers with FT subscription</h3>
 				<p>
-					Please <a href='./'>login</a> or <a href='https://subs.ft.com/products'>subscribe</a> to join the conversation.
+					Please <a href='https://ft.com/login?location=${currentUrlEscaped}'>login</a> or <a href='https://subs.ft.com/products'>subscribe</a> to join the conversation.
 				</p>
 			`;
 			const messageForTrial = `
@@ -287,11 +288,9 @@ class Stream {
 					View our full <a href='https://subs.ft.com/products'>subscription packages</a> to join the conversation.
 				</p>
 			`;
-			customMessageContainer.innerHTML = this.isTrial ? messageForTrial : this.isRegistered ? messageRegistered : messageForAnonymous ;
-			
-			if(!this.isSubscribed){
-				coralContainer.prepend(customMessageContainer);
-			}
+			customMessageContainer.innerHTML = this.isTrialist ? messageForTrial : this.isRegistered ? messageRegistered : messageForAnonymous;
+
+			coralContainer.prepend(customMessageContainer);
 	}
 
 

--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -22,7 +22,7 @@ export default {
 
 				// user is not signed in or session token is invalid
 				// or error in comments api
-				return { userHasValidSession: false, isSubscribed: false, isTrial: false};
+				return { userHasValidSession: false, isSubscribed: false, isTrialist: false};
 			}
 		});
 	}

--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -10,6 +10,10 @@ export default {
 			url.searchParams.append('staging', '1');
 		}
 
+		if (options.onlySubscribers) {
+			url.searchParams.append('onlySubscribers', '1');
+		}
+
 		return fetch(url, { credentials: 'include' }).then(response => {
 		// user is signed in and has a pseudonym
 			if (response.ok) {
@@ -22,7 +26,7 @@ export default {
 
 				// user is not signed in or session token is invalid
 				// or error in comments api
-				return { userHasValidSession: false };
+				return { userHasValidSession: false, isSubscribed: false, isTrial: false};
 			}
 		});
 	}

--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -10,10 +10,6 @@ export default {
 			url.searchParams.append('staging', '1');
 		}
 
-		if (options.onlySubscribers) {
-			url.searchParams.append('onlySubscribers', '1');
-		}
-
 		return fetch(url, { credentials: 'include' }).then(response => {
 		// user is signed in and has a pseudonym
 			if (response.ok) {

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -19,6 +19,31 @@
             		line-height: 1.45rem;
         	}
 	}
+	#coral[data-not-sign-in="true"]{
+		.coral-guidelines,.coral-createComment,.coral-comment-reactButton, .coral-comment-replyButton{
+			display: none;
+		}
+		.coral-featuredComment-reactButton{
+			pointer-events: none;
+		}
+		.coral-custom-message-content{
+			font-family: var(--font-family-primary);
+			font-size: var(--font-size-3);
+			font-weight: var(--font-weight-primary-regular);
+			background-color: #f2dfce;
+			padding: var(--spacing-4);
+			
+			h3 {
+				margin-bottom: -14px;
+				line-height: 1.375;
+				font-weight: var( --font-weight-primary-semiBold);
+			}
+
+			a {
+				@include oTypographyLink($theme: ('base': 'teal-40', 'hover': 'teal-30'));
+			}
+		}
+	}
 	#coral {
 		--ft-magnify: 1.31282;
                  // See https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?view=detail&selectedIssue=CI-1725
@@ -36,7 +61,7 @@
             		line-height: 1.45rem;
         	}
 	}
-	.o-comments-coral-talk-container, #coral {
+	#coral {
 		--font-family-primary: #{inspect(oTypographyGetFontFamily('sans'))};
 		--font-family-secondary: #{inspect(oTypographyGetFontFamily('sans'))};
 		--font-weight-primary-bold: 600;

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -12,13 +12,7 @@
 
 // stylelint-disable selector-class-pattern, declaration-no-important, selector-max-id
 @mixin _oCommentsTalkIframe {
-	.o-comments-coral-talk-container {
-		--ft-magnify: 1.0666666667;
-		.coral-comment-content {
-            		font-size: 1rem;
-            		line-height: 1.45rem;
-        	}
-	}
+
 	#coral[data-not-sign-in="true"]{
 		.coral-guidelines,.coral-createComment,.coral-comment-reactButton, .coral-comment-replyButton{
 			display: none;

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -12,15 +12,21 @@
 // stylelint-disable selector-class-pattern, declaration-no-important, selector-max-id
 @mixin _oCommentsTalkIframe {
 
-	#coral[data-not-sign-in="true"]{
-		.coral-guidelines,.coral-createComment,.coral-comment-reactButton, .coral-comment-replyButton,.coral-featuredComment-reactButton{
+	#coral[data-user-not-signed-in="true"]{
+		.coral-guidelines,
+		.coral-createComment,
+		.coral-comment-reactButton,
+		.coral-comment-replyButton,
+		.coral-featuredComment-reactButton{
 			display: none;
 		}
-		.coral-custom-message-content{
+		.coral__custom-message-content{
 			font-family: var(--font-family-primary);
 			font-size: var(--font-size-3);
 			font-weight: var(--font-weight-primary-regular);
-			background-color: #f2dfce;
+			background-color: oColorsByName('wheat');
+			border-color: oColorsByName('wheat');
+			border-radius: 0;
 			padding: var(--spacing-4);
 			
 			h3 {

--- a/components/o-comments/src/scss/coral-talk-iframe/main.scss
+++ b/components/o-comments/src/scss/coral-talk-iframe/main.scss
@@ -1,7 +1,6 @@
 /*
 * NOTE:
 * This file is used to apply our custom theme to Coral
-* Talk V5 service.
 *
 * The stylesheet is built by the Origami Build Service
 * and the URL for the CSS file is used in Coral Talk
@@ -14,11 +13,8 @@
 @mixin _oCommentsTalkIframe {
 
 	#coral[data-not-sign-in="true"]{
-		.coral-guidelines,.coral-createComment,.coral-comment-reactButton, .coral-comment-replyButton{
+		.coral-guidelines,.coral-createComment,.coral-comment-reactButton, .coral-comment-replyButton,.coral-featuredComment-reactButton{
 			display: none;
-		}
-		.coral-featuredComment-reactButton{
-			pointer-events: none;
 		}
 		.coral-custom-message-content{
 			font-family: var(--font-family-primary);

--- a/components/o-comments/test/helpers/fixtures.js
+++ b/components/o-comments/test/helpers/fixtures.js
@@ -26,10 +26,14 @@ function streamMarkup () {
 				id="o-comments-stream"
 				data-o-component="o-comments"
 				data-o-comments-article-id="id">
+					<div id="coral-shadow-container">
+					</div>
 			</div>
 		</div>
 	`;
 	insert(html);
+	document.getElementById('coral-shadow-container').attachShadow({mode: 'open'});
+	document.getElementById('coral-shadow-container').shadowRoot.innerHTML = `<div id="coral"></div>`;
 }
 
 function countMarkup () {

--- a/components/o-comments/test/methods/stream/authenticate-user.js
+++ b/components/o-comments/test/methods/stream/authenticate-user.js
@@ -203,15 +203,15 @@ export default function authenticateUser () {
 				});
 		});
 
-		it('sets this.isTrial to true if user is in a trial list', () => {
+		it('sets this.isTrialist to true if user is in a trial list', () => {
 			fetchJWTStub.resolves({
-				isTrial: true
+				isTrialist: true
 			});
 
 			const stream = new Stream();
 			return stream.authenticateUser()
 				.then(() => {
-					proclaim.isTrue(stream.isTrial);
+					proclaim.isTrue(stream.isTrialist);
 				});
 		});
 	});

--- a/components/o-comments/test/methods/stream/authenticate-user.js
+++ b/components/o-comments/test/methods/stream/authenticate-user.js
@@ -167,4 +167,53 @@ export default function authenticateUser () {
 		});
 
 	});
+
+	describe("fetchJsonWebToken returns if user is registered , trial or subscriber", () => { 
+		beforeEach(() => {
+			fixtures.streamMarkup();
+			fetchJWTStub = sinon.stub();
+			sinon.stub(auth, 'fetchJsonWebToken').get(() => fetchJWTStub);
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+			sinon.restore();
+		});
+		it('sets this.isSubscribed to true if user is a subscriber', () => {
+			fetchJWTStub.resolves({
+				isSubscribed: true
+			});
+
+			const stream = new Stream();
+			return stream.authenticateUser()
+				.then(() => {
+					proclaim.isTrue(stream.isSubscribed);
+				});
+		});
+
+		it('sets this.isRegistered to true if user is a registered', () => {
+			fetchJWTStub.resolves({
+				isRegistered: true
+			});
+
+			const stream = new Stream();
+			return stream.authenticateUser()
+				.then(() => {
+					proclaim.isTrue(stream.isRegistered);
+				});
+		});
+
+		it('sets this.isTrial to true if user is in a trial list', () => {
+			fetchJWTStub.resolves({
+				isTrial: true
+			});
+
+			const stream = new Stream();
+			return stream.authenticateUser()
+				.then(() => {
+					proclaim.isTrue(stream.isTrial);
+				});
+		});
+	});
+
 }

--- a/components/o-comments/test/methods/stream/render-not-signed-in-message.js
+++ b/components/o-comments/test/methods/stream/render-not-signed-in-message.js
@@ -17,25 +17,25 @@ export default function renderNotSignedInMessage () {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
 		stream.isRegistered  =true
-		stream.renderNotSingedInMessage();
-		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		stream.renderNotSignedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral__custom-message-content p')
 		proclaim.isTrue(messageElement.innerText.indexOf('Subscribe to join the conversation.') === 0);
 	});
 
 	it("shows message for trials users to subscribe", () => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
-		stream.isTrial  =true
-		stream.renderNotSingedInMessage();
-		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		stream.isTrialist  =true
+		stream.renderNotSignedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral__custom-message-content p')
 		proclaim.isTrue(messageElement.innerText.indexOf('View our full subscription packages to join the conversation.') === 0);
 	});
 
 	it("shows message for anonymous users to login subscribe", () => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
-		stream.renderNotSingedInMessage();
-		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		stream.renderNotSignedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral__custom-message-content p')
 		proclaim.isTrue(messageElement.innerText.indexOf('Please login or subscribe to join the conversation.') === 0);
 	});
 }

--- a/components/o-comments/test/methods/stream/render-not-signed-in-message.js
+++ b/components/o-comments/test/methods/stream/render-not-signed-in-message.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+
+import proclaim from 'proclaim';
+import fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
+
+export default function renderNotSignedInMessage () {
+	beforeEach(() => {
+		fixtures.streamMarkup();
+	});
+
+	afterEach(() => {
+		fixtures.reset();
+	});
+
+	it("shows message for registered users to subscribe", () => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		stream.isRegistered  =true
+		stream.renderNotSingedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		proclaim.isTrue(messageElement.innerText.indexOf('Subscribe to join the conversation.') === 0);
+	});
+
+	it("shows message for trials users to subscribe", () => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		stream.isTrial  =true
+		stream.renderNotSingedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		proclaim.isTrue(messageElement.innerText.indexOf('View our full subscription packages to join the conversation.') === 0);
+	});
+
+	it("shows message for anonymous users to login subscribe", () => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		stream.renderNotSingedInMessage();
+		const messageElement = mockStreamEl.querySelector("#coral-shadow-container").shadowRoot.querySelector('.coral-custom-message-content p')
+		proclaim.isTrue(messageElement.innerText.indexOf('Please login or subscribe to join the conversation.') === 0);
+	});
+}

--- a/components/o-comments/test/stream.test.js
+++ b/components/o-comments/test/stream.test.js
@@ -10,7 +10,7 @@ import authenticateUser from './methods/stream/authenticate-user.js';
 import publishEvent from './methods/stream/publish-event.js';
 import renderSignedInMessage from './methods/stream/render-signed-in-message.js';
 import displayNamePrompt from './methods/stream/display-name-prompt.js';
-
+import renderNotSignedInMessage from './methods/stream/render-not-signed-in-message.js';
 describe("Stream", () => {
 	it("is defined", () => {
 		proclaim.equal(typeof Stream, 'function');
@@ -23,4 +23,5 @@ describe("Stream", () => {
 	describe('.publishEvent', publishEvent);
 	describe('.renderSignedInMessage', renderSignedInMessage);
 	describe('.displayNamePrompt', displayNamePrompt);
+	describe('.renderNotSignedInMessage',renderNotSignedInMessage);
 });


### PR DESCRIPTION
this PR is part of the work to **Stop registered and trial users to comment.** We will receive from next-comments-api new data that will tell if the user is anonymous, registered, trial or subscribed .
If the user is anonymous, registered or trial we will show them a a custom message , and the comment box ,guidelines and actions buttons over the comments will be hidden.

[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-1493)

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [x] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [x] I have updated relevant env variables in Doppler.
