### PR TITLE
backstage: remove storybook base dir

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: apps/o3-storybook
-          storybookBaseDir: ./
           exitOnceUploaded: true
           onlyChanged: true
           autoAcceptChanges: 'main' # 👈 Option to accept all changes on main


### PR DESCRIPTION
## Describe your changes

Changes to the way `storybookBaseDir` should mean that we should no longer need to set this according to [this](https://github.com/chromaui/chromatic-cli/issues/1027)

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
