### PR TITLE
fix: (o-header) increase the value of o-header-mega to 5

### DIFF
--- a/components/o-header/src/scss/_variables.scss
+++ b/components/o-header/src/scss/_variables.scss
@@ -7,7 +7,7 @@ $_o-header-padding-y: 8px;
 $_o-header-buttons-theme: 'mono';
 $_o-header-mega-padding-x: 24px;
 $_o-header-mega-padding-y: 18px;
-$_o-header-mega-z-index: 1;
+$_o-header-mega-z-index: 5;
 $_o-header-z-index: 10;
 $_o-header-drawer-z-index: 100;
 $_o-header-drawer-width: 320px;


### PR DESCRIPTION
## Describe your changes

Increasing `z-index` for nav items to win `z-index` wars.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/1c865e22-1b10-4d72-ab27-d8561dbc55a7) | ![image](https://github.com/user-attachments/assets/50a70d89-e1b9-4280-9932-5ed3dd134e68) |

