### PR TITLE
chore: add proposed structure to figma tokens studio

### DIFF
--- a/apps/dictionary/tokens/$metadata.json
+++ b/apps/dictionary/tokens/$metadata.json
@@ -1,5 +1,13 @@
 {
   "tokenSetOrder": [
+    "foundation",
+    "brand/core",
+    "brand/professional",
+    "alias/core",
+    "alias/professional",
+    "theme/core-inverse",
+    "theme/professional-inverse",
+    "components/o3-button",
     "core/base/color",
     "core/base/spacing",
     "core/base/typography",

--- a/apps/dictionary/tokens/$themes.json
+++ b/apps/dictionary/tokens/$themes.json
@@ -14,7 +14,15 @@
       "core/use-case/focus": "enabled",
       "core/components/o3-editorial-typography": "source",
       "core/components/o3-form/use-case": "source",
-      "core/components/o3-form": "source"
+      "core/components/o3-form": "source",
+      "foundation": "disabled",
+      "brand/core": "disabled",
+      "brand/professional": "disabled",
+      "alias/core": "disabled",
+      "alias/professional": "disabled",
+      "theme/core-inverse": "disabled",
+      "theme/professional-inverse": "disabled",
+      "components/o3-button": "disabled"
     },
     "$figmaStyleReferences": {
       "color-usecase.background.button.primary.active": "S:ef8234289a222e339b586d8ea3466f08d0d010f5,",
@@ -226,7 +234,15 @@
       "core/use-case/focus": "enabled",
       "core/components/o3-editorial-typography": "source",
       "core/professional/components/o3-form/use-case": "source",
-      "core/professional/components/o3-form": "source"
+      "core/professional/components/o3-form": "source",
+      "foundation": "disabled",
+      "brand/core": "disabled",
+      "brand/professional": "disabled",
+      "alias/core": "disabled",
+      "alias/professional": "disabled",
+      "theme/core-inverse": "disabled",
+      "theme/professional-inverse": "disabled",
+      "components/o3-button": "disabled"
     },
     "$figmaStyleReferences": {
       "color-usecase.background.button.primary.active": "S:55d4b73d90c40ff305a097a15d86f53de276da57,",
@@ -430,7 +446,15 @@
       "internal/use-case/typography": "enabled",
       "internal/use-case/focus": "enabled",
       "internal/components/o3-form": "source",
-      "internal/components/o3-form/use-case": "source"
+      "internal/components/o3-form/use-case": "source",
+      "foundation": "disabled",
+      "brand/core": "disabled",
+      "brand/professional": "disabled",
+      "alias/core": "disabled",
+      "alias/professional": "disabled",
+      "theme/core-inverse": "disabled",
+      "theme/professional-inverse": "disabled",
+      "components/o3-button": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:6510:3502",
     "$figmaModeId": "6510:2",
@@ -528,7 +552,15 @@
       "whitelabel/use-case/focus": "enabled",
       "whitelabel/components/o3-editorial-typography": "source",
       "whitelabel/components/o3-form": "source",
-      "whitelabel/components/o3-form/use-case": "source"
+      "whitelabel/components/o3-form/use-case": "source",
+      "foundation": "disabled",
+      "brand/core": "disabled",
+      "brand/professional": "disabled",
+      "alias/core": "disabled",
+      "alias/professional": "disabled",
+      "theme/core-inverse": "disabled",
+      "theme/professional-inverse": "disabled",
+      "components/o3-button": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:4842:355",
     "$figmaModeId": "4842:3",
@@ -657,7 +689,15 @@
       "sustainable-views/use-case/focus": "enabled",
       "whitelabel/components/o3-form/use-case": "source",
       "sustainable-views/components/o3-form": "source",
-      "sustainable-views/components/o3-form/use-case": "source"
+      "sustainable-views/components/o3-form/use-case": "source",
+      "foundation": "disabled",
+      "brand/core": "disabled",
+      "brand/professional": "disabled",
+      "alias/core": "disabled",
+      "alias/professional": "disabled",
+      "theme/core-inverse": "disabled",
+      "theme/professional-inverse": "disabled",
+      "components/o3-button": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:6169:227",
     "$figmaModeId": "6169:4",

--- a/apps/dictionary/tokens/alias/core.json
+++ b/apps/dictionary/tokens/alias/core.json
@@ -1,0 +1,176 @@
+{
+  "o3": {
+    "color": {
+      "use-case": {
+        "link": {
+          "text": {
+            "@": {
+              "value": "{o3.color.palette.teal}",
+              "type": "color",
+              "description": ""
+            },
+            "hover": {
+              "value": "{o3.color.palette.teal-30}",
+              "type": "color"
+            }
+          },
+          "underline": {
+            "@": {
+              "value": "#CFD8D1",
+              "type": "color"
+            },
+            "hover": {
+              "value": "#9EC0BD",
+              "type": "color"
+            }
+          }
+        },
+        "link-inverse": {
+          "text": {
+            "@": {
+              "value": "#ffffffff",
+              "type": "color"
+            },
+            "hover": {
+              "value": "#d4d4d6",
+              "type": "color"
+            }
+          },
+          "underline": {
+            "@": {
+              "value": "#ffffffff",
+              "type": "color"
+            },
+            "hover": {
+              "value": "#d4d4d6",
+              "type": "color"
+            }
+          }
+        },
+        "page": {
+          "background": {
+            "value": "{o3.color.palette.paper}",
+            "type": "color"
+          }
+        },
+        "page-inverse": {
+          "background": {
+            "value": "{o3.color.palette.slate}",
+            "type": "color"
+          }
+        },
+        "body": {
+          "text": {
+            "value": "{o3.color.palette.black-80}",
+            "type": "color"
+          }
+        },
+        "body-inverse": {
+          "text": {
+            "value": "{o3.color.palette.white}",
+            "type": "color"
+          }
+        },
+        "heading": {
+          "text": {
+            "value": "{o3.color.palette.black-80}",
+            "type": "color"
+          }
+        },
+        "heading-inverse": {
+          "text": {
+            "value": "{o3.color.palette.white}",
+            "type": "color"
+          }
+        },
+        "muted": {
+          "text": {
+            "value": "{o3.color.palette.black-50}",
+            "type": "color",
+            "description": "\"Muted\" text is less prominent, for example credits and captions."
+          }
+        },
+        "muted-inverse": {
+          "text": {
+            "value": "#a8aaad",
+            "type": "color",
+            "description": "\"Muted\" text is less prominent, for example credits and captions."
+          }
+        },
+        "footer": {
+          "text": {
+            "value": "{o3.color.palette.black-80}",
+            "type": "color"
+          }
+        },
+        "caption": {
+          "text": {
+            "value": "{o3.color.palette.black-80}",
+            "type": "color"
+          }
+        },
+        "button": {
+          "primary": {
+            "background": {
+              "value": "{o3.color.palette.teal}",
+              "type": "color"
+            },
+            "text": {
+              "value": "{o3.color.palette.white}",
+              "type": "color"
+            },
+            "border": {
+              "value": "{o3.color.pallete.transparent}",
+              "type": "color"
+            },
+            "hover": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            },
+            "focus": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            },
+            "active": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.40}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/alias/professional.json
+++ b/apps/dictionary/tokens/alias/professional.json
@@ -1,0 +1,100 @@
+{
+  "o3": {
+    "color": {
+      "use-case": {
+        "link": {
+          "text": {
+            "@": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color",
+              "description": ""
+            },
+            "hover": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color"
+            },
+            "focus": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color"
+            }
+          },
+          "underline": {
+            "@": {
+              "value": "{o3.color.palette.mint-80}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{o3.color.palette.mint-80}",
+              "type": "color"
+            },
+            "focus": {
+              "value": "{o3.color.palette.black}",
+              "type": "color"
+            }
+          }
+        },
+        "button": {
+          "primary": {
+            "background": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color"
+            },
+            "text": {
+              "value": "{o3.color.palette.white}",
+              "type": "color"
+            },
+            "border": {
+              "value": "{o3.color.pallete.transparent}",
+              "type": "color"
+            },
+            "hover": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "lighten",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            },
+            "focus": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "lighten",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            },
+            "active": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "lighten",
+                      "value": "{o3.color.modifier.40}",
+                      "space": "hsl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/brand/core.json
+++ b/apps/dictionary/tokens/brand/core.json
@@ -1,0 +1,839 @@
+{
+  "o3": {
+    "color": {
+      "palette": {
+        "ft-pink": {
+          "value": "#FCD0B1",
+          "type": "color",
+          "description": "FT Pink is used for the FT logo",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:47b573ac7de8e17071c3ecc61c05dc843277efb5,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "ft-grey": {
+          "value": "#333333ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d85c5ab18d32b1525bc200af8071e1615cfc9452,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white": {
+          "value": "#ffffffff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:76037475c9beb1096647e1b98ab85097403ede29,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black": {
+          "value": "#000000ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:65c9a696bc2d35cbce6175905980bcc3f0fe0449,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret": {
+          "value": "#990f3dff",
+          "type": "color",
+          "description": "Claret is the main branding colour for MyFT related products. It should be used sparingly and never be used as a background colour.\n\nUsage example: MyFT branding; MyFT CTAs",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:82431c59eb5d4b565bc74b2b629398b9bfe2cec4,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal": {
+          "value": "#0d7680ff",
+          "type": "color",
+          "description": "Teal is the most striking colour and main CTA colour on ft.com. It is reserved for important action items that need to stand out: buttons, text links and other critical functional use cases.",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a56ec15ce664561d1049dd70ad6f40fee93ef09c,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford": {
+          "value": "#0f5499ff",
+          "type": "color",
+          "description": "Oxford is used to denote opinion pieces (in combination with Sky). It is used on the homepage and in articles. Use for information and callouts in general.\n\nUsage example: opinion branding; opinion topic tags.",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:3e6285be16ea3f3656b8e17321063c4d6ae22e33,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "slate": {
+          "value": "#262a33ff",
+          "type": "color",
+          "description": "Slate is a warmer version of black. It is used as inverse backgrounds for editorial content and as a theme option(Mono) for buttons.",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:e64a2c357204910e0d1221cbd096d4ea421df703,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "paper": {
+          "value": "#fff1e5ff",
+          "type": "color",
+          "description": "Paper, as it’s name implies, is the FT’s main background colour. It is the main expression of the brand colour on product. It is a lighter, more legible shade of FT Pink and can be seen as a kind of replacement of white.",
+          "origamiKeys": [
+            "palette",
+            "secondary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:aa745b0eb03dc5a44e7eb3aecc0926801bed0b9a,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "mandarin": {
+          "value": "#ff8833ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:da2e31e2245623672b5948419f0920a4ffc33eee,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "light-blue": {
+          "value": "#00a0ddff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:630f112ade10fb00f6a147d5a784fd1ce5f4b7b3,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "crimson": {
+          "value": "#cc0000ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a0cbf78171209d78cf0c20ab39dd294cba87f137,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "graphics-dark-blue": {
+          "value": "#006f9bff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6cc4f821f74ed9461ae3107af16e0eb548d95db4,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "wheat": {
+          "value": "#f2dfceff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:8452daa2b5a27d34ad193c4041dbce9b303d4b0b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "candy": {
+          "value": "#ff7faaff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:11bd74e0ca0cd3683600689cf26526a55a25872a,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "wasabi": {
+          "value": "#96cc28ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:68b0707aeb3e04036f58b82d9beca1bf1d960ad3,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "jade": {
+          "value": "#00994dff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6c3b75302d6e7076b8e34be0c929744571cccaba,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "velvet": {
+          "value": "#593380ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:35caf1cf2dab4ba8f8cfc00c53eb67dd07a5f178,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "lemon": {
+          "value": "#ffec1aff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:f47a7c3596c7f7bc156588a622cfcc97c3e44b97,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "sky": {
+          "value": "#cce6ffff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:1294d55ab841186eb63885af566000b2eef5080a,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "matisse-blue": {
+          "value": "#355778ff",
+          "type": "color",
+          "description": "",
+          "origamiKeys": [
+            "palette",
+            "tertiary"
+          ],
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:97a4d2db7a3f874e12bb0dad9dbc1a86258b4b42,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-5": {
+          "value": "#f2e5daff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:692a1e7506f807908eed009c165c0e27e33a70d9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-10": {
+          "value": "#e6d9ceff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:809e41d28dad010981288feb25d73dae584d749d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-20": {
+          "value": "#ccc1b7ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:bd9f86093a0d5c4cd89258492c206bdfa7f61bea,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-30": {
+          "value": "#b3a9a0ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d4368b7e7881ccff163e8eccc0366d52631287be,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-40": {
+          "value": "#999189ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:c6afdacb2920a4b7e9141baff1e43716e0fcd597,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-50": {
+          "value": "#807973ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:5feec167fc9731a9a4004653a8ae9f391c3f65ba,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-60": {
+          "value": "#66605cff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:e4976f227cdebafa4cac52e38c524a40409b50f9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-70": {
+          "value": "#4d4845ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:c351bb6b2e4c2269b97843a62cb6194188c5a405,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-80": {
+          "value": "#33302eff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:10fb4b10a5a444d58bde998147ea30527d8d9e62,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "black-90": {
+          "value": "#1a1817ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:fa57f5fd7c79357a5a885a610e65f7b157a69ae7,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white-10": {
+          "value": "#fff2e8ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:1af3e8b5fa956d6318f921cc8a61d4c5cbceee87,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white-20": {
+          "value": "#fff4eaff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a8c90dd9019e4e6723c8bf10ce45deb60dbd4f49,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white-40": {
+          "value": "#fff7efff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d2e5cc151154824a3d68001e014ee9f499af2ec5,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white-60": {
+          "value": "#fff9f5ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d62e9ba2fb5e1c6db690cd357f1e2c2b34387c5b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "white-80": {
+          "value": "#fffcfaff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:624fce88118ac9eda92c1b8cec8f252eacdbc8c8,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-30": {
+          "value": "#082a4dff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:9238ab9bcc9b526ea7fa110d60a0791b41457aff,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-40": {
+          "value": "#0a3866ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:e8b02de8ab37b46f2b84fc8a1233ef4ecb5202f5,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-50": {
+          "value": "#0d4680ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:d2fc0358826232bbc1d4992d8a8207237a591ee0,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-60": {
+          "value": "#0f5499ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:1c3a18307cab317b4648faf482773e1d0a57ea2d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-70": {
+          "value": "#1262b3ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:2aaf2c58fa33011ee705c36ea5c22402537e2161,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-80": {
+          "value": "#1470ccff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:7568cc29ab3a6243f14f35bde4021bcfd8294b2c,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-90": {
+          "value": "#177ee6ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:32c68030468b87facbca3c61327a09fed2359566,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "oxford-100": {
+          "value": "#1a8cffff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:7e89b5a2f557f7351670e95321762fbd8523afe8,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-20": {
+          "value": "#052f33ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:0b0b2288f32fde0b1e4e1427b7f33377bae752e6,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-30": {
+          "value": "#08474dff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:dcd8cc437de0feac4062680b8cfd39d5d42b476d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-40": {
+          "value": "#0a5e66ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6683bb569449d827aa1aae5a85e677fdca62b2b4,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-50": {
+          "value": "#0d7680ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:0c3eae84bf4a82bc3529964f45248be8d28f5e9f,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-60": {
+          "value": "#0f8e99ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a9a12d89efb37074e879f132929c9426cb4310f1,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-70": {
+          "value": "#12a5b3ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:baa99021c28c9a3d0d961fb624bb61e0cf90898b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-80": {
+          "value": "#14bdccff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:e2127a01bff001b63b2f81030a72c5e45b26463b,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-90": {
+          "value": "#17d4e6ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6ca614e35345ba90e860965e30848d76cc116de3,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "teal-100": {
+          "value": "#1aecffff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:34296160b860e6ee104cf4d4154598a3559088db,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-30": {
+          "value": "#4d081fff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:fbb1d65aaa16faa05486eb6aec242804fcf53f5d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-40": {
+          "value": "#660a29ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:2cf06cbdde60b7e7806bcc48ab8c7b042e798ce8,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-50": {
+          "value": "#800d33ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:7609034bcb97a9054c437e2743c3e061be327836,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-60": {
+          "value": "#990f3dff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:a9543b74d96ee94e0e559b28115679859547e495,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-70": {
+          "value": "#b31247ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:b106f70d6afb95ca023785e81f6e9bf23af964bd,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-80": {
+          "value": "#cc1452ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:bc2681d9d46fdc66bd56deca9503f9c6b83e2f96,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-90": {
+          "value": "#e6175cff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:6bbae7140c9d961c5f82563c5c472581ff686a55,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "claret-100": {
+          "value": "#ff1a66ff",
+          "type": "color",
+          "description": "",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:5638ac3ef048e2ac4f85acd450f4caf8e896637d,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "wheat-100": {
+          "value": "#FFEBD9",
+          "type": "color",
+          "blendMode": "normal",
+          "extensions": {
+            "org.lukasoppermann.figmaDesignTokens": {
+              "styleId": "S:1fe341101aa47ac15dc4fdebf4ae4c12e3b173d9,",
+              "exportKey": "color"
+            }
+          }
+        },
+        "mint": {
+          "value": "{o3.DO-NOT-USE}",
+          "type": "color"
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/brand/professional.json
+++ b/apps/dictionary/tokens/brand/professional.json
@@ -1,0 +1,40 @@
+{
+  "o3": {
+    "color": {
+      "palette": {
+        "mint": {
+          "value": "#c0efd8",
+          "type": "color",
+          "origamiKeys": [
+            "palette",
+            "primary"
+          ]
+        },
+        "mint-80": {
+          "value": "#A4CCB8",
+          "type": "color"
+        },
+        "mint-70": {
+          "value": "#8FB3A1",
+          "type": "color"
+        },
+        "mint-60": {
+          "value": "#7B998A",
+          "type": "color"
+        },
+        "mint-50": {
+          "value": "#668073",
+          "type": "color"
+        },
+        "mint-40": {
+          "value": "#52665C",
+          "type": "color"
+        },
+        "mint-30": {
+          "value": "#3D4D45",
+          "type": "color"
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/components/o3-button.json
+++ b/apps/dictionary/tokens/components/o3-button.json
@@ -1,0 +1,38 @@
+{
+  "o3": {
+    "button": {
+      "primary": {
+        "background": {
+          "value": "{o3.color.use-case.button.primary.background}",
+          "type": "color"
+        },
+        "color": {
+          "value": "{o3.color.use-case.button.primary.text}",
+          "type": "color"
+        },
+        "border": {
+          "value": "#ffffff00",
+          "type": "color"
+        },
+        "hover": {
+          "background": {
+            "value": "{o3.color.use-case.button.primary.hover.background}",
+            "type": "color"
+          }
+        },
+        "focus": {
+          "background": {
+            "value": "{o3.color.use-case.button.primary.focus.background}",
+            "type": "color"
+          }
+        },
+        "active": {
+          "background": {
+            "value": "{o3.color.use-case.button.primary.active.background}",
+            "type": "color"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/core/components/o3-button.json
+++ b/apps/dictionary/tokens/core/components/o3-button.json
@@ -173,12 +173,12 @@
       },
       "secondary": {
         "standard": {
-          "color": {
-            "value": "#0d7680",
-            "type": "color"
-          },
           "background": {
             "value": "#ffffff00",
+            "type": "color"
+          },
+          "color": {
+            "value": "#0d7680",
             "type": "color"
           },
           "border": {

--- a/apps/dictionary/tokens/foundation.json
+++ b/apps/dictionary/tokens/foundation.json
@@ -1,0 +1,696 @@
+{
+  "o3": {
+    "DO-NOT-USE": {
+      "value": "rgba(0,0,0,0)",
+      "type": "color"
+    },
+    "typography": {
+      "use-case": {
+        "body-standard": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.0}",
+            "lineHeight": "{o3.font.lineheight-metric2.0}"
+          },
+          "type": "typography"
+        },
+        "body-big": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.1}",
+            "lineHeight": "{o3.font.lineheight-metric2.1}"
+          },
+          "type": "typography"
+        },
+        "body-small": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.negative-1}",
+            "lineHeight": "{o3.font.lineheight-metric2.negative-1}"
+          },
+          "type": "typography"
+        },
+        "body-small-caps": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.negative-1}",
+            "lineHeight": "{o3.font.lineheight-metric2.negative-1}"
+          },
+          "type": "typography"
+        },
+        "body-small-bold": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.negative-1}",
+            "lineHeight": "{o3.font.lineheight-metric2.negative-1}"
+          },
+          "type": "typography"
+        },
+        "footer": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.0}",
+            "lineHeight": "{o3.font.lineheight-metric2.0}"
+          },
+          "type": "typography"
+        },
+        "caption": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.regular}",
+            "fontSize": "{o3.font.size-metric2.negative-2}",
+            "lineHeight": "{o3.font.lineheight-metric2.negative-2}"
+          },
+          "type": "typography"
+        },
+        "heading1": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.4}",
+            "lineHeight": "{o3.font.lineheight-metric2.4}"
+          },
+          "type": "typography"
+        },
+        "heading2": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.3}",
+            "lineHeight": "{o3.font.lineheight-metric2.3}"
+          },
+          "type": "typography"
+        },
+        "heading3": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.2}",
+            "lineHeight": "{o3.font.lineheight-metric2.2}"
+          },
+          "type": "typography"
+        },
+        "heading4": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.1}",
+            "lineHeight": "{o3.font.lineheight-metric2.1}"
+          },
+          "type": "typography"
+        },
+        "heading5": {
+          "value": {
+            "fontFamily": "{o3.font.family.metric}",
+            "fontWeight": "{o3.font.weight.semibold}",
+            "fontSize": "{o3.font.size-metric2.0}",
+            "lineHeight": "{o3.font.lineheight-metric2.0}"
+          },
+          "type": "typography"
+        }
+      }
+    },
+    "spacing": {
+      "5xs": {
+        "value": "4px",
+        "type": "spacing"
+      },
+      "4xs": {
+        "value": "8px",
+        "type": "spacing"
+      },
+      "3xs": {
+        "value": "12px",
+        "type": "spacing"
+      },
+      "2xs": {
+        "value": "16px",
+        "type": "spacing"
+      },
+      "xs": {
+        "value": "20px",
+        "type": "spacing"
+      },
+      "s": {
+        "value": "24px",
+        "type": "spacing"
+      },
+      "m": {
+        "value": "32px",
+        "type": "spacing"
+      },
+      "l": {
+        "value": "40px",
+        "type": "spacing"
+      },
+      "xl": {
+        "value": "48px",
+        "type": "spacing"
+      },
+      "2xl": {
+        "value": "64px",
+        "type": "spacing"
+      },
+      "3xl": {
+        "value": "80px",
+        "type": "spacing"
+      },
+      "4xl": {
+        "value": "96px",
+        "type": "spacing"
+      }
+    },
+    "font": {
+      "family": {
+        "metric": {
+          "value": "metric 2 VF",
+          "type": "fontFamilies"
+        },
+        "financier-display": {
+          "value": "financier display VF",
+          "type": "fontFamilies"
+        },
+        "georgia": {
+          "value": "georgia",
+          "type": "fontFamilies"
+        }
+      },
+      "weight": {
+        "light": {
+          "value": "300",
+          "type": "fontWeights"
+        },
+        "regular": {
+          "value": "400",
+          "type": "fontWeights"
+        },
+        "medium": {
+          "value": "500",
+          "type": "fontWeights"
+        },
+        "semibold": {
+          "value": "700",
+          "type": "fontWeights"
+        },
+        "bold": {
+          "value": "800",
+          "type": "fontWeights"
+        }
+      },
+      "lineheight": {
+        "0": {
+          "value": "20",
+          "type": "dimension"
+        },
+        "1": {
+          "value": "20",
+          "type": "dimension"
+        },
+        "2": {
+          "value": "24",
+          "type": "dimension"
+        },
+        "3": {
+          "value": "28",
+          "type": "dimension"
+        },
+        "4": {
+          "value": "32",
+          "type": "dimension"
+        },
+        "5": {
+          "value": "32",
+          "type": "dimension"
+        },
+        "6": {
+          "value": "40",
+          "type": "dimension"
+        },
+        "7": {
+          "value": "48",
+          "type": "dimension"
+        },
+        "8": {
+          "value": "56",
+          "type": "dimension"
+        },
+        "9": {
+          "value": "72",
+          "type": "dimension"
+        },
+        "10": {
+          "value": "84",
+          "type": "dimension"
+        },
+        "negative-2": {
+          "value": "16",
+          "type": "dimension"
+        },
+        "negative-1": {
+          "value": "16",
+          "type": "dimension"
+        }
+      },
+      "size": {
+        "0": {
+          "value": "16",
+          "type": "fontSizes"
+        },
+        "1": {
+          "value": "18",
+          "type": "fontSizes"
+        },
+        "2": {
+          "value": "20",
+          "type": "fontSizes"
+        },
+        "3": {
+          "value": "24",
+          "type": "fontSizes"
+        },
+        "4": {
+          "value": "28",
+          "type": "fontSizes"
+        },
+        "5": {
+          "value": "32",
+          "type": "fontSizes"
+        },
+        "6": {
+          "value": "40",
+          "type": "fontSizes"
+        },
+        "7": {
+          "value": "48",
+          "type": "fontSizes"
+        },
+        "8": {
+          "value": "56",
+          "type": "fontSizes"
+        },
+        "9": {
+          "value": "72",
+          "type": "fontSizes"
+        },
+        "10": {
+          "value": "84",
+          "type": "fontSizes"
+        },
+        "negative-2": {
+          "value": "12",
+          "type": "fontSizes"
+        },
+        "negative-1": {
+          "value": "14",
+          "type": "fontSizes"
+        }
+      },
+      "lineheight-metric2": {
+        "0": {
+          "value": "20",
+          "type": "dimension"
+        },
+        "1": {
+          "value": "24",
+          "type": "dimension"
+        },
+        "2": {
+          "value": "28",
+          "type": "dimension"
+        },
+        "3": {
+          "value": "32",
+          "type": "dimension"
+        },
+        "4": {
+          "value": "32",
+          "type": "dimension"
+        },
+        "5": {
+          "value": "40",
+          "type": "dimension"
+        },
+        "6": {
+          "value": "48",
+          "type": "dimension"
+        },
+        "7": {
+          "value": "56",
+          "type": "dimension"
+        },
+        "8": {
+          "value": "72",
+          "type": "dimension"
+        },
+        "9": {
+          "value": "84",
+          "type": "dimension"
+        },
+        "negative-3": {
+          "value": "16",
+          "type": "dimension"
+        },
+        "negative-2": {
+          "value": "16",
+          "type": "dimension"
+        },
+        "negative-1": {
+          "value": "20",
+          "type": "dimension"
+        }
+      },
+      "size-metric2": {
+        "0": {
+          "value": "16",
+          "type": "fontSizes"
+        },
+        "1": {
+          "value": "18",
+          "type": "fontSizes"
+        },
+        "2": {
+          "value": "20",
+          "type": "fontSizes"
+        },
+        "3": {
+          "value": "24",
+          "type": "fontSizes"
+        },
+        "4": {
+          "value": "28",
+          "type": "fontSizes"
+        },
+        "5": {
+          "value": "32",
+          "type": "fontSizes"
+        },
+        "6": {
+          "value": "40",
+          "type": "fontSizes"
+        },
+        "7": {
+          "value": "48",
+          "type": "fontSizes"
+        },
+        "8": {
+          "value": "64",
+          "type": "fontSizes"
+        },
+        "9": {
+          "value": "72",
+          "type": "fontSizes"
+        },
+        "negative-3": {
+          "value": "10",
+          "type": "fontSizes"
+        },
+        "negative-2": {
+          "value": "12",
+          "type": "fontSizes"
+        },
+        "negative-1": {
+          "value": "14",
+          "type": "fontSizes"
+        }
+      }
+    },
+    "border-radius": {
+      "s": {
+        "value": "8",
+        "type": "borderRadius"
+      },
+      "2xs": {
+        "value": "4",
+        "type": "borderRadius"
+      },
+      "xs": {
+        "value": "6",
+        "type": "borderRadius"
+      },
+      "m": {
+        "value": "16",
+        "type": "borderRadius"
+      },
+      "l": {
+        "value": "24",
+        "type": "borderRadius"
+      },
+      "xl": {
+        "value": "48",
+        "type": "borderRadius"
+      }
+    },
+    "focus": {
+      "use-case": {
+        "ring": {
+          "inner": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "4",
+              "color": "{o3.color.palette.white}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "outer": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "8",
+              "color": "{o3.color.palette.black-70}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "inverse": {
+            "inner": {
+              "value": {
+                "x": "0",
+                "y": "0",
+                "blur": "0",
+                "spread": "4",
+                "color": "{o3.color.palette.black-70}",
+                "type": "dropShadow"
+              },
+              "type": "boxShadow"
+            },
+            "outer": {
+              "value": {
+                "x": "0",
+                "y": "0",
+                "blur": "0",
+                "spread": "8",
+                "color": "{o3.color.palette.white}",
+                "type": "dropShadow"
+              },
+              "type": "boxShadow"
+            }
+          }
+        },
+        "outline": {
+          "color": {
+            "value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "2",
+              "color": "{o3.color.palette.black-50}",
+              "type": "dropShadow"
+            },
+            "type": "boxShadow"
+          },
+          "inverse": {
+            "color": {
+              "value": {
+                "x": "0",
+                "y": "0",
+                "blur": "0",
+                "spread": "2",
+                "color": "{o3.color.palette.white}",
+                "type": "dropShadow"
+              },
+              "type": "boxShadow"
+            }
+          }
+        }
+      }
+    },
+    "icons": {
+      "ft-icon": {
+        "arrow-left": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M16 4L8 12L16 20\" stroke=\"black\" stroke-width=\"2\"/>\n</svg>",
+          "type": "asset"
+        },
+        "arrow-right": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M8 4L16 12L8 20\" stroke=\"black\" stroke-width=\"2\"/>\n</svg>",
+          "type": "asset"
+        },
+        "arrow-down": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M20 8L12 16L4 8\" stroke=\"black\" stroke-width=\"2\"/>\n</svg>",
+          "type": "asset"
+        },
+        "arrow-up": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M20 16L12 8L4 16\" stroke=\"black\" stroke-width=\"2\"/>\n</svg>",
+          "type": "asset"
+        },
+        "cross": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M4.92893 17.6569L6.34315 19.0711L12 13.4142L17.6569 19.0711L19.0711 17.6569L13.4142 12L19.0711 6.34315L17.6569 4.92893L12 10.5858L6.34315 4.92894L4.92893 6.34315L10.5858 12L4.92893 17.6569Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "download": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M11 4V13.4962L8.6585 11.4474L7.3415 12.9526L11.3415 16.4526L12 17.0288L12.6585 16.4526L16.6585 12.9526L15.3415 11.4474L13 13.4962V4H11ZM4 19V21H20V19H4Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "edit-filled": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M4 18V13.7716L15.1 2.67157L19.3284 6.9L8.22843 18H4ZM21 19H3V21H21V19Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "edit-outlined": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M4 16V18H6H7.46667H8.29509L8.88088 17.4142L18.4142 7.88088L19.8284 6.46667L18.4142 5.05245L16.9475 3.58579L15.5333 2.17157L14.1191 3.58579L4.58579 13.1191L4 13.7049V14.5333V16ZM7.46667 16L8 15.4667L15.5858 7.88088L17 6.46667L16.9475 6.41421L15.5858 5.05245L15.5333 5L14.1191 6.41421L6.53333 14L6 14.5333V16H7.46667ZM21 19H3V21H21V19Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "grid": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M11 5H5V11H11V5Z\" fill=\"black\"/>\n  <path d=\"M19 5H13V11H19V5Z\" fill=\"black\"/>\n  <path d=\"M5 13H11V19H5V13Z\" fill=\"black\"/>\n  <path d=\"M19 13H13V19H19V13Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "list": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M4 7H6V9H4V7Z\" fill=\"black\"/>\n  <path d=\"M20 7H8V9H20V7Z\" fill=\"black\"/>\n  <path d=\"M6 11H4V13H6V11Z\" fill=\"black\"/>\n  <path d=\"M4 15H6V17H4V15Z\" fill=\"black\"/>\n  <path d=\"M8 11H20V13H8V11Z\" fill=\"black\"/>\n  <path d=\"M20 15H8V17H20V15Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "plus": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M11 13V20H13V13H20V11H13V4H11V11H4V13H11Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "search": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M10 4C6.68629 4 4 6.68629 4 10C4 13.3137 6.68629 16 10 16C11.2958 16 12.4957 15.5892 13.4765 14.8907L18.2929 19.7071L19.7071 18.2929L14.8907 13.4765C15.5892 12.4957 16 11.2958 16 10C16 6.68629 13.3137 4 10 4ZM6 10C6 7.79086 7.79086 6 10 6C12.2091 6 14 7.79086 14 10C14 12.2091 12.2091 14 10 14C7.79086 14 6 12.2091 6 10Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "tick": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M4 13L8 17L19 6\" stroke=\"black\" stroke-width=\"2\"/>\n</svg>",
+          "type": "asset"
+        },
+        "upload": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M13 17V7.50377L15.3415 9.55257L16.6585 8.04742L12.6585 4.54742L12 3.97123L11.3415 4.54742L7.3415 8.04742L8.6585 9.55257L11 7.50377V17H13ZM4 19V21H20V19H4Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "refresh": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M16.1905 6.39291C14.9278 5.44922 13.3836 4.95935 11.8078 5.00264C10.232 5.04593 8.71695 5.61983 7.50796 6.63143C6.29897 7.64302 5.46682 9.03308 5.14626 10.5765C4.82569 12.12 5.03548 13.7264 5.74165 15.1358C6.44782 16.5451 7.60903 17.6749 9.03725 18.3421C10.4655 19.0093 12.0771 19.1749 13.6111 18.8121C15.1452 18.4492 16.5119 17.5792 17.4899 16.3429C18.4679 15.1066 19 13.5764 19 12V11L21 11V12C21 14.0268 20.3159 15.9942 19.0584 17.5838C17.801 19.1733 16.0438 20.2919 14.0715 20.7584C12.0991 21.2249 10.027 21.012 8.19075 20.1541C6.35447 19.2963 4.86149 17.8438 3.95355 16.0317C3.04562 14.2197 2.7759 12.1542 3.18805 10.1698C3.6002 8.18539 4.67011 6.39817 6.22452 5.09755C7.77893 3.79693 9.72685 3.05905 11.7529 3.0034C13.7144 2.94951 15.638 3.53819 17.2318 4.67688L17.911 3.50457L20.5022 8.00854L15.3061 8.00059L16.2233 6.41744L16.1905 6.39291Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "calendar": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M9 14V12H7V14H9Z\" fill=\"black\"/>\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M8 5V3H6V5H3V21H21V5H18V3H16V5H8ZM5 10H19V19H5V10Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "play": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M6 20V4L20 12L6 20Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "print": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5 3L5 9C3.34315 9 2 10.3431 2 12V17H5V21H19V17H22V12C22 10.3431 20.6569 9 19 9V3H5ZM17 5H7V8H17V5ZM17 14H7V19H17V14ZM19 12V11H18V12H19Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "signout": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M14 4H3V20H14V18H5V6H14V4Z\" fill=\"black\"/>\n  <path d=\"M22.4142 12L17.2071 6.79289L15.7929 8.20711L18.5858 11H9V13H18.5858L15.7929 15.7929L17.2071 17.2071L22.4142 12Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "speaker": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M3 15V9H7L14 4V20L7 15H3Z\" fill=\"black\"/>\n  <path d=\"M19.853 8.74719C19.4258 7.71592 18.7997 6.77889 18.0104 5.98959L19.0711 4.92893C19.9997 5.85752 20.7362 6.95991 21.2388 8.17317C21.7413 9.38642 22 10.6868 22 12C22 13.3132 21.7413 14.6136 21.2388 15.8268C20.7362 17.0401 19.9997 18.1425 19.0711 19.0711L18.0104 18.0104C18.7997 17.2211 19.4258 16.2841 19.853 15.2528C20.2801 14.2215 20.5 13.1162 20.5 12C20.5 10.8838 20.2801 9.77846 19.853 8.74719Z\" fill=\"black\"/>\n  <path d=\"M15.8891 8.11091C16.3998 8.62163 16.8049 9.22795 17.0813 9.89524C17.3577 10.5625 17.5 11.2777 17.5 12C17.5 12.7223 17.3577 13.4375 17.0813 14.1048C16.8049 14.772 16.3998 15.3784 15.8891 15.8891L16.9498 16.9497C17.5998 16.2997 18.1154 15.5281 18.4672 14.6788C18.819 13.8295 19 12.9193 19 12C19 11.0807 18.819 10.1705 18.4672 9.32122C18.1154 8.47194 17.5998 7.70026 16.9498 7.05025L15.8891 8.11091Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "user-filled": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M12 12C14.2091 12 16 10.2091 16 8C16 5.79086 14.2091 4 12 4C9.79086 4 8 5.79086 8 8C8 10.2091 9.79086 12 12 12Z\" fill=\"black\"/>\n  <path d=\"M5 18C5 16.1194 7 13 12 13C17 13 19 16.1194 19 18V21H5V18Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "user-outlined": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M16 8C16 10.2091 14.2091 12 12 12C9.79086 12 8 10.2091 8 8C8 5.79086 9.79086 4 12 4C14.2091 4 16 5.79086 16 8ZM14 8C14 9.10457 13.1046 10 12 10C10.8954 10 10 9.10457 10 8C10 6.89543 10.8954 6 12 6C13.1046 6 14 6.89543 14 8Z\" fill=\"black\"/>\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 13C17 13 19 16.1194 19 18V21H5V18C5 16.1194 7 13 12 13ZM7 18C7 17.4127 7.90585 15 12 15C16.0941 15 17 17.4127 17 18V19H7V18Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "speech-left": {
+          "value": "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M7.324 18C9.46 18 11.5 16.2617 11.5 13.9727C11.5 10.9995 8.857 9.48929 6.304 9.94533C6.304 7.97608 8.068 6.37403 11.314 5.87062L11.176 5C6.025 5.3672 2.5 8.84374 2.5 12.9185C2.5 16.3979 4.774 18 7.324 18ZM17.324 18C19.46 18 21.5 16.2617 21.5 13.9727C21.5 10.9995 18.857 9.48929 16.304 9.94533C16.304 7.97608 18.068 6.37403 21.314 5.87062L21.176 5C16.025 5.3672 12.5 8.84374 12.5 12.9185C12.5 16.3979 14.774 18 17.324 18Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "error": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" fill=\"none\">\n  <path d=\"M15.4528 11.25V8.75H4.54718V11.25H15.4528Z\" fill=\"black\"/>\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10ZM18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "success": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M18 5H6C5.44772 5 5 5.44772 5 6V18C5 18.5523 5.44772 19 6 19H18C18.5523 19 19 18.5523 19 18V6C19 5.44772 18.5523 5 18 5ZM6 3C4.34315 3 3 4.34315 3 6V18C3 19.6569 4.34315 21 6 21H18C19.6569 21 21 19.6569 21 18V6C21 4.34315 19.6569 3 18 3H6Z\" fill=\"black\"/>\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M17.2584 9.4923L10.1217 16.629L6.74162 13.2489L8.15584 11.8347L10.1217 13.8006L15.8442 8.07809L17.2584 9.4923Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "minus": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <rect x=\"5\" y=\"10.25\" width=\"14\" height=\"3.5\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        }
+      },
+      "ft-social": {
+        "facebook": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M13.5419 22V12.8768H16.5169L16.959 9.32329H13.5419V7.05214C13.5419 6.02472 13.8192 5.32175 15.2505 5.32175H17.0789V2.13905C16.7642 2.0927 15.6776 2 14.4187 2C11.7809 2 9.98247 3.66087 9.98247 6.70452V9.33102H7V12.8845H9.98247V22H13.5419V22Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "linkedin": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.06474 7.93165C6.41941 7.93165 7.26418 7.04798 7.26418 5.94422C7.23925 4.81651 6.41998 3.95847 5.0908 3.95847C3.76161 3.95847 2.89192 4.81595 2.89192 5.94422C2.89192 7.04798 3.73555 7.93165 5.04037 7.93165H5.06474ZM21.0221 20.9995V14.407C21.0221 10.8746 19.1048 9.23091 16.5484 9.23091C14.4855 9.23091 13.5609 10.3469 13.0459 11.1303V9.50114H9.15917C9.21072 10.5804 9.15917 20.9995 9.15917 20.9995H13.0459V14.5781C13.0459 14.2354 13.0708 13.8916 13.1739 13.6465C13.4544 12.9595 14.094 12.2485 15.1671 12.2485C16.5739 12.2485 17.136 13.3027 17.136 14.8483V21L21.0221 20.9995ZM7.00836 9.50123V20.9996H3.12222V9.50123H7.00836Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        },
+        "x": {
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\">\n  <path d=\"M13.443 10.7118L19.3644 3.97656H17.9612L12.8196 9.82466L8.71303 3.97656H3.97657L10.1865 12.8199L3.97657 19.8828H5.37985L10.8095 13.707L15.1464 19.8828H19.8828L13.4426 10.7118H13.443ZM11.521 12.8978L10.8918 12.0172L5.88547 5.01021H8.04082L12.081 10.6651L12.7102 11.5457L17.9619 18.8962H15.8065L11.521 12.8982V12.8978Z\" fill=\"black\"/>\n</svg>",
+          "type": "asset"
+        }
+      }
+    },
+    "color": {
+      "modifier": {
+        "10": {
+          "value": "0.1",
+          "type": "number"
+        },
+        "20": {
+          "value": "0.2",
+          "type": "number"
+        },
+        "30": {
+          "value": "0.3",
+          "type": "number"
+        },
+        "40": {
+          "value": "0.4",
+          "type": "number"
+        },
+        "50": {
+          "value": "0.5",
+          "type": "number"
+        },
+        "60": {
+          "value": "0.6",
+          "type": "number"
+        },
+        "70": {
+          "value": "0.7",
+          "type": "number"
+        },
+        "80": {
+          "value": "0.8",
+          "type": "number"
+        },
+        "90": {
+          "value": "0.9",
+          "type": "number"
+        }
+      },
+      "pallete": {
+        "transparent": {
+          "value": "rgba(0,0,0,0)",
+          "type": "color"
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/theme/core-inverse.json
+++ b/apps/dictionary/tokens/theme/core-inverse.json
@@ -1,0 +1,20 @@
+{
+  "o3": {
+    "color": {
+      "use-case": {
+        "button": {
+          "primary": {
+            "background": {
+              "value": "{o3.color.palette.white}",
+              "type": "color"
+            },
+            "text": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/dictionary/tokens/theme/professional-inverse.json
+++ b/apps/dictionary/tokens/theme/professional-inverse.json
@@ -1,0 +1,95 @@
+{
+  "o3": {
+    "color": {
+      "use-case": {
+        "link": {
+          "text": {
+            "@": {
+              "value": "{o3.color.palette.mint}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{o3.color.palette.mint-70}",
+              "type": "color"
+            },
+            "focus": {
+              "value": "#8fb3a1",
+              "type": "color"
+            }
+          },
+          "underline": {
+            "@": {
+              "value": "{o3.color.palette.mint}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{o3.color.palette.mint-70}",
+              "type": "color"
+            },
+            "focus": {
+              "value": "{o3.color.palette.black}",
+              "type": "color"
+            }
+          }
+        },
+        "button": {
+          "primary": {
+            "background": {
+              "value": "{o3.color.palette.mint}",
+              "type": "color"
+            },
+            "text": {
+              "value": "{o3.color.palette.slate}",
+              "type": "color"
+            },
+            "hover": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "lch"
+                    }
+                  }
+                }
+              }
+            },
+            "focus": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.20}",
+                      "space": "lch"
+                    }
+                  }
+                }
+              }
+            },
+            "active": {
+              "background": {
+                "value": "{o3.color.use-case.button.primary.background}",
+                "type": "color",
+                "$extensions": {
+                  "studio.tokens": {
+                    "modify": {
+                      "type": "darken",
+                      "value": "{o3.color.modifier.40}",
+                      "space": "lch"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes

This is a draft PR for the structure of the proposed token that takes inheritance and reduces duplication. More details are on 
[this Figma Jam board](https://www.figma.com/board/JH6pR3Q0hgc7dIOPuCbwOA/Tokens-studio-improvements?node-id=0-1&node-type=canvas&t=h5AEa9YYBtmUNHPe-0). This PR does not remove old tokens and just adds new structure. It contains an example of how we can brand the o3-button. 

We moved shared tokens to the foundation set and enabled it for all brands. We moved icons and utility tokens inside there as well.

We introduced colour modifier tokens so we could darken or lighten colours. This is very useful for changing colours in different states, such as hover, active, and focus.
