### PR TITLE
docs: Brand the blog index page [OR-714]

### DIFF
--- a/apps/for-everyone-website/src/pages/[brand]/blog.astro
+++ b/apps/for-everyone-website/src/pages/[brand]/blog.astro
@@ -1,0 +1,13 @@
+---
+import config from "virtual:starlight/user-config"
+
+export function getStaticPaths() {
+  return Object.keys(config.locales)
+    .filter(brand => brand !== 'root')
+    .map(brand => ({ params: { brand } }));
+}
+
+import BlogIndex from '../blog/index.astro';
+---
+
+<BlogIndex />

--- a/apps/for-everyone-website/src/pages/blog/index.astro
+++ b/apps/for-everyone-website/src/pages/blog/index.astro
@@ -19,8 +19,6 @@ const postsByYearMap = Map.groupBy(allPosts, ({data}) => {
 });
 
 const postsByYear = Array.from(postsByYearMap);
-
-
 ---
 
 <style>
@@ -34,11 +32,18 @@ const postsByYear = Array.from(postsByYearMap);
 </style>
 
 
-
 <StarlightPage
 	frontmatter={{
 		title: 'Origami Blog',
-	}}
+		head: [{
+			tag: 'link',
+			attrs: {
+				rel: 'canonical',
+				href: (new URL('blog', Astro.site)).toString()
+			}
+		}
+		]
+	}},
 	headings={
 		postsByYearMap.keys().map(year => ({
 	depth: 2,


### PR DESCRIPTION
Ensure the currently selected brand is maintained when viewing the blog index page.

This allows the user to navigate between branded and non-branded blog content.