### PR TITLE
fix: Make the toggle tip component inline.

### DIFF
--- a/components/o3-tooltip/main.css
+++ b/components/o3-tooltip/main.css
@@ -10,7 +10,7 @@
 
 o3-tooltip-toggle.o3-tooltip {
 	position: relative;
-	display: block;
+	display: inline-flex;
 }
 
 .o3-tooltip > .o3-tooltip-wrapper {
@@ -42,7 +42,8 @@ o3-tooltip-onboarding[no-title] .o3-tooltip-content {
 	margin-right: var(--icon-button-size);
 }
 
-o3-tooltip-onboarding[no-title]  .o3-tooltip-content-title, o3-tooltip-toggle[no-title]  .o3-tooltip-content-title {
+o3-tooltip-onboarding[no-title] .o3-tooltip-content-title,
+o3-tooltip-toggle[no-title] .o3-tooltip-content-title {
 	display: none;
 }
 
@@ -51,7 +52,9 @@ o3-tooltip-onboarding[no-title]  .o3-tooltip-content-title, o3-tooltip-toggle[no
 	font-size: var(--o3-font-size-0);
 	color: inherit;
 	margin-bottom: var(--o3-spacing-4xs);
-	padding-right: calc(var(--padding-right) + var(--o3-spacing-5xs)); /* add extra 4px padding to create space between close button and heading title */
+	padding-right: calc(
+		var(--padding-right) + var(--o3-spacing-5xs)
+	); /* add extra 4px padding to create space between close button and heading title */
 }
 
 /* ARROW STYLES */


### PR DESCRIPTION
This removes excess space below the toggle tip and allows it to be positioned correctly in flow.

It will then be possible to remove these overrides with a couple extra steps for the product. Remove the `div` with the brand attribute, and apply it to an existing parent element. Use the `gap` property and o3 CSS Custom Properties for spacing on the partner content title element:
https://github.com/Financial-Times/next-article/blob/5c2eb8785dfcf7e11341dec1d6d9b5c4395658ae/client/partner-content.scss#L164 

Before: 

![Screenshot 2024-07-26 at 10 54 06](https://github.com/user-attachments/assets/ade24cdf-6d29-47db-b084-b6b63b429d98)

After:

![Screenshot 2024-07-26 at 10 53 50](https://github.com/user-attachments/assets/e415829f-8927-46ad-9cbb-db82d4291ba5)

