### PR TITLE
fix: use published ftdomdelegate version

### DIFF
--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -32,7 +32,7 @@
     "@financial-times/o-overlay": "^4.2.1",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-typography": "^7.4.1",
-    "ftdomdelegate": "^5.0.1"
+    "ftdomdelegate": "^5.0.0"
   },
   "devDependencies": {
     "@financial-times/o-forms": "^9.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,7 +3012,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "10.3.8",
+			"version": "11.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -3030,7 +3030,7 @@
 				"@financial-times/o-overlay": "^4.2.1",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.4.1",
-				"ftdomdelegate": "^5.0.1"
+				"ftdomdelegate": "^5.0.0"
 			}
 		},
 		"components/o-cookie-message": {
@@ -3822,7 +3822,7 @@
 		},
 		"components/o-video": {
 			"name": "@financial-times/o-video",
-			"version": "7.2.13",
+			"version": "7.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -3875,7 +3875,7 @@
 		},
 		"components/o3-editorial-typography": {
 			"name": "@financial-times/o3-editorial-typography",
-			"version": "1.0.2",
+			"version": "1.1.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3886,7 +3886,7 @@
 		},
 		"components/o3-foundation": {
 			"name": "@financial-times/o3-foundation",
-			"version": "1.1.3",
+			"version": "1.2.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"


### PR DESCRIPTION
## Describe your changes

Sets ftdomdelegate back to v5.0.0 due to publishing issues with 5.0.1

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
