### PR TITLE
feat: add options commentsAuthUrl and commentsAPIUrl to o-comments

### DIFF
--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -135,6 +135,18 @@ If you want to initialise every comment stream or count element on the page (bas
 import oComments from '@financial-times/o-comments';
 oComments.init();
 ```
+### Options
+These are the available options we can pass to oComments:
+- articleId 
+- articleUrl
+- displayName
+- commentsAuthUrl
+- commentsAPIUrl
+- useStagingEnvironment
+- addClass
+- scrollContainer
+- assetType
+- disableOTracking
 
 ### Firing an oDomContentLoaded event
 
@@ -202,6 +214,8 @@ const comments = new Comments(commentsElement, {
 +	data-o-comments-disable-o-tracking="true">
 </div>
 ```
+
+
 
 ## Sass
 

--- a/components/o-comments/src/js/comments.js
+++ b/components/o-comments/src/js/comments.js
@@ -32,7 +32,7 @@ class Comments {
 	}
 
 	static getCount (id) {
-		return Count.fetchCount(id);
+		return Count.fetchCount(id,this.options);
 	}
 
 	/**

--- a/components/o-comments/src/js/comments.js
+++ b/components/o-comments/src/js/comments.js
@@ -31,8 +31,8 @@ class Comments {
 		}
 	}
 
-	static getCount (id) {
-		return Count.fetchCount(id,this.options);
+	static getCount (id,options) {
+		return Count.fetchCount(id,options);
 	}
 
 	/**

--- a/components/o-comments/src/js/count.js
+++ b/components/o-comments/src/js/count.js
@@ -9,6 +9,7 @@ class Count {
 		this.countEl = countEl;
 		this.articleId = opts.articleId;
 		this.useStagingEnvironment = Boolean(opts.useStagingEnvironment);
+		this.options = opts;
 	}
 
 	/**
@@ -26,7 +27,7 @@ class Count {
 			throw new Error('Element must be a HTMLElement');
 		}
 
-		return Count.fetchCount(this.articleId, this.useStagingEnvironment)
+		return Count.fetchCount(this.articleId, this.options)
 			.then((count) => {
 				this.countEl.textContent = count;
 
@@ -49,8 +50,9 @@ class Count {
 		}
 	}
 
-	static fetchCount (id, useStaging) {
-		const url = `https://comments-api.ft.com/story/count/${id}` + (useStaging ? '?staging=1' : '');
+	static fetchCount (id, options = {}) {
+		const commentsAPIUrl = options?.commentsAPIUrl || 'https://comments-api.ft.com';
+		const url = `${commentsAPIUrl}/story/count/${id}` + (options?.useStagingEnvironment ? '?staging=1' : '');
 
 		return fetch(url)
 			.then(res => res.json())

--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -28,7 +28,7 @@ class Stream {
 				});
 		};
 
-		return displayName.validation(this.options.displayName)
+		return displayName.validation(this.options.displayName,this.options)
 			.then(displayName => renderAndAuthenticate(displayName))
 			.catch(() => renderAndAuthenticate());
 	}
@@ -48,7 +48,7 @@ class Stream {
 
 	authenticateUser (displayName) {
 		const fetchOptions = {
-			useStagingEnvironment: this.useStagingEnvironment
+			...this.options,
 		};
 
 		if (displayName) {
@@ -147,7 +147,7 @@ class Stream {
 									this.login();
 								});
 							if (purgeCacheAfterCompletion) {
-								purgeJwtCache();
+								purgeJwtCache(this.options);
 							}
 						});
 				});

--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -1,6 +1,7 @@
 export default {
 	fetchJsonWebToken: function fetchJsonWebToken (options = {}) {
-		const url = new URL('https://comments-api.ft.com/user/auth/');
+		const commentsAPIUrl = options?.commentsAPIUrl || 'https://comments-api.ft.com';
+		const url = options?.commentsAuthUrl ? new URL(options.commentsAuthUrl) : new URL(`${commentsAPIUrl}/user/auth/`);
 
 		if (options.displayName) {
 			url.searchParams.append('displayName', options.displayName);

--- a/components/o-comments/src/js/utils/display-name.js
+++ b/components/o-comments/src/js/utils/display-name.js
@@ -14,8 +14,9 @@ const form = `<form id="o-comments-displayname-form" class="o-forms o-forms o-co
 	</form>
 </form>`;
 
-const isUnique = (displayName) => {
-	const url = `https://comments-api.ft.com/displayname/isavailable/${encodeURIComponent(displayName)}`;
+const isUnique = (displayName,options = {}) => {
+	const commentsAPIUrl = options?.commentsAPIUrl || 'https://comments-api.ft.com';
+	const url = `${commentsAPIUrl}/displayname/isavailable/${encodeURIComponent(displayName)}`;
 
 	return fetch(url, { method: 'GET' })
 		.then(response => response.json())
@@ -63,7 +64,7 @@ const prompt = () => {
 	return overlay;
 };
 
-const validation = (displayName) => {
+const validation = (displayName,options) => {
 	return new Promise((resolve, reject) => {
 		if (!displayName) {
 			return reject(new Error('Empty display name'));
@@ -74,7 +75,7 @@ const validation = (displayName) => {
 		if (invalidCharacters) {
 			return reject(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
 		} else {
-			isUnique(displayName)
+			isUnique(displayName,options)
 				.then(isUnique => {
 					if (!isUnique) {
 						return reject(new Error('Unfortunately that display name is already taken'));
@@ -93,7 +94,7 @@ const validation = (displayName) => {
 	});
 };
 
-const promptValidation = (event) => {
+const promptValidation = (event,options = {}) => {
 	event.preventDefault();
 
 	return new Promise(resolve => {
@@ -106,7 +107,7 @@ const promptValidation = (event) => {
 		displayNameForm.classList.remove('o-forms-input--invalid');
 
 
-		return validation(displayName)
+		return validation(displayName,options)
 			.then(displayName => resolve(displayName))
 			.catch(error => {
 				errorMessage.innerText = error.message;

--- a/components/o-comments/src/js/utils/purge-jwt-cache.js
+++ b/components/o-comments/src/js/utils/purge-jwt-cache.js
@@ -1,5 +1,7 @@
-export default function purgeJwtCache() {
-	const url = `https://comments-api.ft.com/user/auth`;
+export default function purgeJwtCache(options = {}) {
+	const commentsAPIUrl = options?.commentsAPIUrl || 'https://comments-api.ft.com';
+
+	const url = `${commentsAPIUrl}/user/auth`;
 	return fetch(url, {
 		method: 'PURGE',
 		credentials: 'include'

--- a/components/o-comments/test/count.test.js
+++ b/components/o-comments/test/count.test.js
@@ -21,7 +21,9 @@ describe("Count", () => {
 		describe("when element exists", () => {
 			describe("when initialized without staging option", () => {
 				beforeEach(() => {
-					sinon.stub(Count, 'fetchCount').withArgs('id').resolves(10);
+					sinon.stub(Count, 'fetchCount').withArgs('id',{
+						articleId: 'id'
+					}).resolves(10);
 					fixtures.countMarkup();
 				});
 
@@ -36,8 +38,8 @@ describe("Count", () => {
 						articleId: 'id'
 					});
 
-					return count.renderCount()
-						.then(() => proclaim.equal(count.countEl.innerHTML, 10));
+					const prom =  count.renderCount();
+					prom.then(() => proclaim.equal(count.countEl.innerHTML, 10));
 				});
 			});
 
@@ -93,7 +95,10 @@ describe("Count", () => {
 
 			describe("when initialized with staging option", () => {
 				beforeEach(() => {
-					sinon.stub(Count, 'fetchCount').withArgs('id', true).resolves(20);
+					sinon.stub(Count, 'fetchCount').withArgs('id', {
+						articleId: 'id',
+						useStagingEnvironment: true
+					}).resolves(20);
 					fixtures.countMarkup();
 				});
 
@@ -182,7 +187,7 @@ describe("Count", () => {
 
 			it("returns the comment count from staging", () => {
 				const useStaging = true;
-				return Count.fetchCount('article-id', useStaging)
+				return Count.fetchCount('article-id', {useStagingEnvironment : useStaging})
 					.then(count => proclaim.equal(count, 20));
 			});
 		});


### PR DESCRIPTION
Add options commentsAPIUrl and commentsAuthUrl to o-comments

commentsAPIUrl sets the host url when making requests to comments API
commentsAuthUrl sets the entire url when making request to comments API just for authentication

These properties will be used as for testing and QA purposes

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
