### PR TITLE
feat: fix search term wide

### DIFF
--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -37,10 +37,11 @@
 		min-width: 50%;
 		flex-grow: 1;
 		align-items: center;
+		max-width: 640px;
+		position: relative;
 
 		.o-forms-input--text.o-forms-input--suffix {
 			width: 100%;
-			max-width: 640px;
 			margin-top: 10px;
 		}
 	}


### PR DESCRIPTION
## Describe your changes
we previously try to fix the search bar wide and we add the max-width to the input instead the form that causes the typeahead size not be the same because is absolute positioned and is looking for the width of the nearest parent so we need to apply to max-width to the correct element
https://github.com/Financial-Times/origami/pull/1740/files

**ScreenShots**
Before:
![image](https://github.com/Financial-Times/origami/assets/98393608/0fda40ab-50d7-4606-af53-a57411d6bad8)

After:
![image](https://github.com/Financial-Times/origami/assets/98393608/da9c2923-ed99-4279-8596-bc7337d37d7b)
