### PR TITLE
Implement drop cap and summary [OR-725]

### DIFF
--- a/apps/dictionary/tokens/whitelabel/components/o3-editorial-typography.json
+++ b/apps/dictionary/tokens/whitelabel/components/o3-editorial-typography.json
@@ -285,6 +285,42 @@
           "lineHeight": "{o3.font.lineheight-metric2.2}"
         },
         "type": "typography"
+      },
+      "summary-m": {
+        "value": {
+          "fontFamily": "{o3.font.family.metric}",
+          "fontWeight": "{o3.font.weight.regular}",
+          "fontSize": "{o3.font.size-metric2.1}",
+          "lineHeight": "{o3.font.lineheight-metric2.3}"
+        },
+        "type": "typography"
+      },
+      "summary-l": {
+        "value": {
+          "fontFamily": "{o3.font.family.metric}",
+          "fontWeight": "{o3.font.weight.regular}",
+          "fontSize": "{o3.font.size-metric2.2}",
+          "lineHeight": "{o3.font.lineheight-metric2.4}"
+        },
+        "type": "typography"
+      },
+      "dropcap-l": {
+        "value": {
+          "fontFamily": "{o3.font.family.metric}",
+          "fontWeight": "{o3.font.weight.light}",
+          "fontSize": "108",
+          "lineHeight": "108"
+        },
+        "type": "typography"
+      },
+      "dropcap-m": {
+        "value": {
+          "fontFamily": "{o3.font.family.metric}",
+          "fontWeight": "{o3.font.weight.light}",
+          "fontSize": "94",
+          "lineHeight": "94"
+        },
+        "type": "typography"
       }
     }
   }

--- a/apps/dictionary/tokens/whitelabel/components/o3-editorial-typography.json
+++ b/apps/dictionary/tokens/whitelabel/components/o3-editorial-typography.json
@@ -308,8 +308,8 @@
         "value": {
           "fontFamily": "{o3.font.family.metric}",
           "fontWeight": "{o3.font.weight.light}",
-          "fontSize": "108",
-          "lineHeight": "108"
+          "fontSize": "106px",
+          "lineHeight": "89px"
         },
         "type": "typography"
       },
@@ -317,8 +317,8 @@
         "value": {
           "fontFamily": "{o3.font.family.metric}",
           "fontWeight": "{o3.font.weight.light}",
-          "fontSize": "94",
-          "lineHeight": "94"
+          "fontSize": "94px",
+          "lineHeight": "77px"
         },
         "type": "typography"
       }

--- a/apps/for-everyone-website/astro.config.mjs
+++ b/apps/for-everyone-website/astro.config.mjs
@@ -46,6 +46,10 @@ export default defineConfig({
 					label: 'internal',
 					lang: 'en-GB-x-internal',
 				},
+				whitelabel: {
+					label: 'whitelabel',
+					lang: 'en-GB-x-wl',
+				},
 			},
 			components: {
 				Hero: './src/components/Hero.astro',

--- a/apps/for-everyone-website/src/components/ContentPanel.astro
+++ b/apps/for-everyone-website/src/components/ContentPanel.astro
@@ -8,6 +8,8 @@ function getBrandFromLocale(lang: string) {
 			return "sustainable-views"
 		case "en-GB-x-internal":
 			return "internal"
+		case "en-GB-x-wl":
+			return "whitelabel"
 		case "en-GB-x-core":
 		default:
 			return "core"

--- a/apps/for-everyone-website/src/components/editorial-typography/DropCap.astro
+++ b/apps/for-everyone-website/src/components/editorial-typography/DropCap.astro
@@ -1,0 +1,18 @@
+---
+import * as DropCap from './preview/DropCap.tsx'
+import FigmaSbLinks from '../utils/FigmaSbLinks.astro';
+import Preview from '../utils/Preview.astro';
+
+const {brand} = Astro.props;
+const figma =
+	'https://www.figma.com/design/y25ZjT1MqqHbNXNXsm8DET/Documentation-Content-Template?node-id=754-4370&t=kyDVEfsg2tRJspyY-4';
+const quoteSbLinkGenerator = (type: string) => {
+	return `https://o3.origami.ft.com/?path=/story/${brand}-o3-editorial-typography--quote&args=type:${type}`;
+};
+const sb = quoteSbLinkGenerator('block');
+
+---
+
+<Preview component={DropCap} />
+
+<FigmaSbLinks {figma} storybook={sb} />

--- a/apps/for-everyone-website/src/components/editorial-typography/preview/DropCap.tsx
+++ b/apps/for-everyone-website/src/components/editorial-typography/preview/DropCap.tsx
@@ -1,0 +1,23 @@
+import {Body} from '@financial-times/o3-editorial-typography/esm';
+
+function DropCap() {
+	return (
+		<>
+			<meta itemProp="@preview" />
+			<Body dropCap={true}>
+				Ttfn stands for "ta-ta for now", a phrase popularised by the character
+				Tigger from "Winnie the Pooh." A capital "T" followed by a lower case
+				"t" is also how we decided on the size and position of the drop cap.
+				This was hard to find example copy for. Lorem ipsum dolor sit amet,
+				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+				et dolore magna aliqua.
+			</Body>
+			<meta itemProp="@preview" />
+		</>
+	);
+}
+
+export const filePath =
+	'src/components/editorial-typography/preview/DropCap.tsx';
+
+export {DropCap as preview};

--- a/apps/for-everyone-website/src/content/docs/guides/typography.mdx
+++ b/apps/for-everyone-website/src/content/docs/guides/typography.mdx
@@ -16,6 +16,7 @@ import '@financial-times/o3-typography/css/core.css';
 
 import '@financial-times/o3-editorial-typography/css/core.css';
 import '@financial-times/o3-editorial-typography/css/sustainable-views.css';
+import '@financial-times/o3-editorial-typography/css/whitelabel.css';
 
 import Overview from '../../../components/editorial-typography/Overview.astro';
 import HeadingStyles from '../../../components/editorial-typography/HeadingStyles.astro';
@@ -26,6 +27,7 @@ import Links from '../../../components/editorial-typography/Links.astro';
 import BigNumber from '../../../components/editorial-typography/BigNumber.astro';
 import Byline from '../../../components/editorial-typography/Byline.astro';
 import TopicTag from '../../../components/editorial-typography/TopicTag.astro';
+import DropCap from '../../../components/editorial-typography/DropCap.astro';
 
 import TypeScale from '../../../components/TypeScale.astro';
 import TypeFamily from '../../../components/TypeFamily.astro';
@@ -138,6 +140,14 @@ Names of heading styles in Editorial typography are now aligned with the Editori
 ### Body and Details styles
 
 <BodyStyles brand="core" />
+
+<BrandedContent brands="whitelabel">
+	#### Drop cap
+	Use for stylistic emphasis on the first letter of an article.
+
+    <DropCap brand={props.brand} />
+
+</BrandedContent>
 
 ### Quotes
 

--- a/components/o3-editorial-typography/README.md
+++ b/components/o3-editorial-typography/README.md
@@ -176,7 +176,7 @@ import {Standfirst} from '@financial-times/o3-editorial-typography/cjs'; // or /
 
 #### Summary
 
-Use to provide a brief overview of an article’s content for supported brands.
+Use to provide a concise summary of the article, offering a quick, high-level overview of the key points. It allows readers to grasp the main ideas without reading the entire article.
 
 ```html
 <p class="o3-editorial-typography-summary">Summary</p>

--- a/components/o3-editorial-typography/README.md
+++ b/components/o3-editorial-typography/README.md
@@ -14,10 +14,11 @@ Typographic styles for editorial content.
     - [Editorial detail styles](#editorial-detail-styles)
       - [Topic Tag](#topic-tag)
       - [Standfirst](#standfirst)
+      - [Summary](#summary)
       - [Caption](#caption)
       - [Byline](#byline)
-      - [Quote](#quote)
-      - [Big Number](#big-number)
+    - [Quote](#quote)
+    - [Big Number](#big-number)
     - [Lists](#lists)
     - [Links](#links)
   - [Theme modifiers](#theme-modifiers)
@@ -54,7 +55,7 @@ Heading styles are available in 5 different types.
 
 ```html
 <h1 class="o3-editorial-typography-headline-large" data-o3-editorial-underline>
- Large headline
+	Large headline
 </h1>
 
 <h1 class="o3-editorial-typography-headline">Headline</h1>
@@ -95,9 +96,7 @@ O3 editorial paragraphs are styled with the `o3-editorial-typography-body` class
 #### HTML
 
 ```html
-<p class="o3-editorial-typography-body">
- This is a small paragraph of text.
-</p>
+<p class="o3-editorial-typography-body">This is a small paragraph of text.</p>
 ```
 
 #### JSX
@@ -114,6 +113,7 @@ import {Body} from '@financial-times/o3-typography/cjs'; // or /esm
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | theme | `standard` \| `inverse` | `standard` | Theme of the body. |
+| dropCap | `boolean` | `false` | Style the first letter as a drop cap, for supported brands. |
 
 **Note:** if the children of the `<Body>` component are not text, the wrapper element with be a `<div>` element. If the children are just string, the wrapper element will be a `<p>` element.
 
@@ -147,8 +147,8 @@ import {TopicTag} from '@financial-times/o3-editorial-typography/cjs'; // or /es
 
 Color and hover colour of the topic tag can be customized by using the following CSS variables:
 
-| Variable                                          | Description                  | Default                |
-| ------------------------------------------------- | ---------------------------- | ---------------------- |
+| Variable                                          | Description                   | Default                |
+| ------------------------------------------------- | ----------------------------- | ---------------------- |
 | `--o3-editorial-typography-topic-tag-color`       | Colour of the topic tag       | `claret` - for core    |
 | `--o3-editorial-typography-topic-tag-hover-color` | Hover colour of the topic tag | `claret-30` - for core |
 
@@ -173,6 +173,22 @@ import {Standfirst} from '@financial-times/o3-editorial-typography/cjs'; // or /
 | Prop  | Type                    | Default    | Description              |
 | ----- | ----------------------- | ---------- | ------------------------ |
 | theme | `standard` \| `inverse` | `standard` | Theme of the standfirst. |
+
+#### Summary
+
+Use to provide a brief overview of an article’s content for supported brands.
+
+```html
+<p class="o3-editorial-typography-summary">Summary</p>
+```
+
+or with JSX import:
+
+```jsx
+import {Summary} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
+
+<Summary>Summary</Summary>;
+```
 
 #### Caption
 
@@ -203,16 +219,16 @@ Author name is usually an anchor but does not have to be if there is no page to 
 
 ```html
 <div class="o3-editorial-typography-byline">
- <a class="o3-editorial-typography-byline-author" href="#">Joe Doe</a>
- &nbsp;
- <span class="o3-editorial-typography-byline-location">in London</span>
- &nbsp;
- <time
-  class="o3-editorial-typography-byline-timestamp"
-  datetime="2019-10-11T20:51:54Z"
-  title="October 11 2019 9:51 pm"
-  >October 11 2019</time
- >
+	<a class="o3-editorial-typography-byline-author" href="#">Joe Doe</a>
+	&nbsp;
+	<span class="o3-editorial-typography-byline-location">in London</span>
+	&nbsp;
+	<time
+		class="o3-editorial-typography-byline-timestamp"
+		datetime="2019-10-11T20:51:54Z"
+		title="October 11 2019 9:51 pm"
+		>October 11 2019</time
+	>
 </div>
 ```
 
@@ -222,18 +238,18 @@ or with JSX import:
 import {Byline} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 <Byline>
- <a className="o3-editorial-typography-byline-author" href="#">
-  Joe Doe
- </a>
- &nbsp;
- <span className="o3-editorial-typography-byline-location">in London</span>
- &nbsp;
- <time
-  className="o3-editorial-typography-byline-timestamp"
-  dateTime="2019-10-11T20:51:54Z"
-  title="October 11 2019 9:51 pm">
-  October 11 2019
- </time>
+	<a className="o3-editorial-typography-byline-author" href="#">
+		Joe Doe
+	</a>
+	&nbsp;
+	<span className="o3-editorial-typography-byline-location">in London</span>
+	&nbsp;
+	<time
+		className="o3-editorial-typography-byline-timestamp"
+		dateTime="2019-10-11T20:51:54Z"
+		title="October 11 2019 9:51 pm">
+		October 11 2019
+	</time>
 </Byline>;
 ```
 
@@ -244,29 +260,29 @@ import {Byline} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 Byline author colour and hover color can be customized by using the following CSS variables:
 
-| Variable                                              | Description                      | Default                |
-| ----------------------------------------------------- | -------------------------------- | ---------------------- |
+| Variable                                              | Description                       | Default                |
+| ----------------------------------------------------- | --------------------------------- | ---------------------- |
 | `--o3-editorial-typography-byline-author-color`       | Colour of the byline author       | `claret` - for core    |
 | `--o3-editorial-typography-byline-author-hover-color` | Hover colour of the byline author | `claret-30` - for core |
 
-#### Quote
+### Quote
 
 Quote is a composite component that includes quote text, author and caption. It is used to display direct words said by a person. It comes in two types: `block` and `pull`. The difference between the two is that `block` quote has vertical line on the left side of the quote, while `pull` quote has none. Pure HTML markup is as follows:
 
 ```html
 <blockquote class="o3-editorial-typography-blockquote">
- <p>
-  Origami is about empowering developers of all levels to build robust,
-  on-brand products ranging from simple static sites through to rich, dynamic
-  web applications, to do it faster, to do it cheaper, and leave them more
-  supportable and more maintainable.
- </p>
- <cite>
-  <span class="o3-editorial-typography-blockquote__author">Quote Author</span>
-  <span class="o3-editorial-typography-blockquote__caption"
-   >Quote Source</span
-  >
- </cite>
+	<p>
+		Origami is about empowering developers of all levels to build robust,
+		on-brand products ranging from simple static sites through to rich, dynamic
+		web applications, to do it faster, to do it cheaper, and leave them more
+		supportable and more maintainable.
+	</p>
+	<cite>
+		<span class="o3-editorial-typography-blockquote__author">Quote Author</span>
+		<span class="o3-editorial-typography-blockquote__caption"
+			>Quote Source</span
+		>
+	</cite>
 </blockquote>
 ```
 
@@ -276,14 +292,14 @@ or with JSX import:
 import {Quote} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 <Quote
- type="pull"
- quoteAuthor="Quote Author"
- quoteSource="Quote Source"
- quoteIcon={true}>
- Origami is about empowering developers of all levels to build robust, on-brand
- products ranging from simple static sites through to rich, dynamic web
- applications, to do it faster, to do it cheaper, and leave them more
- supportable and more maintainable.
+	type="pull"
+	quoteAuthor="Quote Author"
+	quoteSource="Quote Source"
+	quoteIcon={true}>
+	Origami is about empowering developers of all levels to build robust, on-brand
+	products ranging from simple static sites through to rich, dynamic web
+	applications, to do it faster, to do it cheaper, and leave them more
+	supportable and more maintainable.
 </Quote>;
 ```
 
@@ -296,16 +312,16 @@ import {Quote} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 | quoteIcon | `boolean` | `true` | Adds an icon to the quote. |
 | theme | `standard` \| `inverse` | `standard` | Theme of the quote. |
 
-#### Big Number
+### Big Number
 
 Big Number is a composite component that includes a large number and a label. It is used to describe a big number in the editorial content. Pure HTML markup is as follows:
 
 ```html
 <div class="o3-editorial-typography-big-number">
- <div class="o3-editorial-typography-big-number__title">£27,5m</div>
- <div class="o3-editorial-typography-big-number__content">
-  Cost expected to increase by £13.7m a year.
- </div>
+	<div class="o3-editorial-typography-big-number__title">£27,5m</div>
+	<div class="o3-editorial-typography-big-number__content">
+		Cost expected to increase by £13.7m a year.
+	</div>
 </div>
 ```
 
@@ -313,7 +329,7 @@ Big Number is a composite component that includes a large number and a label. It
 import {BigNumber} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 <BigNumber title="£27,5m">
- Cost expected to increase by £13.7m a year.
+	Cost expected to increase by £13.7m a year.
 </BigNumber>;
 ```
 
@@ -331,11 +347,11 @@ Lists may be used in different contexts they inherit font properties such as siz
 
 ```html
 <div class="o3-editorial-typography-body">
- <ol class="o3-editorial-typography-list-ordered">
-  <li>Lorem ipsum adipiscing elit.</li>
-  <li>Sed feugiat turpis at massa tristique.</li>
-  <li>Curabitu r accumsan elit luctus.</li>
- </ol>
+	<ol class="o3-editorial-typography-list-ordered">
+		<li>Lorem ipsum adipiscing elit.</li>
+		<li>Sed feugiat turpis at massa tristique.</li>
+		<li>Curabitu r accumsan elit luctus.</li>
+	</ol>
 </div>
 ```
 
@@ -343,14 +359,14 @@ Lists may be used in different contexts they inherit font properties such as siz
 import {Body, List} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 <Body>
- <List
-  type="ordered"
-  listItems={[
-   'Lorem ipsum adipiscing elit.',
-   'Sed feugiat turpis at massa tristique.',
-   'Curabitu r accumsan elit luctus.',
-  ]}
- />
+	<List
+		type="ordered"
+		listItems={[
+			'Lorem ipsum adipiscing elit.',
+			'Sed feugiat turpis at massa tristique.',
+			'Curabitu r accumsan elit luctus.',
+		]}
+	/>
 </Body>;
 ```
 
@@ -367,10 +383,10 @@ Links are styled using `o3-editorial-typography-link` inside a `o3-editorial-typ
 
 ```html
 <p class="o3-editorial-typography-body">
- An article by
- <a href="https://ft.com/" class="o3-editorial-typography-link"
-  >The Financial Times</a
- >.
+	An article by
+	<a href="https://ft.com/" class="o3-editorial-typography-link"
+		>The Financial Times</a
+	>.
 </p>
 ```
 
@@ -378,8 +394,8 @@ Links are styled using `o3-editorial-typography-link` inside a `o3-editorial-typ
 import {Body, Link} from '@financial-times/o3-editorial-typography/cjs'; // or /esm
 
 <Body>
- An article by
- <Link href="https://ft.com/">The Financial Times</Link>.
+	An article by
+	<Link href="https://ft.com/">The Financial Times</Link>.
 </Body>;
 ```
 
@@ -404,7 +420,7 @@ or if you are using JSX templates, theme can be passed as theme prop:
 import {Headline} from '@financial-times/o3-editorial-typography/cjs';
 
 <Headline type="headline" theme="inverse">
- Headline
+	Headline
 </Headline>;
 ```
 

--- a/components/o3-editorial-typography/drop-cap.css
+++ b/components/o3-editorial-typography/drop-cap.css
@@ -1,11 +1,12 @@
 /* Currently unsupported by brands,
 We intend to introduce this to future Specialist Titles */
-
 .o3-editorial-typography-body--drop-cap:first-child:first-letter {
 	font-family: var(--_o3-dropcap-font-family);
 	font-weight: var(--_o3-dropcap-font-weight);
 	font-size: var(--_o3-dropcap-font-size);
 	line-height: var(--_o3-dropcap-line-height);
+	float: left;
+	margin: 0 1rem;
 }
 
 .o3-editorial-typography-body--drop-cap {

--- a/components/o3-editorial-typography/drop-cap.css
+++ b/components/o3-editorial-typography/drop-cap.css
@@ -1,6 +1,6 @@
 /* Currently unsupported by brands,
 We intend to introduce this to future Specialist Titles */
-.o3-editorial-typography-body--drop-cap:first-child:first-letter {
+.o3-editorial-typography-body--drop-cap:first-letter {
 	font-family: var(--_o3-dropcap-font-family);
 	font-weight: var(--_o3-dropcap-font-weight);
 	font-size: var(--_o3-dropcap-font-size);

--- a/components/o3-editorial-typography/drop-cap.css
+++ b/components/o3-editorial-typography/drop-cap.css
@@ -1,0 +1,36 @@
+/* Currently unsupported by brands,
+We intend to introduce this to future Specialist Titles */
+
+.o3-editorial-typography-body--drop-cap:first-child:first-letter {
+	font-family: var(--_o3-dropcap-font-family);
+	font-weight: var(--_o3-dropcap-font-weight);
+	font-size: var(--_o3-dropcap-font-size);
+	line-height: var(--_o3-dropcap-line-height);
+}
+
+.o3-editorial-typography-body--drop-cap {
+	--_o3-dropcap-font-family: var(
+		--_o3-editorial-typography-dropcap-m-font-family
+	);
+	--_o3-dropcap-font-size: var(--_o3-editorial-typography-dropcap-m-font-size);
+	--_o3-dropcap-font-weight: var(
+		--_o3-editorial-typography-dropcap-m-font-weight
+	);
+	--_o3-dropcap-line-height: var(
+		--_o3-editorial-typography-dropcap-m-line-height
+	);
+	@media screen and (min-width: 980px) {
+		--_o3-dropcap-font-family: var(
+			--_o3-editorial-typography-dropcap-l-font-family
+		);
+		--_o3-dropcap-font-size: var(
+			--_o3-editorial-typography-dropcap-l-font-size
+		);
+		--_o3-dropcap-font-weight: var(
+			--_o3-editorial-typography-dropcap-l-font-weight
+		);
+		--_o3-dropcap-line-height: var(
+			--_o3-editorial-typography-dropcap-l-line-height
+		);
+	}
+}

--- a/components/o3-editorial-typography/src/css/brands/whitelabel.css
+++ b/components/o3-editorial-typography/src/css/brands/whitelabel.css
@@ -1,0 +1,8 @@
+@import '@financial-times/o3-foundation/css/whitelabel.css';
+@import '../tokens/whitelabel/o3-editorial-typography/_variables.css';
+@import '../../../main.css';
+
+/* Currently unsupported by brands,
+We intend to introduce this to future Specialist Titles */
+@import '../../../drop-cap.css';
+@import '../../../summary.css';

--- a/components/o3-editorial-typography/src/css/tokens/whitelabel/o3-editorial-typography/_variables.css
+++ b/components/o3-editorial-typography/src/css/tokens/whitelabel/o3-editorial-typography/_variables.css
@@ -122,10 +122,10 @@
   --_o3-editorial-typography-summary-l-line-height: var(--o3-font-lineheight-metric2-4);
   --_o3-editorial-typography-dropcap-l-font-family: var(--o3-font-family-metric);
   --_o3-editorial-typography-dropcap-l-font-weight: var(--o3-font-weight-light);
-  --_o3-editorial-typography-dropcap-l-font-size: 6.75rem;
-  --_o3-editorial-typography-dropcap-l-line-height: 6.75rem;
+  --_o3-editorial-typography-dropcap-l-font-size: 6.625rem;
+  --_o3-editorial-typography-dropcap-l-line-height: 5.5625rem;
   --_o3-editorial-typography-dropcap-m-font-family: var(--o3-font-family-metric);
   --_o3-editorial-typography-dropcap-m-font-weight: var(--o3-font-weight-light);
   --_o3-editorial-typography-dropcap-m-font-size: 5.875rem;
-  --_o3-editorial-typography-dropcap-m-line-height: 5.875rem;
+  --_o3-editorial-typography-dropcap-m-line-height: 4.8125rem;
 }

--- a/components/o3-editorial-typography/src/css/tokens/whitelabel/o3-editorial-typography/_variables.css
+++ b/components/o3-editorial-typography/src/css/tokens/whitelabel/o3-editorial-typography/_variables.css
@@ -112,4 +112,20 @@
   --_o3-editorial-typography-big-number-content-font-weight: var(--o3-font-weight-regular);
   --_o3-editorial-typography-big-number-content-font-size: var(--o3-font-size-metric2-2);
   --_o3-editorial-typography-big-number-content-line-height: var(--o3-font-lineheight-metric2-2);
+  --_o3-editorial-typography-summary-m-font-family: var(--o3-font-family-metric);
+  --_o3-editorial-typography-summary-m-font-weight: var(--o3-font-weight-regular);
+  --_o3-editorial-typography-summary-m-font-size: var(--o3-font-size-metric2-1);
+  --_o3-editorial-typography-summary-m-line-height: var(--o3-font-lineheight-metric2-3);
+  --_o3-editorial-typography-summary-l-font-family: var(--o3-font-family-metric);
+  --_o3-editorial-typography-summary-l-font-weight: var(--o3-font-weight-regular);
+  --_o3-editorial-typography-summary-l-font-size: var(--o3-font-size-metric2-2);
+  --_o3-editorial-typography-summary-l-line-height: var(--o3-font-lineheight-metric2-4);
+  --_o3-editorial-typography-dropcap-l-font-family: var(--o3-font-family-metric);
+  --_o3-editorial-typography-dropcap-l-font-weight: var(--o3-font-weight-light);
+  --_o3-editorial-typography-dropcap-l-font-size: 6.75rem;
+  --_o3-editorial-typography-dropcap-l-line-height: 6.75rem;
+  --_o3-editorial-typography-dropcap-m-font-family: var(--o3-font-family-metric);
+  --_o3-editorial-typography-dropcap-m-font-weight: var(--o3-font-weight-light);
+  --_o3-editorial-typography-dropcap-m-font-size: 5.875rem;
+  --_o3-editorial-typography-dropcap-m-line-height: 5.875rem;
 }

--- a/components/o3-editorial-typography/src/tsx/body.tsx
+++ b/components/o3-editorial-typography/src/tsx/body.tsx
@@ -1,11 +1,15 @@
 import {BodyProps} from '../types/index';
 import {getDataAttributes} from './utils';
 
-export const Body = ({theme, children}: BodyProps) => {
+export const Body = ({theme, children, dropCap}: BodyProps) => {
 	const attributes = getDataAttributes(theme);
+	const classes = ['o3-editorial-typography-body'];
+	if (dropCap) {
+		classes.push('o3-editorial-typography-body--drop-cap');
+	}
 	const HtmlElement = typeof children === 'string' ? 'p' : 'div';
 	return (
-		<HtmlElement className="o3-editorial-typography-body" {...attributes}>
+		<HtmlElement className={classes.join(' ')} {...attributes}>
 			{children}
 		</HtmlElement>
 	);

--- a/components/o3-editorial-typography/src/tsx/index.ts
+++ b/components/o3-editorial-typography/src/tsx/index.ts
@@ -1,7 +1,8 @@
 import {Headline} from './headline';
 import {Body} from './body';
+import {Summary} from './summary';
 export * from './detail';
 export * from './list';
 export * from './link';
 
-export {Headline, Body};
+export {Headline, Body, Summary};

--- a/components/o3-editorial-typography/src/tsx/summary.tsx
+++ b/components/o3-editorial-typography/src/tsx/summary.tsx
@@ -1,0 +1,7 @@
+import {SummaryProps} from '../types/index';
+
+export const Summary = ({children}: SummaryProps) => {
+	const classes = ['o3-editorial-typography-summary'];
+	const HtmlElement = typeof children === 'string' ? 'p' : 'div';
+	return <HtmlElement className={classes.join(' ')}>{children}</HtmlElement>;
+};

--- a/components/o3-editorial-typography/src/types/index.ts
+++ b/components/o3-editorial-typography/src/types/index.ts
@@ -7,6 +7,11 @@ export type HeadlineProps = {
 
 export type BodyProps = {
 	theme?: 'standard' | 'inverse';
+	dropCap?: boolean;
+	children: (string | JSX.Element)[] | string | JSX.Element;
+};
+
+export type SummaryProps = {
 	children: (string | JSX.Element)[] | string | JSX.Element;
 };
 

--- a/components/o3-editorial-typography/stories/core/body.stories.tsx
+++ b/components/o3-editorial-typography/stories/core/body.stories.tsx
@@ -16,7 +16,7 @@ export default {
 	],
 	parameters: {
 		backgrounds: {default: 'paper'},
-		controls: {exclude: ['children']},
+		controls: {exclude: ['children', 'dropCap']},
 	},
 } as Meta;
 

--- a/components/o3-editorial-typography/stories/story-templates.tsx
+++ b/components/o3-editorial-typography/stories/story-templates.tsx
@@ -1,6 +1,7 @@
 import {
 	Headline as HeadlineTsx,
 	Body as BodyTsx,
+	Summary as SummaryTsx,
 	Caption as CaptionTsx,
 	StandFirst as StandFirstTsx,
 	TopicTag as TopicTagTsx,
@@ -15,6 +16,7 @@ import type {StoryObj, Meta} from '@storybook/react';
 import type {
 	HeadlineProps,
 	BodyProps,
+	SummaryProps,
 	QuoteProps,
 	BigNumberProps,
 	BylineProps,
@@ -31,6 +33,10 @@ type HeadlineStory = StoryObjNoArgs & {
 
 type BodyStory = StoryObjNoArgs & {
 	args: Omit<BodyProps, 'children'> & {content: string};
+};
+
+type SummaryStory = StoryObjNoArgs & {
+	args: Omit<SummaryProps, 'children'> & {content: string};
 };
 
 type DetailStory = StoryObjNoArgs & {
@@ -98,6 +104,15 @@ const BodyTemplate: StoryObj = {
 	},
 	render: args => {
 		return <BodyTsx {...args}>{args.content}</BodyTsx>;
+	},
+};
+
+const SummaryTemplate: StoryObj = {
+	argTypes: {
+		...TemplateSBConfig.argTypes,
+	},
+	render: args => {
+		return <SummaryTsx {...args}>{args.content}</SummaryTsx>;
 	},
 };
 
@@ -265,6 +280,13 @@ export const Body: BodyStory = {
 		content:
 			'Lorem ipsum dolor sit amet consectetur adipisicing elit. Amet earum libero at voluptatum illum facere totam architecto eum porro exercitationem, ea, accusamus quia? Repellat beatae similique ab? Reprehenderit, ullam quae?',
 		theme: 'standard',
+	},
+};
+
+export const Summary: SummaryStory = {
+	...SummaryTemplate,
+	args: {
+		content: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. ',
 	},
 };
 

--- a/components/o3-editorial-typography/stories/whitelable/big-number.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/big-number.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {BigNumber as BigNumberTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: BigNumberTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const BigNumber = StoryTemplates.BigNumber;
+BigNumber.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/stories/whitelable/body.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/body.stories.tsx
@@ -2,21 +2,21 @@ import type {Meta} from '@storybook/react';
 import {Body as BodyTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
+	title: 'Whitelabel/o3-editorial-typography',
 	component: BodyTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 

--- a/components/o3-editorial-typography/stories/whitelable/byline.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/byline.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {Byline as BylineTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: BylineTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'brand', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,12 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const Byline = StoryTemplates.Byline;
+Byline.parameters = {
 	design: DesignParams,
+};
+
+Byline.args = {
+	...StoryTemplates.Byline.args,
+	brand: 'whitelabel',
 };

--- a/components/o3-editorial-typography/stories/whitelable/caption.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/caption.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {Caption as CaptionTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: CaptionTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const Caption = StoryTemplates.Caption;
+Caption.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/stories/whitelable/headline.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/headline.stories.tsx
@@ -1,0 +1,45 @@
+import type {Meta} from '@storybook/react';
+import {Headline} from '../../src/tsx/index';
+import * as StoryTemplates from '../story-templates';
+
+import '../../src/css/brands/whitelabel.css';
+
+export default {
+	title: 'Whitelabel/o3-editorial-typography',
+	component: Headline,
+	decorators: [
+		Story => (
+			<div data-o3-brand="whitelabel">
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		backgrounds: {default: 'white'},
+		controls: {exclude: ['children', 'underline', 'theme']},
+	},
+} as Meta;
+
+const DesignParams = {
+	type: 'figma',
+	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
+};
+
+export const Heading = StoryTemplates.Heading;
+Heading.parameters = {
+	design: DesignParams,
+};
+
+Heading.argTypes = {
+	type: {
+		options: ['headline', 'subheading', 'chapter', 'label'],
+		control: {
+			type: 'radio',
+		},
+	},
+};
+
+Heading.args = {
+	...StoryTemplates.Heading.args,
+	type: 'headline',
+};

--- a/components/o3-editorial-typography/stories/whitelable/link.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/link.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {Link as LinkTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: LinkTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const Link = StoryTemplates.Link;
+Link.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/stories/whitelable/list.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/list.stories.tsx
@@ -1,22 +1,25 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {List as ListTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: ListTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		html: {
+			root: '#component-wrapper',
+		},
+		controls: {exclude: ['theme']},
 	},
 } as Meta;
 
@@ -25,7 +28,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const List = StoryTemplates.List;
+List.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/stories/whitelable/pull-quote.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/pull-quote.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {Quote as QuoteTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: QuoteTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'type', 'quoteSource', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,13 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const PullQuote = StoryTemplates.Quote;
+PullQuote.parameters = {
 	design: DesignParams,
+};
+
+PullQuote.args = {
+	...StoryTemplates.Quote.args,
+	type: 'pull',
+	quoteSource: '',
 };

--- a/components/o3-editorial-typography/stories/whitelable/standfirst.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/standfirst.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {StandFirst as StandFirstTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: StandFirstTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const StandFirst = StoryTemplates.StandFirst;
+StandFirst.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/stories/whitelable/summary.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/summary.stories.tsx
@@ -1,0 +1,31 @@
+import type {Meta} from '@storybook/react';
+import {Summary as SummaryTsx} from '../../src/tsx/index';
+import * as StoryTemplates from '../story-templates';
+
+import '../../src/css/brands/whitelabel.css';
+
+export default {
+	title: 'Whitelabel/o3-editorial-typography',
+	component: SummaryTsx,
+	decorators: [
+		Story => (
+			<div data-o3-brand="whitelabel">
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		backgrounds: {default: 'white'},
+		controls: {exclude: ['children']},
+	},
+} as Meta;
+
+const DesignParams = {
+	type: 'figma',
+	url: 'https://www.figma.com/design/5ATknbGociZMlnNXX4sy4f/Whitelabel---Origami-(o3)?node-id=3-2&m=dev',
+};
+
+export const Summary = StoryTemplates.Summary;
+Summary.parameters = {
+	design: DesignParams,
+};

--- a/components/o3-editorial-typography/stories/whitelable/topic-tag.stories.tsx
+++ b/components/o3-editorial-typography/stories/whitelable/topic-tag.stories.tsx
@@ -1,22 +1,22 @@
 import type {Meta} from '@storybook/react';
-import {Body as BodyTsx} from '../../src/tsx/index';
+import {TopicTag as TopicTagTsx} from '../../src/tsx/index';
 import * as StoryTemplates from '../story-templates';
 
-import '../../src/css/brands/sustainable-views.css';
+import '../../src/css/brands/whitelabel.css';
 
 export default {
-	title: 'Sustainable views/o3-editorial-typography',
-	component: BodyTsx,
+	title: 'Whitelabel/o3-editorial-typography',
+	component: TopicTagTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="sustainable-views">
+			<div data-o3-brand="whitelabel">
 				<Story />
 			</div>
 		),
 	],
 	parameters: {
 		backgrounds: {default: 'white'},
-		controls: {exclude: ['children', 'theme', 'dropCap']},
+		controls: {exclude: ['children', 'theme']},
 	},
 } as Meta;
 
@@ -25,7 +25,7 @@ const DesignParams = {
 	url: 'https://www.figma.com/file/5ATknbGociZMlnNXX4sy4f/Whitelabel---Design-System?type=design&node-id=4717-652&mode=design&t=Y50jCZbAtgxH2F3S-4',
 };
 
-export const Body = StoryTemplates.Body;
-Body.parameters = {
+export const TopicTag = StoryTemplates.TopicTag;
+TopicTag.parameters = {
 	design: DesignParams,
 };

--- a/components/o3-editorial-typography/summary.css
+++ b/components/o3-editorial-typography/summary.css
@@ -1,0 +1,15 @@
+/* Currently unsupported by brands,
+We intend to introduce this to future Specialist Titles */
+
+.o3-editorial-typography-summary {
+	font-family: var(--_o3-editorial-typography-summary-m-font-family);
+	font-size: var(--_o3-editorial-typography-summary-m-font-size);
+	font-weight: var(--_o3-editorial-typography-summary-m-font-weight);
+	line-height: var(--_o3-editorial-typography-summary-m-line-height);
+	@media screen and (min-width: 980px) {
+		font-family: var(--_o3-editorial-typography-summary-l-font-family);
+		font-size: var(--_o3-editorial-typography-summary-l-font-size);
+		font-weight: var(--_o3-editorial-typography-summary-l-font-weight);
+		line-height: var(--_o3-editorial-typography-summary-l-line-height);
+	}
+}


### PR DESCRIPTION
These are specific to the whitelabel brand for now. We intend to roll them out to future Specialist Brands.

**Summary:**
<img width="1512" alt="Screenshot 2024-06-12 at 16 53 59" src="https://github.com/Financial-Times/origami/assets/10405691/1f638021-fb82-490b-ab05-295b015a20e0">

**Drop cap**: Where body copy is "Tt...[lorem ipsum]" the "T" is the dropcap and the top of the "T" aligns with the top of "t" and the button of "T" aligns with the baseline of the 3rd line of copy.

<img width="1055" alt="Screenshot 2024-06-12 at 19 51 58" src="https://github.com/Financial-Times/origami/assets/10405691/4df10583-7931-4a21-a64b-6ca77e4a1548">
<img width="1056" alt="Screenshot 2024-06-12 at 19 52 07" src="https://github.com/Financial-Times/origami/assets/10405691/5db5e5d1-6dea-43ff-87a2-c7befce95e6c">

