### PR TITLE
feat: introduce `o3-grid-column-width` CSS Custom Property

### DIFF
--- a/components/o3-foundation/README.md
+++ b/components/o3-foundation/README.md
@@ -181,6 +181,19 @@ You can precisely control the positioning of grid items using the `grid-column` 
 </div>
 ```
 
+#### Using grid with nested children
+
+In some cases, an element may be nested deeply and not have access to the grid. o3-foundation provides CSS Custom Properties to help align elements to grid in these cases:
+
+```css
+.my-nested-class {
+	--o3-grid-columns-to-span-count: 6;
+	width: var(--o3-grid-columns-to-span-width)
+}
+```
+
+Use `--o3-grid-columns-to-span-count` to control how many columns you want your element to span. In this example, the width of `my-nested-class` will be equivalent to 6 columns. `--o3-grid-columns-to-span-count` must be defined for `.o3-grid-columns-to-span-width` to work.
+
 #### Advanced usage of grid
 
 For advanced usage `o3-foundation` provides CSS Custom Properties for grid that you can set on your class:

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -1,4 +1,5 @@
 :root {
+	--_o3-grid-gutters: calc(var(--o3-grid-columns) - 1);
 	--o3-grid-template: 0px
 		repeat(var(--o3-grid-columns), 1fr) 0px;
 	--o3-grid-area: 'bleed-left content-start . . content-end bleed-right';
@@ -10,6 +11,7 @@
 			repeat(var(--o3-grid-columns), 1fr) 8px;
 		--o3-grid-area: 'bleed-left content-start . . . . . . content-end bleed-right';
 		--o3-grid-columns: 8;
+		--o3-grid-column-width: calc((740px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 	}
 
 	@media screen and (min-width: 980px) {
@@ -18,12 +20,14 @@
 		--o3-grid-area: 'bleed-left content-start . . . . . . . . . . content-end bleed-right';
 		--o3-grid-columns: 12;
 		--o3-grid-gap: 24px;
+		--o3-grid-column-width: calc((980px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 	}
 
 	@media screen and (min-width: 1268px) {
-		--column-width: calc((1220px - 11 * var(--o3-grid-gap)) / 12);
+		--o3-grid-columns: 12;
 		--o3-grid-template: 1fr
-			repeat(var(--o3-grid-columns), var(--column-width)) 1fr;
+			repeat(var(--o3-grid-columns), var(--o3-grid-column-width)) 1fr;
+		--o3-grid-column-width: calc((1220px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 	}
 }
 

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -6,7 +6,7 @@
 	--o3-grid-columns: 4;
 	--o3-grid-gap: 16px;
 	--_o3-grid-column-width: calc((100vw - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
-	--o3-grid-span-columns: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-span-columns-count)) - var(--o3-grid-gap));
+	--o3-grid-columns-to-span-width: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-columns-to-span-count)) - var(--o3-grid-gap));
 
 	@media screen and (min-width: 740px) {
 		--o3-grid-template: 8px

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -32,7 +32,7 @@
 }
 
 .o3-grid * {
-	--o3-grid-columns-to-span-width: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-span-columns-count)) - var(--o3-grid-gap));
+	--o3-grid-columns-to-span-width: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-columns-to-span-count)) - var(--o3-grid-gap));
 }
 
 .o3-grid {

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -5,7 +5,8 @@
 	--o3-grid-area: 'bleed-left content-start . . content-end bleed-right';
 	--o3-grid-columns: 4;
 	--o3-grid-gap: 16px;
-	--o3-grid-column-width: calc((100vw - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
+	--_o3-grid-column-width: calc((100vw - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
+	--o3-grid-span-columns: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-span-columns-count)) - var(--o3-grid-gap));
 
 	@media screen and (min-width: 740px) {
 		--o3-grid-template: 8px

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -5,13 +5,14 @@
 	--o3-grid-area: 'bleed-left content-start . . content-end bleed-right';
 	--o3-grid-columns: 4;
 	--o3-grid-gap: 16px;
+	--o3-grid-column-width: calc((100vw - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 
 	@media screen and (min-width: 740px) {
 		--o3-grid-template: 8px
 			repeat(var(--o3-grid-columns), 1fr) 8px;
 		--o3-grid-area: 'bleed-left content-start . . . . . . content-end bleed-right';
 		--o3-grid-columns: 8;
-		--o3-grid-column-width: calc((740px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
+
 	}
 
 	@media screen and (min-width: 980px) {
@@ -20,7 +21,6 @@
 		--o3-grid-area: 'bleed-left content-start . . . . . . . . . . content-end bleed-right';
 		--o3-grid-columns: 12;
 		--o3-grid-gap: 24px;
-		--o3-grid-column-width: calc((980px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 	}
 
 	@media screen and (min-width: 1268px) {

--- a/components/o3-foundation/grid.css
+++ b/components/o3-foundation/grid.css
@@ -6,7 +6,6 @@
 	--o3-grid-columns: 4;
 	--o3-grid-gap: 16px;
 	--_o3-grid-column-width: calc((100vw - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
-	--o3-grid-columns-to-span-width: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-columns-to-span-count)) - var(--o3-grid-gap));
 
 	@media screen and (min-width: 740px) {
 		--o3-grid-template: 8px
@@ -30,6 +29,10 @@
 			repeat(var(--o3-grid-columns), var(--o3-grid-column-width)) 1fr;
 		--o3-grid-column-width: calc((1220px - var(--_o3-grid-gutters) * var(--o3-grid-gap)) / var(--o3-grid-columns));
 	}
+}
+
+.o3-grid * {
+	--o3-grid-columns-to-span-width: calc(((var(--_o3-grid-column-width) + var(--o3-grid-gap)) * var(--o3-grid-span-columns-count)) - var(--o3-grid-gap));
 }
 
 .o3-grid {

--- a/components/o3-foundation/stories/grid-sb-styles.css
+++ b/components/o3-foundation/stories/grid-sb-styles.css
@@ -7,9 +7,3 @@
 	background-color: tomato;
 	cursor: pointer;
 }
-
-.nested-element {
-	--o3-grid-columns-to-span-count: 2;
-	width: var(--o3-grid-columns-to-span-width);
-	background-color: green;
-}

--- a/components/o3-foundation/stories/grid-sb-styles.css
+++ b/components/o3-foundation/stories/grid-sb-styles.css
@@ -7,3 +7,9 @@
 	background-color: tomato;
 	cursor: pointer;
 }
+
+.nested-element {
+	--o3-grid-columns-to-span-count: 2;
+	width: var(--o3-grid-columns-to-span-width);
+	background-color: green;
+}

--- a/components/o3-foundation/stories/grid.tsx
+++ b/components/o3-foundation/stories/grid.tsx
@@ -74,6 +74,10 @@ export function O3Grid() {
 					{item.text}
 				</div>
 			))}
+			<div style={{gridColumn: `content-start / span 6`, backgroundColor: 'tomato'}}>
+				Span 6
+				<div className='nested-element'>Nested Element</div>
+			</div>
 		</div>
 	);
 }

--- a/components/o3-foundation/stories/grid.tsx
+++ b/components/o3-foundation/stories/grid.tsx
@@ -74,9 +74,12 @@ export function O3Grid() {
 					{item.text}
 				</div>
 			))}
-			<div style={{gridColumn: `content-start / span 6`, backgroundColor: 'tomato'}}>
+			<div className="o3-grid-item" style={{gridColumn: `content-start / span 6`, backgroundColor: 'tomato'}}>
 				Span 6
-				<div className='nested-element'>Nested Element</div>
+				<div style={{'--o3-grid-columns-to-span-count': 2,
+					width: 'var(--o3-grid-columns-to-span-width)',
+					backgroundColor: 'lightblue'
+				}}>Nested Element span 2</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Describe your changes

Some components outside of grids may use grid dimensions. For example, form elements may use `max-width` constrained by a number of columns in grid, without being part of one.

This PR adds CSS custom properties at each breakpoint to give components outside of a grid some values to work with.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
