### PR TITLE
backstage: ignore tokens in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ tools/*
 !tools/create-component
 !tools/o3-chrome-extension
 apps/website/_emails/
+apps/dictionary/tokens


### PR DESCRIPTION
## Describe your changes

Tokens Studio does some formatting on push, which can be overridden by prettier in local dev setups. This is adding noise to PRs. Ignoring tokens should reduce noice in PRs in future.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
