### PR TITLE
fix: (o-header) subnav scroll behaviour

### DIFF
--- a/components/o-header/src/js/subnav.js
+++ b/components/o-header/src/js/subnav.js
@@ -18,17 +18,21 @@ function init(headerEl) {
 	function checkCurrentPosition() {
 		const wrapperWidth = wrapper.clientWidth;
 		const currentSelection = wrapper.querySelector('[aria-current]');
+
 		if (currentSelection) {
-			const currentSelectionEnd = currentSelection.getBoundingClientRect().right;
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const currentSelectionRect = currentSelection.getBoundingClientRect();
+			const currentSelectionEnd = currentSelectionRect.right - wrapperRect.left;
 
 			//if the current selection is wider than the end of the wrapper
 			if (currentSelectionEnd > wrapperWidth) {
-				// check by how much
-				let diff = currentSelectionEnd - wrapperWidth;
-				// if the difference is greater than half of the wrapper, scroll to the end of the current selection.
-				diff = diff > wrapperWidth / 2 ? currentSelectionEnd : wrapperWidth / 2;
+				const RIGHT_ARROW_BUTTON_OFFSET = 25;
 
-				wrapper.scrollTo(diff, 0);
+				//calculate offscreen distance of the selected item and include buffer for the right arrow button
+				const scrollDistance =
+					currentSelectionEnd - wrapperWidth + RIGHT_ARROW_BUTTON_OFFSET;
+
+				wrapper.scrollTo(scrollDistance, 0);
 			}
 		}
 		scrollable();


### PR DESCRIPTION
## Summary

When building a new Life & Arts navigation for the FT App, we spotted that the o-header sub navigation does not scroll to the correct position of the selected item. This can be seen on Ft.com also when on a smaller viewports (390 width) on here as an example: https://www.ft.com/globetrotter/miami.

## More details 

There is a bug in the way we calculate how far to scroll in order to make sure the selected item is in view in the SubNav.

We were previously calculating the scroll position by first checking how far off the item is out of view via `currentSelectionEnd - wrapperWidth`. If this was less than the wrapper width, we would only scroll by half the width of the wrapper, which is not the right thing to do here especially when the item is only slightly out of view.

The fix includes:

* Removing the unnecessary scroll by half the wrapper width logic.

* Calculating the right edge of the selected item `currentSelectionEnd`  more accurately by taking into consideration the wrapper's left boundary (rather than just checking the wrapper width) via: `currentSelectionRect.right - wrapperRect.left`.

* Calculating the scroll distance more accurately by including a fixed buffer distance `RIGHT_ARROW_BUTTON_OFFSET` for the right arrow button. This is required otherwise the selected item text will be slightly cropped off by the button. This is especially apparent on smaller, mobile viewports.  

I have tested this change in FT App on Android iOS and Desktop browser and also dotcom-page-kit storybook.

Before / After:
<img width="350" alt="Screenshot 2024-09-24 at 11 25 14" src="https://github.com/user-attachments/assets/450ca135-a1c1-427a-81bc-74101095a601">  <img width="372" alt="Screenshot 2024-09-24 at 11 20 29" src="https://github.com/user-attachments/assets/e6def480-c4ca-4f75-bece-e9035dfd3623">

App - Before:

https://github.com/user-attachments/assets/faa63a4a-5ef1-416c-88ac-646c7c92b954

App - After:


https://github.com/user-attachments/assets/ba6093c7-7655-4423-9068-c1d8eda70d85



## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] ~~If it is a new feature, I have added thorough tests.~~
- [ ] ~~I have updated relevant docs.~~
- [ ] ~~I have updated relevant env variables in Doppler.~~
