### PR TITLE
fix: fix typos

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -309,19 +309,19 @@ class Stream {
 			const customMessageContainer = document.createElement("section");
 			customMessageContainer.classList.add('coral__custom-message-content','coral');
 			const messageRegistered = `
-			<h3>Commenting is only available to readers with FT subscription</h3>
+			<h3>Commenting is only available to readers with an FT subscription</h3>
 				<p>
 				${this.options.linkSubscribe ? `<a class="linkSubscribe" href='${this.options.linkSubscribe}'>Subscribe</a>` : `Subscribe`} to join the conversation.
 				</p>
 			`;
 			const messageForAnonymous = `
-			<h3>Commenting is only available to readers with a FT subscription</h3>
+			<h3>Commenting is only available to readers with an FT subscription</h3>
 				<p>
 					Please ${this.options.linkLogin ? ` <a class="linkLogin" href='${this.options.linkLogin}'>login</a>` : `login`} or ${this.options.linkSubscribe ? `<a href='${this.options.linkSubscribe}' class="linkSubscribe" >subscribe</a>` : `subscribe`} to join the conversation.
 				</p>
 			`;
 			const messageForTrial = `
-			<h3>You are still in a trial period</h3>
+			<h3>You are still on a trial period</h3>
 				<p>
 					View our full ${this.options.linkSubscribe ? `<a class="linkSubscribe" href='${this.options.linkSubscribe}'>subscription packages</a>` : `subscription packages` } to join the conversation.
 				</p>


### PR DESCRIPTION
Fix typos according to this [ticket](https://financialtimes.atlassian.net/browse/CI-1493?focusedCommentId=836927)
Sentences to fix:
"Commenting is only available to readers with an FT subscription"

"You are still on a trial period"

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
