### PR TITLE
fix!: ci-2234 coral illegal comments url

### DIFF
--- a/components/o-comments/MIGRATION.md
+++ b/components/o-comments/MIGRATION.md
@@ -1,5 +1,8 @@
 ## Migration
 
+### Migrating from v10 to v11
+To migrate you need to have a page that will display the illegal comments report form, existing on an available path e.g. https://github.com/Financial-Times/next-article/commit/3dca12c19ee223f654d11cf74ad8d545e1bad0b7. This defaults to switching `/content/` to `/article/comment-report/` but you can specify your own paths.
+
 ### Migrating from v9 to v10
 To migrate you need to have the coral API in version 7 and change the urls to fetch fonts and styles on coral API admin to fetch styles from this version . See more in (documentation)[https://docs.coralproject.net/migrating-6-to-7#after-coral-has-been-updated-to-v7]
 

--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -238,8 +238,10 @@ This component contains a sass file (/src/scss/coral-talk-iframe/main.scss) that
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 9 | N/A | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-⚠ maintained | 8 | N/A | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
+✨ active | 11 | N/A | [migrate to v11](MIGRATION.md#migrating-from-v10-to-v11) |
+⚠ maintained | 10 | N/A | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
+⚠ maintained | 9 | N/A | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
+╳ deprecated | 8 | 8.3.3 | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
 ╳ deprecated | 7 | 7.7 | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
 ╳ deprecated | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
 ╳ deprecated | 5 | 5.0.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |

--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -47,6 +47,22 @@ Use the following markup to enable a comment stream:
 ```
 Coral needs a parent element id when initialising the comment stream embed script.
 
+### Redirection for illegal comment reporting
+
+Within Coral, when a user clicks on the link to report an illegal comment, Coral's default behaviour is to open a new window with the same url and some added querystring items. However, this causes issues for first-click free users who get redirected to the barrier page instead. In order to stay compliant with the DSA, which requires anonymous users to be able to report illegal comments, the link click is intercepted and the user redirected to a non-paywalled page instead.
+
+The paywall report path defaults to `/content/`, the redirect report path defaults to `/article/comment-report/`. If you need either of these to be different paths, you can add either or both of the following attributes to change them to your paths.
+
+```diff
+<div class="o-comments"
+	id="{element-id}"
+	data-o-component="o-comments"
+	data-o-comments-article-id="{article-id}"
+	data-o-comments-article-url="{optional-article-url}"
++	data-o-comments-paywalled-report-path="{optional-paywall-report-path}"
++	data-o-comments-redirect-report-path="{optional-redirect-report-path}">
+</div>```
+
 ### Count
 
 Add the following attribute to the markup to enable a comment count:

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -31,7 +31,8 @@
     "@financial-times/o-normalise": "^3.3.0",
     "@financial-times/o-overlay": "^4.2.1",
     "@financial-times/o-spacing": "^3.0.0",
-    "@financial-times/o-typography": "^7.4.1"
+    "@financial-times/o-typography": "^7.4.1",
+    "ftdomdelegate": "^5.0.1"
   },
   "devDependencies": {
     "@financial-times/o-forms": "^9.9.0",

--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -2,6 +2,7 @@ import events from './utils/events.js';
 import displayName from './utils/display-name.js';
 import auth from './utils/auth.js';
 import purgeJwtCache from './utils/purge-jwt-cache.js';
+import Delegate from 'ftdomdelegate';
 
 class Stream {
 	/**
@@ -21,6 +22,8 @@ class Stream {
 	}
 
 	init () {
+		this.redirectIllegalCommentReport();
+
 		const renderAndAuthenticate = (displayName) => {
 			return Promise.all([this.renderComments(), this.authenticateUser(displayName)])
 				.then(() => {
@@ -44,6 +47,46 @@ class Stream {
 		else if(this.onlySubscribers){
 			this.renderNotSignedInMessage();
 		}
+	}
+
+	/*
+		coral's default behaviour is to reload the page with the comments section in a different view
+		however, this causes issues for first-click free users who get redirected to the barrier page
+		this will send the user to a url that isn't behind the paywall instead
+	*/
+	#tidyPath(path) {
+		if (!path) {
+			return;
+		}
+		if (!path.startsWith('/')) {
+			path = `/${path}`;
+		}
+		if (!path.endsWith('/')) {
+			path = `${path}/`;
+		}
+		return path;
+	}
+
+	redirectIllegalCommentReport () {
+		let paywalledReportPath = this.#tidyPath(this.options?.paywalledReportPath) || '/content/';
+		let redirectReportPath = this.#tidyPath(this.options?.redirectReportPath) || '/article/comment-report/';
+		const sendToCommentReport = function (event, elem) {
+			event.preventDefault();
+			const href = elem.getAttribute('href');
+			// the below will actually work for comments on vanity urls, as the underlying article url is used in coral
+			const newUrl = href.replace(paywalledReportPath, redirectReportPath);
+			window.open(newUrl);
+		}
+
+		document.addEventListener('oComments.ready', () => {
+			const shadowContainer = this.streamEl.querySelector('#coral-shadow-container');
+			const shadowRoot = shadowContainer?.shadowRoot;
+			const shadowFirstContainer = shadowRoot?.children?.length && shadowRoot.children[0];
+			if (shadowFirstContainer) {
+				const commentReportDelegate = new Delegate(shadowFirstContainer);
+				commentReportDelegate.on('click', 'a[href*=illegalContentReport]', sendToCommentReport);
+			}
+		});
 	}
 
 	authenticateUser (displayName) {

--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -4,6 +4,20 @@ import auth from './utils/auth.js';
 import purgeJwtCache from './utils/purge-jwt-cache.js';
 import Delegate from 'ftdomdelegate';
 
+// eslint version is too old to support private methods and we do not want to expose this function as part of the Stream class interface
+function tidyPath(path) {
+	if (!path) {
+		return;
+	}
+	if (!path.startsWith('/')) {
+		path = `/${path}`;
+	}
+	if (!path.endsWith('/')) {
+		path = `${path}/`;
+	}
+	return path;
+}
+
 class Stream {
 	/**
 	 * Class constructor.
@@ -54,22 +68,10 @@ class Stream {
 		however, this causes issues for first-click free users who get redirected to the barrier page
 		this will send the user to a url that isn't behind the paywall instead
 	*/
-	#tidyPath(path) {
-		if (!path) {
-			return;
-		}
-		if (!path.startsWith('/')) {
-			path = `/${path}`;
-		}
-		if (!path.endsWith('/')) {
-			path = `${path}/`;
-		}
-		return path;
-	}
 
 	redirectIllegalCommentReport () {
-		let paywalledReportPath = this.#tidyPath(this.options?.paywalledReportPath) || '/content/';
-		let redirectReportPath = this.#tidyPath(this.options?.redirectReportPath) || '/article/comment-report/';
+		const paywalledReportPath = tidyPath(this.options?.paywalledReportPath) || '/content/';
+		const redirectReportPath = tidyPath(this.options?.redirectReportPath) || '/article/comment-report/';
 		const sendToCommentReport = function (event, elem) {
 			event.preventDefault();
 			const href = elem.getAttribute('href');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3029,7 +3029,8 @@
 				"@financial-times/o-normalise": "^3.3.0",
 				"@financial-times/o-overlay": "^4.2.1",
 				"@financial-times/o-spacing": "^3.0.0",
-				"@financial-times/o-typography": "^7.4.1"
+				"@financial-times/o-typography": "^7.4.1",
+				"ftdomdelegate": "^5.0.1"
 			}
 		},
 		"components/o-cookie-message": {


### PR DESCRIPTION
## Describe your changes

DSA compliance.

The Coral link to report illegal comments works by reopening the same page in a new window, with some added query string items. However, if someone is a first-click free user this will result in the barrier page loading instead. This means that anonymous users can't use the tool to report illegal comments, which is a condition of the DSA.

This change intercepts the clicks on this link, alters the path to a route that is not behind the paywall, then opens that url in a new window.

## Issue ticket number and link

https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?assignee=5be57e310e625003a46e9693&selectedIssue=CI-2234

## Link to Figma designs
N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
