### PR TITLE
feat: adjust search bar width according to the designs

### DIFF
--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -39,7 +39,8 @@
 		align-items: center;
 
 		.o-forms-input--text.o-forms-input--suffix {
-			width: 90%;
+			width: 100%;
+			max-width: 640px;
 			margin-top: 10px;
 		}
 	}


### PR DESCRIPTION
## Describe your changes
According to new figma designs we did this PR to change some styles on search bar
https://github.com/Financial-Times/origami/pull/1725
but in final designs the search bar size is a less wide
## Issue ticket number and link
https://financialtimes.atlassian.net/browse/CON-3426
## Link to Figma designs
https://www.figma.com/design/L6qyUFPPLRmf59OxTkz2VJ/Semantic-Search?node-id=1544-97207&m=dev

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
