### PR TITLE
feat: add timestamp to session generations in o-tracking

### DIFF
--- a/libraries/o-tracking/package.json
+++ b/libraries/o-tracking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/o-tracking",
-  "version": "4.5.5",
+  "version": "4.5.4",
   "description": "Provides tracking for a product. Tracking requests are sent to the Spoor API.",
   "keywords": [
     "tracking",

--- a/libraries/o-tracking/package.json
+++ b/libraries/o-tracking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/o-tracking",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "Provides tracking for a product. Tracking requests are sent to the Spoor API.",
   "keywords": [
     "tracking",

--- a/libraries/o-tracking/src/javascript/core.js
+++ b/libraries/o-tracking/src/javascript/core.js
@@ -55,6 +55,7 @@ function track(config, callback = function(){ /* empty */}) {
 		device: {
 			spoor_session: currentSession.id,
 			spoor_session_is_new: currentSession.isNew,
+			spoor_session_timestamp: currentSession.timestamp,
 			spoor_id: userID(),
 		},
 	};

--- a/libraries/o-tracking/src/javascript/tracking.js
+++ b/libraries/o-tracking/src/javascript/tracking.js
@@ -17,7 +17,7 @@ const initPage = page.init;
  *
  * @type {string}
  */
-const version = '4.5.4';
+const version = '4.5.5';
 
 /**
  * The source of this event.

--- a/libraries/o-tracking/src/javascript/utils.js
+++ b/libraries/o-tracking/src/javascript/utils.js
@@ -28,6 +28,26 @@ function log(...args) {
 }
 
 /**
+ * Creates a logging function that logs messages to the console with a specified namespace.
+ *
+ * @function namedLog
+ * @param {string} namespace - The namespace to be prefixed to each log message.
+ * @returns {function} A function that logs messages to the console with the given namespace if the configuration allows.
+ *
+ * @example
+ * const log = namedLog('MyNamespace');
+ * log('This is a message'); 
+ * // Output: [MyNamespace]: This is a message
+ */
+function namedLog(namespace) {
+	return function(...args) {
+		if(get('config').test && window.console) {
+			window.console.log(`%c[${namespace}]:`, 'color: teal', ...args)
+		}
+	}
+}
+
+/**
  * Tests if variable is a certain type. Defaults to check for undefined if no type specified.
  *
  * @param {*} variable - The variable to check.
@@ -389,6 +409,7 @@ function isDeepEqual(a, b) {
 
 export {
 	log,
+	namedLog,
 	is,
 	is as isUndefined,
 	merge,

--- a/libraries/o-tracking/test/core.test.js
+++ b/libraries/o-tracking/test/core.test.js
@@ -78,9 +78,10 @@ describe('Core', function () {
 			proclaim.equal(sent_data.user.user_id, "userID");
 
 			// Device
-			proclaim.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_session_is_new","spoor_id"]);
+			proclaim.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_session_is_new","spoor_session_timestamp", "spoor_id"]);
 			proclaim.equal(sent_data.device.spoor_session, session().id);
 			proclaim.equal(sent_data.device.spoor_session_is_new, session().isNew);
+			proclaim.equal(sent_data.device.spoor_session_timestamp, session().timestamp);
 
 		});
 

--- a/libraries/o-tracking/test/core/session.test.js
+++ b/libraries/o-tracking/test/core/session.test.js
@@ -35,6 +35,7 @@ describe('Core.Session', function () {
 			const newSession = getSession();
 			proclaim.equal(newSession.id, session.id);
 			proclaim.equal(newSession.isNew, false);
+			proclaim.equal(newSession.timestamp, session.timestamp)
 		});
 	});
 
@@ -58,6 +59,20 @@ describe('Core.Session', function () {
 				const newSession = getSession();
 				proclaim.isTrue(newSession.isNew);
 				done();
+			}, 2)
+		});
+
+		it('should generate timestamp for session', () => {
+			const currentTimestamp = new Date().getTime();
+			proclaim.equal(currentTimestamp, getSession().timestamp)
+		})
+
+		it('should generate a new timestamp if session has expired', (done) => {
+			const prevSession = initSession({expires: 1});
+			setTimeout(function() {
+				const newSession = getSession();
+				proclaim.notEqual(prevSession.timestamp, newSession.timestamp);
+				done()
 			}, 2)
 		})
 	})


### PR DESCRIPTION
## Describe your changes
- Added a new property `timestamp` to the session object.
- Added a new logging utility function for dev with namespacing support

## Issue ticket number and link
[DATA-9749](https://financialtimes.atlassian.net/browse/DATA-9749)

## Link to Figma designs

## Checklist before requesting a review

- [x] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [x] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[DATA-9749]: https://financialtimes.atlassian.net/browse/DATA-9749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ