### PR TITLE
docs: Add basic whitelabel support to the website [OR-731]

### DIFF
--- a/apps/for-everyone-website/astro.config.mjs
+++ b/apps/for-everyone-website/astro.config.mjs
@@ -46,6 +46,10 @@ export default defineConfig({
 					label: 'internal',
 					lang: 'en-GB-x-internal',
 				},
+				whitelabel: {
+					label: 'whitelabel',
+					lang: 'en-GB-x-wl',
+				},
 			},
 			components: {
 				Hero: './src/components/Hero.astro',

--- a/apps/for-everyone-website/src/components/ContentPanel.astro
+++ b/apps/for-everyone-website/src/components/ContentPanel.astro
@@ -8,6 +8,8 @@ function getBrandFromLocale(lang: string) {
 			return "sustainable-views"
 		case "en-GB-x-internal":
 			return "internal"
+		case "en-GB-x-wl":
+			return "whitelabel"
 		case "en-GB-x-core":
 		default:
 			return "core"

--- a/apps/for-everyone-website/src/components/editorial-typography/DropCap.astro
+++ b/apps/for-everyone-website/src/components/editorial-typography/DropCap.astro
@@ -1,0 +1,18 @@
+---
+import * as DropCap from './preview/DropCap.tsx'
+import FigmaSbLinks from '../utils/FigmaSbLinks.astro';
+import Preview from '../utils/Preview.astro';
+
+const {brand} = Astro.props;
+const figma =
+	'https://www.figma.com/design/y25ZjT1MqqHbNXNXsm8DET/Documentation-Content-Template?node-id=754-4370&t=kyDVEfsg2tRJspyY-4';
+const quoteSbLinkGenerator = (type: string) => {
+	return `https://o3.origami.ft.com/?path=/story/${brand}-o3-editorial-typography--quote&args=type:${type}`;
+};
+const sb = quoteSbLinkGenerator('block');
+
+---
+
+<Preview component={DropCap} />
+
+<FigmaSbLinks {figma} storybook={sb} />

--- a/apps/for-everyone-website/src/components/editorial-typography/preview/DropCap.tsx
+++ b/apps/for-everyone-website/src/components/editorial-typography/preview/DropCap.tsx
@@ -1,0 +1,23 @@
+import {Body} from '@financial-times/o3-editorial-typography/esm';
+
+function DropCap() {
+	return (
+		<>
+			<meta itemProp="@preview" />
+			<Body dropCap={true}>
+				Ttfn stands for "ta-ta for now", a phrase popularised by the character
+				Tigger from "Winnie the Pooh." A capital "T" followed by a lower case
+				"t" is also how we decided on the size and position of the drop cap.
+				This was hard to find example copy for. Lorem ipsum dolor sit amet,
+				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+				et dolore magna aliqua.
+			</Body>
+			<meta itemProp="@preview" />
+		</>
+	);
+}
+
+export const filePath =
+	'src/components/editorial-typography/preview/DropCap.tsx';
+
+export {DropCap as preview};

--- a/apps/for-everyone-website/src/content/docs/guides/typography.mdx
+++ b/apps/for-everyone-website/src/content/docs/guides/typography.mdx
@@ -16,6 +16,7 @@ import '@financial-times/o3-typography/css/core.css';
 
 import '@financial-times/o3-editorial-typography/css/core.css';
 import '@financial-times/o3-editorial-typography/css/sustainable-views.css';
+import '@financial-times/o3-editorial-typography/css/whitelabel.css';
 
 import Overview from '../../../components/editorial-typography/Overview.astro';
 import HeadingStyles from '../../../components/editorial-typography/HeadingStyles.astro';
@@ -26,6 +27,7 @@ import Links from '../../../components/editorial-typography/Links.astro';
 import BigNumber from '../../../components/editorial-typography/BigNumber.astro';
 import Byline from '../../../components/editorial-typography/Byline.astro';
 import TopicTag from '../../../components/editorial-typography/TopicTag.astro';
+import DropCap from '../../../components/editorial-typography/DropCap.astro';
 
 import TypeScale from '../../../components/TypeScale.astro';
 import TypeFamily from '../../../components/TypeFamily.astro';
@@ -138,6 +140,14 @@ Names of heading styles in Editorial typography are now aligned with the Editori
 ### Body and Details styles
 
 <BodyStyles brand="core" />
+
+<BrandedContent brands="whitelabel">
+	#### Drop cap
+	Use for stylistic emphasis on the first letter of an article.
+
+    <DropCap brand={props.brand} />
+
+</BrandedContent>
 
 ### Quotes
 


### PR DESCRIPTION
This shows the drop cap and summary, which are not yet used by any brands but will be for future Specialist Titles.

More work is required (in a future pr) including checking links to figma & storybook – some are set, some aren't. This may benefit from dedicated time to make Figma/Storybook links easier to define and manage – could we define a Figma location once for Storybook's panel and the site?