### PR TITLE
docs: correct editorial body style preview [OR-729]

### DIFF
--- a/apps/for-everyone-website/src/components/editorial-typography/BodyStyles.astro
+++ b/apps/for-everyone-website/src/components/editorial-typography/BodyStyles.astro
@@ -36,13 +36,6 @@ const sbCaption = sbDomain + '--caption';
 			</td>
 		</tr>
 		<tr>
-			<td>M</td>
-			<td class="body-m">body</td>
-			<td>
-				<FigmaSbLinks figma={figmaBody} storybook={sbBody} />
-			</td>
-		</tr>
-		<tr>
 			<td>L</td>
 			<td class="body-l">body</td>
 			<td>
@@ -144,19 +137,18 @@ const sbCaption = sbDomain + '--caption';
 		text-align: center;
 	}
 	[class^='body-'] {
-		font-family: var(--_o3-editorial-typography-use-case-body-l-font-family);
-		font-weight: var(--_o3-editorial-typography-use-case-body-l-font-weight);
+		font-family: var(--_o3-editorial-typography-body-l-font-family);
+		font-weight: var(--_o3-editorial-typography-body-l-font-weight);
 	}
 
-	.body-s,
-	.body-m {
-		font-size: var(--_o3-editorial-typography-use-case-body-s-font-size);
-		line-height: var(--_o3-editorial-typography-use-case-body-s-line-height);
+	.body-s {
+		font-size: var(--_o3-editorial-typography-body-s-font-size);
+		line-height: var(--_o3-editorial-typography-body-s-line-height);
 	}
 
 	.body-l {
-		font-size: var(--_o3-editorial-typography-use-case-body-l-font-size);
-		line-height: var(--_o3-editorial-typography-use-case-body-l-line-height);
+		font-size: var(--_o3-editorial-typography-body-l-font-size);
+		line-height: var(--_o3-editorial-typography-body-l-line-height);
 	}
 
 	.not-content.o3-editorial-typography-blockquote__source,


### PR DESCRIPTION
The styles aren’t applying (this only impacts the preview, since we use private tokens so to replicate styles and show per breakpoint). The M variant does not exist