### PR TITLE
[CON-3537] o-header tweaks

### DIFF
--- a/components/o-header/src/scss/_base.scss
+++ b/components/o-header/src/scss/_base.scss
@@ -1,5 +1,6 @@
 @mixin _oHeaderBase() {
 	.o-header {
+		position: relative;
 		color: _oHeaderGet('header-text');
 		background-color: _oHeaderGet('header-background');
 	}
@@ -7,7 +8,6 @@
 	.o-header__row {
 		border-bottom: 1px solid _oHeaderGet('header-border');
 	}
-
 
 	.o-header__container {
 		@include oGridContainer();

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -63,6 +63,8 @@
 				background-clip: content-box;
 				border: 4px solid transparent;
 			}
+      
+			overscroll-behavior: none;
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes
| Before | After |
|--------|-------|
| https://github.com/user-attachments/assets/328ff53b-c11b-4ca4-8486-3eb240358af7 | https://github.com/user-attachments/assets/a58eafac-a2d9-4057-8ef6-4139a2c70ab1 |

More about [over-scrolling](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior)
### Note
Just a note on this, on mobile it will have a bigger effect and it will disable bouncing scroll behaviour, which I think is an improvement. Mobile drawer should be more constrained.

> In some cases, these behaviors are not desirable. You can use overscroll-behavior to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.


## Demo of MYFT page and my local typeahead project

https://github.com/user-attachments/assets/232476d8-4172-467c-a5c1-1a8e19564269


## Issue ticket number and link

The overscrolling issue is also described [here](https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?selectedIssue=CON-3537)


## Link to Figma designs


## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
