### PR TITLE
fix: Apply button focus colours on `:focus-visible` only.

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -64,7 +64,7 @@
 		border-color: var(--_o3-button-primary-standard-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-primary-standard-focus-color);
 		background-color: var(--_o3-button-primary-standard-focus-background);
 		border-color: var(--_o3-button-primary-standard-focus-border);
@@ -91,7 +91,7 @@
 		border-color: var(--_o3-button-primary-inverse-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-primary-inverse-focus-color);
 		background-color: var(--_o3-button-primary-inverse-focus-background);
 		border-color: var(--_o3-button-primary-inverse-focus-border);
@@ -118,7 +118,7 @@
 		border-color: var(--_o3-button-primary-mono-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-primary-mono-focus-color);
 		background-color: var(--_o3-button-primary-mono-focus-background);
 		border-color: var(--_o3-button-primary-mono-focus-border);
@@ -144,7 +144,7 @@
 		border-color: var(--_o3-button-secondary-standard-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-secondary-standard-focus-color);
 		background-color: var(--_o3-button-secondary-standard-focus-background);
 		border-color: var(--_o3-button-secondary-standard-focus-border);
@@ -171,7 +171,7 @@
 		border-color: var(--_o3-button-secondary-inverse-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-secondary-inverse-focus-color);
 		background-color: var(--_o3-button-secondary-inverse-focus-background);
 		border-color: var(--_o3-button-secondary-inverse-focus-border);
@@ -198,7 +198,7 @@
 		border-color: var(--_o3-button-secondary-mono-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-secondary-mono-focus-color);
 		background-color: var(--_o3-button-secondary-mono-focus-background);
 		border-color: var(--_o3-button-secondary-mono-focus-border);
@@ -224,7 +224,7 @@
 		border-color: var(--_o3-button-ghost-standard-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-ghost-standard-focus-color);
 		background-color: var(--_o3-button-ghost-standard-focus-background);
 		border-color: var(--_o3-button-ghost-standard-focus-border);
@@ -251,7 +251,7 @@
 		border-color: var(--_o3-button-ghost-inverse-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-ghost-inverse-focus-color);
 		background-color: var(--_o3-button-ghost-inverse-focus-background);
 		border-color: var(--_o3-button-ghost-inverse-focus-border);
@@ -278,7 +278,7 @@
 		border-color: var(--_o3-button-ghost-mono-hover-border);
 	}
 
-	&:focus {
+	&:focus-visible {
 		color: var(--_o3-button-ghost-mono-focus-color);
 		background-color: var(--_o3-button-ghost-mono-focus-background);
 		border-color: var(--_o3-button-ghost-mono-focus-border);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,7 +3012,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "11.0.0",
+			"version": "11.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^9.9.0",
@@ -3864,7 +3864,7 @@
 		},
 		"components/o3-button": {
 			"name": "@financial-times/o3-button",
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3875,7 +3875,7 @@
 		},
 		"components/o3-editorial-typography": {
 			"name": "@financial-times/o3-editorial-typography",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3908,7 +3908,7 @@
 		},
 		"components/o3-typography": {
 			"name": "@financial-times/o3-typography",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"


### PR DESCRIPTION
When a button is clicked (pressed) the focus state is applied until clicking elsewhere. Avoid this by applying focus colours with `:focus-visible`.

I chose not to add a `:focus` fallback as:
- Support for `:focus-visible` is very good now.
- We still have a `:focus` ring.