### PR TITLE
[CON-3534] Hide sticky header container

### DIFF
--- a/components/o-header/src/js/sticky.js
+++ b/components/o-header/src/js/sticky.js
@@ -5,6 +5,14 @@ function init (headerEl) {
 		return;
 	}
 
+	function hideStickyHeaderContainer ({stickyHeaderContainer, searchIcon, isActive, isHeaderExpanded}) {
+		if (!isActive && isHeaderExpanded) {
+			stickyHeaderContainer?.setAttribute('aria-hidden', !isActive);
+			stickyHeaderContainer.classList.remove('o-toggle--active')
+			searchIcon?.setAttribute('aria-expanded', isActive);
+		}
+	}
+
 	let viewportOffset;
 	let lastScrollDepth;
 	let lastAnimationFrame;
@@ -13,8 +21,12 @@ function init (headerEl) {
 	function handleFrame () {
 		// sticky el will appear when scrolled down from page top to
 		// (arbitrarily) > half the viewport height
+		const stickyHeaderId = '#o-header-search-sticky';
 		const scrollDepth = window.pageYOffset || window.scrollY;
 		const isActive = scrollDepth > viewportOffset;
+		const stickyHeaderContainer = headerEl.querySelector(stickyHeaderId);
+		const searchIcon = headerEl.querySelector(`[aria-controls="${stickyHeaderId.slice(1)}"]`)
+		const isHeaderExpanded = stickyHeaderContainer.getAttribute('aria-hidden');
 
 		headerEl.classList.toggle('o-header--sticky-active', isActive);
 
@@ -28,6 +40,7 @@ function init (headerEl) {
 			const isScrollingDown = lastScrollDepth < scrollDepth;
 			headerEl.classList.toggle('o-header--sticky-scroll-down', isActive && isScrollingDown);
 			headerEl.classList.toggle('o-header--sticky-scroll-up', isActive && !isScrollingDown);
+			hideStickyHeaderContainer({ stickyHeaderContainer, searchIcon, isActive, isHeaderExpanded });
 		}
 
 		lastScrollDepth = scrollDepth;

--- a/components/o-header/src/scss/_variables.scss
+++ b/components/o-header/src/scss/_variables.scss
@@ -8,7 +8,7 @@ $_o-header-buttons-theme: 'mono';
 $_o-header-mega-padding-x: 24px;
 $_o-header-mega-padding-y: 18px;
 $_o-header-mega-z-index: 1;
-$_o-header-z-index: 1;
+$_o-header-z-index: 10;
 $_o-header-drawer-z-index: 100;
 $_o-header-drawer-width: 320px;
 $_o-header-drawer-divide-height: 40px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3238,7 +3238,7 @@
 		},
 		"components/o-header": {
 			"name": "@financial-times/o-header",
-			"version": "13.0.3",
+			"version": "14.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.2.0",
@@ -3624,7 +3624,7 @@
 		},
 		"components/o-table": {
 			"name": "@financial-times/o-table",
-			"version": "9.3.4",
+			"version": "9.3.5",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^5.0.0"
@@ -3867,7 +3867,7 @@
 		},
 		"components/o3-button": {
 			"name": "@financial-times/o3-button",
-			"version": "1.1.5",
+			"version": "1.1.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"
@@ -3881,7 +3881,7 @@
 		},
 		"components/o3-editorial-typography": {
 			"name": "@financial-times/o3-editorial-typography",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"
@@ -3895,7 +3895,7 @@
 		},
 		"components/o3-form": {
 			"name": "@financial-times/o3-form",
-			"version": "0.0.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3908,7 +3908,7 @@
 		},
 		"components/o3-foundation": {
 			"name": "@financial-times/o3-foundation",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3916,7 +3916,7 @@
 		},
 		"components/o3-tooltip": {
 			"name": "@financial-times/o3-tooltip",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.8"
@@ -3933,7 +3933,7 @@
 		},
 		"components/o3-typography": {
 			"name": "@financial-times/o3-typography",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"


### PR DESCRIPTION
## Describe your changes
* We need to increase `z-index` of `o-header` to prevent collisions with content underneath it. Reported [here](https://financialtimes.slack.com/archives/C02FU5ARJ/p1724404615542639)
* When sticky header is hidden we nned to make sure the search container is no longer visible. Reported [here](https://financialtimes.slack.com/archives/C02FU5ARJ/p1724405613898839?thread_ts=1724404615.542639&cid=C02FU5ARJ)
## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?selectedIssue=CON-3534