### PR TITLE
fix: fix assign of options in conjunction with data-atributtes

### DIFF
--- a/components/o-comments/src/js/comments.js
+++ b/components/o-comments/src/js/comments.js
@@ -3,7 +3,7 @@ import Count from './count.js';
 
 class Comments {
 	constructor (rootEl, opts) {
-		this.options = Object.assign({}, {}, opts || Comments.getDataAttributes(rootEl));
+		this.options = Object.assign({}, Comments.getDataAttributes(rootEl) , opts );
 		const isCount = rootEl.getAttribute('data-o-comments-count') === 'true';
 		if (!this.options.articleId) {
 			// eslint-disable-next-line no-console


### PR DESCRIPTION
Fix options initialisation along with data-attributes
We were choosing between options or data-attributes instead of overriding and assigning on top of each other.
So the preference now is options passed programmatically have preference over data-attributes and overrides values got from it but don't remove the values of other options assign by data-attributes

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
