### PR TITLE
fix: remove unnecessary token building for o3-social-sign-in

### DIFF
--- a/components/o3-social-sign-in/package.json
+++ b/components/o3-social-sign-in/package.json
@@ -23,7 +23,7 @@
     "social-sign-in"
   ],
   "scripts": {
-    "build": "node ../../apps/dictionary/scripts/build-config/build.js && bash ../../scripts/component/build-o3.bash o3-social-sign-in"
+    "build": "bash ../../scripts/component/build-o3.bash o3-social-sign-in"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Describe your changes
o3-social-sign in has a tokens build step in it's `build` script, there are no tokens in this package so it can be removed.

This will help clean up local dev by reducing the generation of unnecessary files.
## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
