### PR TITLE
fix: size text input with border-box

### DIFF
--- a/components/o3-form/src/css/components/text-input.css
+++ b/components/o3-form/src/css/components/text-input.css
@@ -2,6 +2,7 @@
 	border: var(--_o3-form-text-input-border);
 	padding: var(--o3-spacing-3xs) var(--o3-spacing-2xs);
 	background-color: var(--_o3-form-text-input-background-color);
+	box-sizing: border-box;
 	border-radius: var(--_o3-form-text-input-border-radius);
 
 	--o3-grid-columns-to-span-count: 4;


### PR DESCRIPTION
## Describe your changes

The text input field has padding of `16px` either side, this makes the total width of the field exceed the `max-width` defined by `--o3-grid-columns-to-span-width`.

Using `box-sizing: border-box` should ensure that the `max-width` takes into account padding.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
