### PR TITLE
Add Ask FT button to o-header

### DIFF
--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -2,6 +2,8 @@
 
 ## Migrating from v13 to v14
 
+### Search bar
+
 `o-header v14` includes important markup changes to the search bar. Please review the changelog carefully:
 
 1. **Search Input Field Updates**:
@@ -86,6 +88,15 @@
   +   placeholder="Search for stories, topics, or securities"
   + />
   ```
+
+### Ask FT button
+
+`o-header v14` adds optional Ask FT button markup in the following places:
+  - top left menu of the header (o-header/src/tsx/drawer.tsx)
+  - top left menu of the sticky (o-header/src/tsx/sticky.tsx)
+  - as the top, under the search in the drawer menu (o-header/src/tsx/drawer.tsx)
+
+Update your markup according to the [Storybook demo](https://o2-core.origami.ft.com/?path=/story/components-o-header--header-primary&globals=backgrounds:!undefined) or [use o-header's tsx template](https://github.com/Financial-Times/origami/tree/main/components/o-header/src/tsx) with `showAskButton=true` if you need to include Ask FT button.
 
 ## Migrating from v12 to v13
 

--- a/components/o-header/src/scss/_brand.scss
+++ b/components/o-header/src/scss/_brand.scss
@@ -17,6 +17,9 @@
 			header-border: oColorsByName('black-20'),
 			header-background: oColorsByName('paper'),
 			header-icon: oColorsByName('black-80'),
+			header-button-text: oColorsByName('black-80'),
+			header-button-icon: oColorsByName('black-80'),
+			header-button-background: oColorsByName('black-5'),
 			link-hover-text: oColorsByName('black-80'),
 			link-highlight-text: oColorsByName('teal-40'),
 

--- a/components/o-header/src/scss/_brand.scss
+++ b/components/o-header/src/scss/_brand.scss
@@ -17,9 +17,9 @@
 			header-border: oColorsByName('black-20'),
 			header-background: oColorsByName('paper'),
 			header-icon: oColorsByName('black-80'),
-			header-button-text: oColorsByName('black-80'),
-			header-button-icon: oColorsByName('black-80'),
-			header-button-background: oColorsByName('black-5'),
+			header-ask-ft-button-text: oColorsByName('black-80'),
+			header-ask-ft-button-icon: oColorsByName('black-80'),
+			header-ask-ft-button-background: oColorsByName('black-5'),
 			link-hover-text: oColorsByName('black-80'),
 			link-highlight-text: oColorsByName('teal-40'),
 

--- a/components/o-header/src/scss/_mixins.scss
+++ b/components/o-header/src/scss/_mixins.scss
@@ -106,26 +106,27 @@
 	// sass-lint:enable no-vendor-prefixes
 }
 
+/// Base styles for Ask FT button
 @mixin _oHeaderAskFtButton() {
+	@include oTypographySans(-1, $weight: 'semibold');
 	display: flex;
 	align-items: center;
 	gap: 4px;
 	padding: 6px 8px;
 	color: _oHeaderGet('header-button-text');
 	background-color: _oHeaderGet('header-button-background');
-	@include oTypographySans(-1, $weight: 'semibold');
 	border-radius: 4px;
 	text-transform: uppercase;
 	text-decoration: none;
 	white-space: nowrap;
 
 	&::before {
-		content: '';
 		@include oIconsContent(
 			$icon-name: 'sparkles',
 			$color: _oHeaderGet('header-button-icon'),
 			$size: 40,
 		);
+		content: '';
 		margin: -10px; // Undo in-built icon whitespace.
 	}
 }

--- a/components/o-header/src/scss/_mixins.scss
+++ b/components/o-header/src/scss/_mixins.scss
@@ -113,8 +113,8 @@
 	align-items: center;
 	gap: 4px;
 	padding: 6px 8px;
-	color: _oHeaderGet('header-button-text');
-	background-color: _oHeaderGet('header-button-background');
+	color: _oHeaderGet('header-ask-ft-button-text');
+	background-color: _oHeaderGet('header-ask-ft-button-background');
 	border-radius: 4px;
 	text-transform: uppercase;
 	text-decoration: none;
@@ -123,7 +123,7 @@
 	&::before {
 		@include oIconsContent(
 			$icon-name: 'sparkles',
-			$color: _oHeaderGet('header-button-icon'),
+			$color: _oHeaderGet('header-ask-ft-button-icon'),
 			$size: 40,
 		);
 		content: '';

--- a/components/o-header/src/scss/_mixins.scss
+++ b/components/o-header/src/scss/_mixins.scss
@@ -105,3 +105,27 @@
 	}
 	// sass-lint:enable no-vendor-prefixes
 }
+
+@mixin _oHeaderAskFtButton() {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 6px 8px;
+	color: _oHeaderGet('header-button-text');
+	background-color: _oHeaderGet('header-button-background');
+	@include oTypographySans(-1, $weight: 'semibold');
+	border-radius: 4px;
+	text-transform: uppercase;
+	text-decoration: none;
+	white-space: nowrap;
+
+	&::before {
+		content: '';
+		@include oIconsContent(
+			$icon-name: 'sparkles',
+			$color: _oHeaderGet('header-button-icon'),
+			$size: 40,
+		);
+		margin: -10px; // Undo in-built icon whitespace.
+	}
+}

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -375,4 +375,14 @@
 		margin-top: 0.25em;
 		font-size: 14px;
 	}
+
+	.o-header__ask-ft-button--drawer {
+		@include _oHeaderAskFtButton();
+		margin: $_o-header-drawer-padding-y $_o-header-drawer-padding-x 0 $_o-header-drawer-padding-x;
+		justify-content: center;
+	}
+
+	.o-header__ask-ft-button--drawer + .o-header__drawer-menu {
+		margin-top: $_o-header-drawer-padding-y
+	}
 }

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -380,7 +380,7 @@
 		@include _oHeaderAskFtButton();
 
 		// Same as .o-header__drawer-search
-		@include oGridRespondTo('oHeaderL') {
+		@include oGridRespondTo('M') {
 			display: none;
 		}
 

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -378,6 +378,12 @@
 
 	.o-header__ask-ft-button--drawer {
 		@include _oHeaderAskFtButton();
+
+		// Same as .o-header__drawer-search
+		@include oGridRespondTo('oHeaderL') {
+			display: none;
+		}
+
 		margin: $_o-header-drawer-padding-y $_o-header-drawer-padding-x 0 $_o-header-drawer-padding-x;
 		justify-content: center;
 	}

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -197,10 +197,10 @@
 	}
 
 	.o-header__ask-ft-button--top {
-		margin: 0 10px;
+		@include _oHeaderAskFtButton();
 		@include oGridRespondTo($until: 'L') {
 			display: none;
 		}
-		@include _oHeaderAskFtButton();
+		margin: 0 10px;
 	}
 }

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -196,4 +196,11 @@
 		}
 	}
 
+	.o-header__ask-ft-button--top {
+		margin-left: 12px;
+		@include oGridRespondTo($until: 'L') {
+			display: none;
+		}
+		@include _oHeaderAskFtButton();
+	}
 }

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -198,7 +198,7 @@
 
 	.o-header__ask-ft-button--top {
 		@include _oHeaderAskFtButton();
-		@include oGridRespondTo($until: 'L') {
+		@include oGridRespondTo($until: 'M') {
 			display: none;
 		}
 		margin: 0 10px;

--- a/components/o-header/src/scss/features/_top.scss
+++ b/components/o-header/src/scss/features/_top.scss
@@ -197,7 +197,7 @@
 	}
 
 	.o-header__ask-ft-button--top {
-		margin-left: 12px;
+		margin: 0 10px;
 		@include oGridRespondTo($until: 'L') {
 			display: none;
 		}

--- a/components/o-header/src/tsx/Props.ts
+++ b/components/o-header/src/tsx/Props.ts
@@ -51,6 +51,7 @@ export type THeaderOptions = {
 	showMegaNav?: boolean;
 	showLogoLink?: boolean;
 	extraHeaderProps?: any;
+  	showAskButton?: boolean;
 };
 
 export type THeaderVariant = 'simple' | 'large-logo' | string;

--- a/components/o-header/src/tsx/components/ask-ft-button.tsx
+++ b/components/o-header/src/tsx/components/ask-ft-button.tsx
@@ -1,6 +1,6 @@
 export interface AskFtButtonProps {
 	id: string
-	variant: 'top'
+	variant: 'top' | 'drawer'
 	dataTrackable: string
 }
 

--- a/components/o-header/src/tsx/components/ask-ft-button.tsx
+++ b/components/o-header/src/tsx/components/ask-ft-button.tsx
@@ -1,0 +1,17 @@
+export interface AskFtButtonProps {
+	id: string
+	variant: 'top'
+	dataTrackable: string
+}
+
+export const AskFtButton = ({ id, variant, dataTrackable }: AskFtButtonProps) => (
+	<a
+		id={id}
+		className={`o-header__ask-ft-button o-header__ask-ft-button--${variant}`}
+		data-trackable={dataTrackable}
+		href="https://ask.ft.com"
+		title="ASK FT"
+	>
+		Ask FT
+	</a>
+)

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -1,6 +1,7 @@
+import { AskFtButton } from './components/ask-ft-button';
 import {TNavEdition, TNavAction, TNavMenuItem, THeaderProps} from './Props';
 
-export function Drawer({data, userIsLoggedIn, userIsSubscribed}: THeaderProps) {
+export function Drawer({data, showAskButton, userIsLoggedIn, userIsSubscribed }: THeaderProps) {
 	const editions = data.editions;
 	const subscribeAction = data.subscribeAction;
 	const navItems = data.drawer.items;
@@ -20,6 +21,13 @@ export function Drawer({data, userIsLoggedIn, userIsSubscribed}: THeaderProps) {
 					otherEditions={editions.others}
 				/>
 				<DrawerSearch />
+				{showAskButton && 
+					<AskFtButton
+						variant="drawer"
+						dataTrackable="ask-ft-button-drawer"
+						id="ask-ft-button-drawer"
+					/>
+				}
 				{!userIsSubscribed && subscribeAction && (
 					<DrawerAction action={subscribeAction} />
 				)}

--- a/components/o-header/src/tsx/header-default.tsx
+++ b/components/o-header/src/tsx/header-default.tsx
@@ -16,6 +16,7 @@ export function Header({
 	showUserNavigation,
 	userIsSubscribed,
 	userIsLoggedIn,
+	showAskButton,
 	variant,
 	data,
 }: THeaderProps) {
@@ -35,7 +36,7 @@ export function Header({
 		<>
 			{showUserNavigation && <UserActionsNav userNavItems={userNavItems} />}
 			<TopWrapper>
-				<TopColumnLeft />
+				<TopColumnLeft showAskButton={showAskButton} />
 				<TopColumnCenter showLogoLink={showLogoLink} />
 				<TopColumnRight
 					userIsLoggedIn={userIsLoggedIn}

--- a/components/o-header/src/tsx/header.tsx
+++ b/components/o-header/src/tsx/header.tsx
@@ -10,6 +10,7 @@ import {InverseSimpleHeader} from './inverse-header';
 export function MainHeader(props: THeaderProps) {
 	const {
 		data,
+		showAskButton,
 		showLogoLink,
 		showMegaNav,
 		showStickyHeader,
@@ -27,6 +28,7 @@ export function MainHeader(props: THeaderProps) {
 	const defaultHeaderProps = {
 		includeUserActionsNav,
 		includeSubNavigation,
+		showAskButton,
 		showLogoLink,
 		showSubNavigation,
 		showUserNavigation,

--- a/components/o-header/src/tsx/header.tsx
+++ b/components/o-header/src/tsx/header.tsx
@@ -41,6 +41,7 @@ export function MainHeader(props: THeaderProps) {
 
 	const stickyHeaderProps = {
 		userIsLoggedIn,
+		showAskButton,
 		showUserNavigation,
 		userIsSubscribed,
 		includeUserActionsNav,

--- a/components/o-header/src/tsx/sticky.tsx
+++ b/components/o-header/src/tsx/sticky.tsx
@@ -11,6 +11,7 @@ export function StickyHeader({
 	userIsLoggedIn,
 	showUserNavigation,
 	userIsSubscribed,
+	showAskButton,
 	data,
 }: THeaderProps) {
 	const userNavData = userIsLoggedIn
@@ -26,7 +27,7 @@ export function StickyHeader({
 			aria-hidden="true"
 			role="presentation">
 			<TopWrapper>
-				<TopColumnLeft isSticky={true} />
+				<TopColumnLeft isSticky={true} showAskButton={showAskButton} />
 				<StickyTopColumnCenter navBarItems={navBarItems} />
 				<TopColumnRight
 					variant="sticky"

--- a/components/o-header/src/tsx/top.tsx
+++ b/components/o-header/src/tsx/top.tsx
@@ -1,4 +1,5 @@
-import { TNavMenuItem, THeaderVariant } from "./Props";
+import { AskFtButton } from "./components/ask-ft-button";
+import { THeaderVariant, TNavMenuItem } from "./Props";
 
 export function HeaderWrapper({
 	variant,
@@ -37,7 +38,7 @@ export const TopWrapper = ({
 	</div>
 );
 
-export function TopColumnLeft({ isSticky }: { isSticky?: boolean }) {
+export function TopColumnLeft({ isSticky, showAskButton }: { isSticky?: boolean, showAskButton?: boolean }) {
 	const drawerLabel = isSticky ? "Menu" : "Open side navigation menu";
 	const searchProps = {
 		href: isSticky ? "#o-header-search-sticky" : "#o-header-search",
@@ -62,6 +63,13 @@ export function TopColumnLeft({ isSticky }: { isSticky?: boolean }) {
 			>
 				<span className="o-header__top-link-label">Open search bar</span>
 			</a>
+			{showAskButton && 
+				<AskFtButton
+					variant="top"
+					dataTrackable="ask-ft-button-header"
+					id="ask-ft-button-header"
+				/>
+			}
 		</div>
 	);
 }

--- a/components/o-header/src/tsx/top.tsx
+++ b/components/o-header/src/tsx/top.tsx
@@ -66,8 +66,8 @@ export function TopColumnLeft({ isSticky, showAskButton }: { isSticky?: boolean,
 			{showAskButton && 
 				<AskFtButton
 					variant="top"
-					dataTrackable="ask-ft-button-header"
-					id="ask-ft-button-header"
+					dataTrackable={isSticky ? "ask-ft-button-sticky" : "ask-ft-button-header"}
+					id={isSticky ? "ask-ft-button-sticky" : "ask-ft-button-header"}
 				/>
 			}
 		</div>

--- a/components/o-header/stories/arg-types.ts
+++ b/components/o-header/stories/arg-types.ts
@@ -70,6 +70,13 @@ export const argTypes = {
 			defaultValue: {summary: 'true'},
 		},
 	},
+	showAskButton: {
+		description:
+			'Show Ask FT button',
+		table: {
+			defaultValue: {summary: 'true'},
+		},
+	},
 	data: {
 		description:
 			'Navigation data for rendering the header links fetched from the navigation API',

--- a/components/o-header/stories/header.stories.tsx
+++ b/components/o-header/stories/header.stories.tsx
@@ -31,6 +31,7 @@ export const HeaderPrimary: ComponentStory<typeof MainHeader> = args => {
 			<MainHeader {...args} />
 			<Drawer
 				data={args.data}
+				showAskButton={args.showAskButton}
 				userIsLoggedIn={args.userIsLoggedIn}
 				userIsSubscribed={args.userIsSubscribed}
 			/>
@@ -68,6 +69,7 @@ export const DefaultHeaderWithRightAlignedSubnav: ComponentStory<
 			<MainHeader {...args} />;
 			<Drawer
 				data={args.data}
+				showAskButton={args.showAskButton}
 				userIsLoggedIn={args.userIsLoggedIn}
 				userIsSubscribed={args.userIsSubscribed}
 			/>
@@ -119,6 +121,7 @@ LogoOnlyHeader.parameters = {
 			"data",
 			"currentPath",
 			"userIsLoggedIn",
+			"showAskButton",
 			"showSubNavigation",
 			"showUserNavigation",
 			"showMegaNav",
@@ -153,6 +156,7 @@ NoOutboundLinks.parameters = {
 			"data",
 			"currentPath",
 			"variant",
+			"showAskButton",
 			"showMegaNav",
 			"userIsSubscribed",
 			"showStickyHeader",
@@ -182,6 +186,7 @@ InverseSimpleHeader.parameters = {
 			"data",
 			"currentPath",
 			"variant",
+			"showAskButton",
 			"showMegaNav",
 			"showSubNavigation",
 			"showLogoLink",

--- a/components/o-header/stories/header.stories.tsx
+++ b/components/o-header/stories/header.stories.tsx
@@ -51,6 +51,7 @@ HeaderPrimary.args = {
 	userIsSubscribed: false,
 	showLogoLink: true,
 	showStickyHeader: true,
+	showAskButton: true,
 };
 HeaderPrimary.parameters = {
 	controls: {
@@ -82,6 +83,7 @@ DefaultHeaderWithRightAlignedSubnav.args = {
 	showUserNavigation: true,
 	userIsLoggedIn: true,
 	showLogoLink: false,
+	showAskButton: true,
 };
 DefaultHeaderWithRightAlignedSubnav.parameters = {
 	controls: {


### PR DESCRIPTION
## Describe your changes

- Add ASK FT button linking to `https://ask.ft.com/` in `o-header`:
  - Top header - visible on screen size L and up
  - Drawer - visible on smaller screens, same as search in the drawer
  - Sticky header - visible on screen size L and up
- Add new optional `showAskButton` prop in `THeaderOptions` to control ASK FT button rendering. By default, the button is not rendered
- Add `showAskButton` prop in `o-header` stories

Ask FT button was previously added in `dotcom-ui-header` and it is currently active on ft.com home and article pages. This PR adds the same in `o-header` and will be followed with `dotcom-ui-header` changed to align with `o-header`. For reference - this is the PR in `dotcom-ui-header` which has added the button there - https://github.com/Financial-Times/dotcom-page-kit/pull/1031

Please review the PR inline comments. I need confirmation if specific approaches taken are fine or adjustments are needed.

## Issue ticket number and link
Ticket: https://financialtimes.atlassian.net/browse/ARP-251

## Link to Figma designs
https://www.figma.com/design/G0vA3biIFmIeXa0bB3bqWW/ARP%3A-Ask-FT?node-id=6579-37992&t=MyjE38aot5OS5vmH-4

### Storybook screenshots
#### Top
![image](https://github.com/user-attachments/assets/aa096296-f221-45b2-88db-0b607c106e72)

#### Sticky
![image](https://github.com/user-attachments/assets/a0ed6dd8-1a0c-4388-afe1-f64bb166f93f)

#### Drawer mobile
![image](https://github.com/user-attachments/assets/6a0e136a-504b-4db7-972e-c9c70a7fb0eb)

## Checklist before requesting a review
- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
