### PR TITLE
fix: align padding in drawer

### DIFF
--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -63,7 +63,6 @@
 				background-clip: content-box;
 				border: 4px solid transparent;
 			}
-
 			overscroll-behavior: none;
 		}
 	}

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -63,6 +63,7 @@
 				background-clip: content-box;
 				border: 4px solid transparent;
 			}
+
 			overscroll-behavior: none;
 		}
 	}

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -387,7 +387,7 @@
 			display: none;
 		}
 
-		margin: $_o-header-drawer-padding-y $_o-header-drawer-padding-x 0 $_o-header-drawer-padding-x;
+		margin: 0 $_o-header-drawer-padding-x 0 $_o-header-drawer-padding-x;
 		justify-content: center;
 	}
 

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -387,7 +387,6 @@
 			display: none;
 		}
 
-		margin: 0 $_o-header-drawer-padding-x 0 $_o-header-drawer-padding-x;
 		justify-content: center;
 	}
 

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -63,7 +63,7 @@
 				background-clip: content-box;
 				border: 4px solid transparent;
 			}
-      
+
 			overscroll-behavior: none;
 		}
 	}
@@ -92,6 +92,7 @@
 			.o-header__drawer-menu-link {
 				padding-left: 12px;
 				text-decoration: underline;
+				text-decoration-color: oColorsByName('black-80');
 			}
 
 			.o-header__drawer-current-edition {
@@ -129,7 +130,7 @@
 	// Actions
 	//
 	.o-header__drawer-actions {
-		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
+		padding: 0 $_o-header-drawer-padding-x calc($_o-header-drawer-padding-y + 4px) $_o-header-drawer-padding-x;
 	}
 
 	.o-header__drawer-button {
@@ -140,7 +141,7 @@
 	// Search
 	//
 	.o-header__drawer-search {
-		padding: 0px $_o-header-drawer-padding-x;
+		padding: 0 $_o-header-drawer-padding-x calc($_o-header-drawer-padding-y + 4px) $_o-header-drawer-padding-x;
 
 		@include oGridRespondTo('M') {
 			display: none;

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -18,8 +18,10 @@
 			display: block;
 		}
 	}
-	.o-header__drawer-search .o-forms-input--text input::placeholder {
-		color: oColorsByName('black-60');;
+	.o-header__drawer-search, .o-header__search-form {
+		.o-forms-input--text input::placeholder {
+			color: oColorsByName('black-60');;
+		}
 	}
 
 	[data-o-header-search] {

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -1,3 +1,4 @@
+
 @mixin _oHeaderSearch() {
 	.o-header__search {
 		background-color: oColorsByName('white-60');
@@ -17,6 +18,9 @@
 		&[aria-hidden='false'] {
 			display: block;
 		}
+	}
+	.o-header__drawer-search .o-forms-input--text input::placeholder {
+		color: oColorsByName('black-60');;
 	}
 
 	[data-o-header-search] {
@@ -38,12 +42,13 @@
 		min-width: 50%;
 		flex-grow: 1;
 		align-items: center;
-
 		.o-forms-input--text.o-forms-input--suffix {
 			width: 100%;
 			margin-top: 10px;
 		}
+
 	}
+
 
 	.o-header__search-icon {
 		@include oIconsContent($icon-name: 'search', $size: 38, $color: white);

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -48,9 +48,7 @@
 			width: 100%;
 			margin-top: 10px;
 		}
-
 	}
-
 
 	.o-header__search-icon {
 		@include oIconsContent($icon-name: 'search', $size: 38, $color: white);

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -1,4 +1,3 @@
-
 @mixin _oHeaderSearch() {
 	.o-header__search {
 		background-color: oColorsByName('white-60');
@@ -42,6 +41,7 @@
 		min-width: 50%;
 		flex-grow: 1;
 		align-items: center;
+
 		.o-forms-input--text.o-forms-input--suffix {
 			width: 100%;
 			margin-top: 10px;

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -20,7 +20,7 @@
 	}
 	.o-header__drawer-search, .o-header__search-form {
 		.o-forms-input--text input::placeholder {
-			color: oColorsByName('black-60');;
+			color: oColorsByName('black-60');
 		}
 	}
 

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -11,7 +11,6 @@ export function Drawer({
 	const subscribeAction = data.subscribeAction;
 	const navItems = data.drawer.items;
 	const userData = userIsLoggedIn ? data.user : data.anon;
-	const showAskFtButton = showAskButton;
 	const showSubscribeButton = !userIsSubscribed && subscribeAction;
 	const showDrawerActions =
 		showAskFtButton || showSubscribeButton;

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -21,15 +21,8 @@ export function Drawer({data, showAskButton, userIsLoggedIn, userIsSubscribed }:
 					otherEditions={editions.others}
 				/>
 				<DrawerSearch />
-				{showAskButton && 
-					<AskFtButton
-						variant="drawer"
-						dataTrackable="ask-ft-button-drawer"
-						id="ask-ft-button-drawer"
-					/>
-				}
 				{!userIsSubscribed && subscribeAction && (
-					<DrawerAction action={subscribeAction} />
+					<DrawerAction action={subscribeAction} showAskButton={showAskButton} />
 				)}
 				<DrawerMenu navItems={navItems} />
 				<DrawerUser {...userData} />
@@ -61,9 +54,16 @@ function DrawerTools({
 	);
 }
 
-function DrawerAction({action}: {action: TNavAction}) {
+function DrawerAction({action, showAskButton}: {action: TNavAction, showAskButton: boolean}) {
 	return (
 		<div className="o-header__drawer-actions">
+			{showAskButton &&
+				<AskFtButton
+					variant="drawer"
+					dataTrackable="ask-ft-button-drawer"
+					id="ask-ft-button-drawer"
+				/>
+			}
 			<a className="o-header__drawer-button" role="button" href={action.url}>
 				{action.name}
 			</a>

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -13,7 +13,7 @@ export function Drawer({
 	const userData = userIsLoggedIn ? data.user : data.anon;
 	const showSubscribeButton = !userIsSubscribed && subscribeAction;
 	const showDrawerActions =
-		showAskFtButton || showSubscribeButton;
+		showAskButton || showSubscribeButton;
 	return (
 		<div
 			className="o-header__drawer"
@@ -31,7 +31,7 @@ export function Drawer({
 				<DrawerSearch />
 				{showDrawerActions && (
 					<div className="o-header__drawer-actions">
-						{showAskFtButton && (
+						{showAskButton && (
 							<AskFtButton
 								variant="drawer"
 								dataTrackable="ask-ft-button-drawer"

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -11,10 +11,10 @@ export function Drawer({
 	const subscribeAction = data.subscribeAction;
 	const navItems = data.drawer.items;
 	const userData = userIsLoggedIn ? data.user : data.anon;
-	const shouldShowAskFtButton = showAskButton;
-	const shouldShowSubscribeButton = !userIsSubscribed && subscribeAction;
-	const shouldShowDrawerActions =
-		shouldShowAskFtButton || shouldShowSubscribeButton;
+	const showAskFtButton = showAskButton;
+	const showSubscribeButton = !userIsSubscribed && subscribeAction;
+	const showDrawerActions =
+		showAskFtButton || showSubscribeButton;
 	return (
 		<div
 			className="o-header__drawer"
@@ -30,16 +30,16 @@ export function Drawer({
 					otherEditions={editions.others}
 				/>
 				<DrawerSearch />
-				{shouldShowDrawerActions && (
+				{showDrawerActions && (
 					<div className="o-header__drawer-actions">
-						{shouldShowAskFtButton && (
+						{showAskFtButton && (
 							<AskFtButton
 								variant="drawer"
 								dataTrackable="ask-ft-button-drawer"
 								id="ask-ft-button-drawer"
 							/>
 						)}
-						{shouldShowSubscribeButton && (
+						{showSubscribeButton && (
 							<ActionButton action={subscribeAction} />
 						)}
 					</div>

--- a/components/o-header/src/tsx/drawer.tsx
+++ b/components/o-header/src/tsx/drawer.tsx
@@ -1,11 +1,20 @@
-import { AskFtButton } from './components/ask-ft-button';
+import {AskFtButton} from './components/ask-ft-button';
 import {TNavEdition, TNavAction, TNavMenuItem, THeaderProps} from './Props';
 
-export function Drawer({data, showAskButton, userIsLoggedIn, userIsSubscribed }: THeaderProps) {
+export function Drawer({
+	data,
+	showAskButton,
+	userIsLoggedIn,
+	userIsSubscribed,
+}: THeaderProps) {
 	const editions = data.editions;
 	const subscribeAction = data.subscribeAction;
 	const navItems = data.drawer.items;
 	const userData = userIsLoggedIn ? data.user : data.anon;
+	const shouldShowAskFtButton = showAskButton;
+	const shouldShowSubscribeButton = !userIsSubscribed && subscribeAction;
+	const shouldShowDrawerActions =
+		shouldShowAskFtButton || shouldShowSubscribeButton;
 	return (
 		<div
 			className="o-header__drawer"
@@ -21,8 +30,19 @@ export function Drawer({data, showAskButton, userIsLoggedIn, userIsSubscribed }:
 					otherEditions={editions.others}
 				/>
 				<DrawerSearch />
-				{!userIsSubscribed && subscribeAction && (
-					<DrawerAction action={subscribeAction} showAskButton={showAskButton} />
+				{shouldShowDrawerActions && (
+					<div className="o-header__drawer-actions">
+						{shouldShowAskFtButton && (
+							<AskFtButton
+								variant="drawer"
+								dataTrackable="ask-ft-button-drawer"
+								id="ask-ft-button-drawer"
+							/>
+						)}
+						{shouldShowSubscribeButton && (
+							<ActionButton action={subscribeAction} />
+						)}
+					</div>
 				)}
 				<DrawerMenu navItems={navItems} />
 				<DrawerUser {...userData} />
@@ -54,20 +74,11 @@ function DrawerTools({
 	);
 }
 
-function DrawerAction({action, showAskButton}: {action: TNavAction, showAskButton: boolean}) {
+function ActionButton({action}: {action: TNavAction}) {
 	return (
-		<div className="o-header__drawer-actions">
-			{showAskButton &&
-				<AskFtButton
-					variant="drawer"
-					dataTrackable="ask-ft-button-drawer"
-					id="ask-ft-button-drawer"
-				/>
-			}
-			<a className="o-header__drawer-button" role="button" href={action.url}>
-				{action.name}
-			</a>
-		</div>
+		<a className="o-header__drawer-button" role="button" href={action.url}>
+			{action.name}
+		</a>
 	);
 }
 


### PR DESCRIPTION
## Describe your changes
We need to make some design adjustments that we saw after release new version of search drawer
Changes:

- Padding between the search bar and the “Top sections” box should be 16px. If there’s an “ask FT” button, then it should be 16px between the bar and the button and 16px between the button and the “Top sections”
- Text inside the bar seems very faint so we use black tint 60 (happens in safari)
- The underline on the option that’s not selected should be black tints 80, not teal (happens in safari)

## Issue ticket number and link
https://financialtimes.atlassian.net/browse/CON-3544
## Link to Figma designs
https://docs.google.com/document/d/1qsmZwl4AREo__B46fivT5MHLc90lmClil_XBPH0DYw4/edit
## Checklist before requesting a review

- [ x] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)

