### PR TITLE
fix: fix typos on comments barrier message

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -315,7 +315,7 @@ class Stream {
 				</p>
 			`;
 			const messageForAnonymous = `
-			<h3>Commenting is only available to readers with FT subscription</h3>
+			<h3>Commenting is only available to readers with a FT subscription</h3>
 				<p>
 					Please ${this.options.linkLogin ? ` <a class="linkLogin" href='${this.options.linkLogin}'>login</a>` : `login`} or ${this.options.linkSubscribe ? `<a href='${this.options.linkSubscribe}' class="linkSubscribe" >subscribe</a>` : `subscribe`} to join the conversation.
 				</p>


### PR DESCRIPTION
Fix typos on comments barrier message according to discussion on this [ticket](https://financialtimes.atlassian.net/browse/CI-1493?focusedCommentId=836837)

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
