### PR TITLE
fix: Remove prefers-reduced-motion from normalise.css

### DIFF
--- a/components/o3-foundation/normalise.css
+++ b/components/o3-foundation/normalise.css
@@ -10,17 +10,6 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* Reduce motion */
-@media (prefers-reduced-motion: reduce) {
-	*,
-	*:before,
-	*:after {
-		animation-duration: 0.001s !important; /* stylelint-disable-line declaration-no-important */
-		transition-duration: 0.001s !important; /* stylelint-disable-line declaration-no-important */
-		animation-iteration-count: 1 !important; /* stylelint-disable-line declaration-no-important */
-	}
-}
-
 /* add normalising to links */
 a:active,
 a:hover {


### PR DESCRIPTION
The `prefers-reduced-motion` setting is binary and does not give users much control or choice. Preferring reduced motion does not mean the user wants no animation or transition at all. It should be used on a case by case basis. For example to stop the largest and most potentially problematic cases (e.g. parallax). By defaulting to to no animation or transition with `!important` we make it difficult to undo.

```css
/* Reduce motion */
@media (prefers-reduced-motion: reduce) {
	*,
	*:before,
	*:after {
		animation-duration: 0.001s !important; /* stylelint-disable-line declaration-no-important */
		transition-duration: 0.001s !important; /* stylelint-disable-line declaration-no-important */
		animation-iteration-count: 1 !important; /* stylelint-disable-line declaration-no-important */
	}
}
```

https://css-tricks.com/nuking-motion-with-prefers-reduced-motion/
