### PR TITLE
fix: align text input max width to 4 columns

### DIFF
--- a/components/o3-form/src/css/components/text-input.css
+++ b/components/o3-form/src/css/components/text-input.css
@@ -1,10 +1,13 @@
+@import "@financial-times/o3-foundation/grid.css";
 
 .o3-form-text-input {
 	border: var(--_o3-form-text-input-border);
 	padding: var(--o3-spacing-3xs) var(--o3-spacing-2xs);
 	background-color: var(--_o3-form-text-input-background-color);
 	border-radius: var(--_o3-form-text-input-border-radius);
-	max-width: var(--_o3-form-text-input-max-width);
+
+	--o3-grid-columns-to-span-count: 4;
+	max-width: var(--_o3-form-text-input-max-width, var(--o3-grid-columns-to-span-width));
 }
 
 .o3-form-text-input--short-2 {

--- a/components/o3-form/stories/whitelabel/textInput.stories.tsx
+++ b/components/o3-form/stories/whitelabel/textInput.stories.tsx
@@ -9,8 +9,10 @@ const meta: Meta<typeof TextInputTsx> = {
 	component: TextInputTsx,
 	decorators: [
 		Story => (
-			<div data-o3-brand="whitelabel">
-				<Story />
+			<div data-o3-brand="whitelabel" className="o3-grid">
+				<div style={{gridColumn: `content-start / content-end`}}>
+					<Story />
+				</div>
 			</div>
 		),
 	],
@@ -54,33 +56,33 @@ export const TextInputErrorState = {
 		return (
 			<TextInputTsx label={args.label} disabled={args.disabled} description={args.description} length={args.length}
 										feedback={args.feedback}
-										 />);
+			/>);
 	},
 };
 
 export const ShortTextInput = (args) => {
-		return (
-			<>
-				<TextInputTsx label="Day" description="Two digit day of the month" feedback={args.feedback} length={2}
-				/>
-				<TextInputTsx label="Security code"
-											description="3 digit security code as printed on the back of your credit card."
-											feedback={args.feedback} length={3} />
-				<TextInputTsx label="Date of Bith" description="The year you were born" feedback={args.feedback} length={4}
-				/>
-				<TextInputTsx label="Passcode" description="A 5-digin code to authenticate you on login"
-											feedback={args.feedback} length={5} />
-			</>
-		);
+	return (
+		<>
+			<TextInputTsx label="Day" description="Two digit day of the month" feedback={args.feedback} length={2}
+			/>
+			<TextInputTsx label="Security code"
+										description="3 digit security code as printed on the back of your credit card."
+										feedback={args.feedback} length={3} />
+			<TextInputTsx label="Date of Bith" description="The year you were born" feedback={args.feedback} length={4}
+			/>
+			<TextInputTsx label="Passcode" description="A 5-digin code to authenticate you on login"
+										feedback={args.feedback} length={5} />
+		</>
+	);
 };
 ShortTextInput.parameters = {
 	controls: {
-		disable: true
+		disable: true,
 	},
 	design: {
 		type: 'figma',
 		url: links['whitelabel-o3-form--text-input'].figma,
 	},
-}
+};
 
 export default meta;


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
