### PR TITLE
feat: add professional-inverse theme to ft-concept-button

### DIFF
--- a/components/ft-concept-button/main.scss
+++ b/components/ft-concept-button/main.scss
@@ -45,7 +45,14 @@ $_ftConceptButtonThemes: (
 		highlight: oColorsByName('black-80'),
 		pressed-highlight: rgba(oColorsByName('black'), 0.2),
 		disabled: rgba(oColorsByName('black'), 0.5)
-	)
+	),
+	professional-inverse: (
+		background: oColorsByName('mint'),
+		text: oColorsByName('black'),
+		highlight: oColorsByName('mint'),
+		pressed-highlight: rgba(oColorsByName('mint'), 0.15),
+		disabled: rgba(oColorsByName('black'), 0.5)
+	),
 );
 
 @function _ftConceptButtonGetThemeColor($key) {
@@ -126,7 +133,7 @@ $_ftConceptButtonThemes: (
 			@include oNormaliseFocusContentForElementColour(
 				_ftConceptButtonGetThemeColor(background)
 			);
-		};
+		}
 
 		background-color: transparent;
 		border: 1px solid _ftConceptButtonGetThemeColor(background);
@@ -182,6 +189,7 @@ $_ftConceptButtonThemes: (
 		'opinion',
 		'inverse',
 		'monochrome',
+		'professional-inverse',
 	)
 ) {
 	.ft-concept-button__link,

--- a/components/ft-concept-button/src/tsx/concept-button.tsx
+++ b/components/ft-concept-button/src/tsx/concept-button.tsx
@@ -6,7 +6,13 @@ export interface ConceptButtonProps {
 	// descriptive label for button
 	ariaLabel?: string;
 	// button theme
-	theme?: 'standard' | 'inverse' | 'opinion' | 'monochrome' | 'inverse-monochrome';
+	theme?:
+		| 'standard'
+		| 'inverse'
+		| 'opinion'
+		| 'monochrome'
+		| 'inverse-monochrome'
+		| 'professional-inverse';
 	// button type
 	type?: 'concept' | 'follow';
 	// whether the button is currently pressed


### PR DESCRIPTION
## Describe your changes
Add FT Professional themes to `ft-concept-button`
## Issue ticket number and link

## Link to Figma designs
https://www.figma.com/design/MyHQ1qdwYyek5IBdhEEaND/%F0%9F%92%A0-FT-UI-Library---Origami-(o2)?node-id=0-915&t=AAqSgW1l8rOOOG7E-0
## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
