### PR TITLE
fix: Correctly detect truly circular paths in JS objects, rather than objects with multiple references

### DIFF
--- a/libraries/o-tracking/src/javascript/core/send.js
+++ b/libraries/o-tracking/src/javascript/core/send.js
@@ -1,5 +1,5 @@
 import {get as getSetting} from './settings.js';
-import {broadcast, is, findCircularPathsIn, containsCircularPaths, merge, addEvent, log} from '../utils.js';
+import {broadcast, is, safelyStringifyJson, merge, addEvent, log} from '../utils.js';
 import {Queue} from './queue.js';
 import {get as getTransport} from './transports/index.js';
 
@@ -68,15 +68,7 @@ function sendRequest(request, callback) {
 	log('user_callback', user_callback);
 	log('PreSend', request);
 
-	if (containsCircularPaths(request)) {
-		const errorMessage = "o-tracking does not support circular references in the analytics data.\n" +
-		"Please remove the circular references in the data.\n" +
-		"Here are the paths in the data which are circular:\n" +
-		JSON.stringify(findCircularPathsIn(request), undefined, 4);
-		throw new Error(errorMessage);
-	}
-
-	const stringifiedData = JSON.stringify(request);
+	const stringifiedData = safelyStringifyJson(request);
 
 	transport.complete(function (error) {
 		if (is(user_callback, 'function')) {

--- a/libraries/o-tracking/src/javascript/core/store.js
+++ b/libraries/o-tracking/src/javascript/core/store.js
@@ -1,4 +1,4 @@
-import {broadcast, containsCircularPaths, decode, encode, findCircularPathsIn, is} from '../utils.js';
+import {broadcast, safelyStringifyJson, decode, encode, is} from '../utils.js';
 
 /**
  * Class for storing data
@@ -172,14 +172,7 @@ Store.prototype.write = function (data) {
 	if (typeof this.data === 'string') {
 		value = this.data;
 	} else {
-		if (containsCircularPaths(this.data)) {
-			const errorMessage = "o-tracking does not support circular references in the analytics data.\n" +
-			"Please remove the circular references in the data.\n" +
-			"Here are the paths in the data which are circular:\n" +
-			JSON.stringify(findCircularPathsIn(this.data), undefined, 4);
-			throw new Error(errorMessage);
-		}
-		value = JSON.stringify(this.data);
+		value = safelyStringifyJson(this.data);
 	}
 
 	this.storage.save(this.storageKey, value);

--- a/libraries/o-tracking/src/javascript/tracking.js
+++ b/libraries/o-tracking/src/javascript/tracking.js
@@ -17,7 +17,7 @@ const initPage = page.init;
  *
  * @type {string}
  */
-const version = '4.6.0';
+const version = '4.6.1';
 
 /**
  * The source of this event.

--- a/libraries/o-tracking/src/javascript/utils.js
+++ b/libraries/o-tracking/src/javascript/utils.js
@@ -241,100 +241,131 @@ function assignIfUndefined (subject, target) {
 	}
 }
 
-/**
- * Used to find out all the paths which contain a circular reference.
- *
- * @param {*} rootObject The object we want to search within for circular references
- * @returns {string[]} Returns an array of strings, the strings are the full paths to the circular references within the rootObject
- */
-function findCircularPathsIn(rootObject) {
-	const traversedValues = new WeakSet();
-	const circularPaths = [];
-
-	function _findCircularPathsIn(currentObject, path) {
-		// If we already saw this object
-		// the rootObject contains a circular reference
-		// and we can stop looking any further into this currentObj
-		if (traversedValues.has(currentObject)) {
-			circularPaths.push(path);
-			return;
-		}
-
-		// Only Objects and things which inherit from Objects can contain circular references
-		// I.E. string/number/boolean/template literals can not contain circular references
-		if (currentObject instanceof Object) {
-			traversedValues.add(currentObject);
-
-			// Loop through all the values of the current object and search those for circular references
-			for (const [key, value] of Object.entries(currentObject)) {
-				// No need to recurse on every value because only things which inherit
-				// from Objects can contain circular references
-				if (value instanceof Object) {
-					const parentObjectIsAnArray = Array.isArray(currentObject);
-					if (parentObjectIsAnArray) {
-					// Store path in bracket notation when value is an array
-						_findCircularPathsIn(value, `${path}[${key}]`);
-					} else {
-					// Store path in dot-notation when value is an object
-						_findCircularPathsIn(value, `${path}.${key}`);
-					}
-				}
-			}
-		}
-	}
-
-	_findCircularPathsIn(rootObject, "");
-	return circularPaths;
-}
 
 /**
- * Used to find out whether an object contains a circular reference.
+ * Identify circular references in 'object', and replace them with a string representation
+ * of the reference. Returns a succesfully serialised JSON string, and a list of circular
+ * references which were removed.
+ * 
+ * Inspired by https://github.com/sindresorhus/safe-stringify and 
+ * https://github.com/sindresorhus/decircular
  *
- * @param {object} rootObject The object we want to search within for circular references
- * @returns {boolean} Returns true if a circular reference was found, otherwise returns false
+ * @param {*} object The object we want to stringify, and search within for circular references
+ * @returns {Object: {jsonString: string, warnings: array}} The stringified object, and a warnings for each circular reference which was removed
  */
-function containsCircularPaths(rootObject) {
-	// Used to keep track of all the values the rootObject contains
-	const traversedValues = new WeakSet();
+function removeCircularReferences(object) {
 
-	/**
-	 *
-	 * @param {*} currentObject The current object we want to search within for circular references
-	 * @returns {boolean|undefined} Returns true if a circular reference was found, otherwise returns undefined
-	 */
-	function _containsCircularPaths(currentObject) {
-		// If we already saw this object
-		// the rootObject contains a circular reference
-		// and we can stop looking any further
-		if (traversedValues.has(currentObject)) {
-			return true;
+	// WeakMaps release memory when all references are garbage-collected
+	const circularReferences = new WeakMap();
+	const paths = new WeakMap();
+
+	const warnings = [];
+
+	function getPathFragment(parent, key) {
+		if (!key) {
+			return '$';
 		}
 
-		// Only Objects and things which inherit from Objects can contain circular references
-		// I.E. string/number/boolean/template literals can not contain circular references
-		if (currentObject instanceof Object) {
-			traversedValues.add(currentObject);
-			// Loop through all the values of the current object and search those for circular references
-			for (const value of Object.values(currentObject)) {
-				// No need to recurse on every value because only things which inherit
-				// from Objects can contain circular references
-				if (value instanceof Object) {
-					if (_containsCircularPaths(value)) {
-						return true;
-					}
-				}
-			}
+		if (Array.isArray(parent)) {
+			return `[${key}]`;
 		}
+
+		return `.${key}`;
 	}
 
-	// _containsCircularPaths returns true or undefined.
-	// By using Boolean we convert the undefined into false.
-	return Boolean(
-		_containsCircularPaths(
-			rootObject
-		)
-	);
+	function formatCircularReferencesWarning(references) {
+		const paths = references.map(path => '`' + path.join('') + '`');
+		return 'Circular reference between ' + paths.join(' AND ');
+	}
+
+	function replacer(key, value) {
+		// Scalars don't need to be inspected as they can't contain circular references
+		if (!(value !== null && typeof value === 'object')) {
+			return value
+		}
+
+		// Record the path from the root ($) to the current object (value)
+		// in order to print helpful circular reference warnings.
+		const path = [...paths.get(this) || [], getPathFragment(this, key)];
+		paths.set(value, path);
+
+		// If a reference to the current value is already in the list, we have
+		// a circular reference. Add the current value to the list along with its path,
+		// and return a useful error string rather than the unserialisable value.
+		if (circularReferences.has(value)) {
+			const references = [...circularReferences.get(value), path];
+			circularReferences.set(value, references);
+			const warning = formatCircularReferencesWarning(references);
+			warnings.push(warning);
+			return warning;
+		}
+
+		// This is the first time we've seen the current value in this branch 
+		// of the object. Record its path from the object root.
+		circularReferences.set(value, [path]);
+
+		// Recurse into the value to proactively find circular references
+		// before encountering a loop.
+		const newValue = Array.isArray(value) ? [] : {};
+		for (const [k, v] of Object.entries(value)) {
+			newValue[k] = replacer.call(value, k, v);
+		}
+
+		// All circular references to this object will have been identified,
+		// so remove it from the list.
+		circularReferences.delete(value);
+
+		// This branch of the object can now be safely serialised to a JSON string
+		return newValue;
+	}
+
+	const jsonString = JSON.stringify(object, replacer);
+	return {jsonString, warnings};
 }
+
+
+/**
+ * Stringify an object to JSON, removing any circular references. When circular references
+ * are found, an error is thrown in a new event loop so that global error handlers can report it.
+ *
+ * @param {*} object The object we want to stringify, and search within for circular references
+ * @returns {string} The safely stringified JSON string
+ */
+function safelyStringifyJson(object) {
+
+	// JSON.stringify throws on two cases:
+	// - value contains a circular reference
+	// - A BigInt value is encountered
+	// Circular references are a real possibility in the way o-tracking is called (and saves a queue of 
+	// messages in a store), so we need to handle those gracefully.
+	// 
+	// However, for performance reasons, we always attempt to do a basic JSON.stringify() first. The 
+	// recursion involved in removeCircularReferences() makes it about 20x slower to stringify a basic payload. 
+	// This performance hit will be exacerbated on slow devices (e.g. old Android phones) with lots of queued offline events.
+	try {
+		return JSON.stringify(object);
+
+	// NB: error is discarded - we have more work to do in order to throw a useful message
+	} catch (error) {
+	
+		const {jsonString, warnings} = removeCircularReferences(object);
+	
+		if (warnings.length) {
+			// Throw in a new event loop, as we always want to return JSON so the tracking payload is sent
+			setTimeout(() => {
+				const errorMessage = "AssertionError: o-tracking does not support circular references in the analytics data.\n" +
+				"Please remove the circular references in the data.\n" +
+				"Here are the paths in the data which are circular:\n" +
+				warnings.join('\n');
+				throw new Error(errorMessage);
+			});
+		}
+	
+		return jsonString;
+	}
+
+
+};
 
 /**
  * Find out whether two objects are deeply equal to each other.
@@ -424,7 +455,7 @@ export {
 	sanitise,
 	assignIfUndefined,
 	filterProperties,
-	findCircularPathsIn,
-	containsCircularPaths,
+	removeCircularReferences,
+	safelyStringifyJson,
 	isDeepEqual
 };

--- a/libraries/o-tracking/test/core/store.test.js
+++ b/libraries/o-tracking/test/core/store.test.js
@@ -113,4 +113,28 @@ describe('Core.Store', function () {
 			});
 		});
 	});
+
+	it('should replace circular references with warning strings', function () {
+		const store = new Store('test');
+
+		const customTrackingData = {ohh: 'ahh'};
+		customTrackingData.circular = customTrackingData;
+
+		const request = {
+			context: {
+				customTrackingData,
+			},
+		};
+
+		store.write(request);
+
+		const newStore = new Store('test');
+		const written = newStore.read();
+
+		proclaim.deepEqual(written.context.customTrackingData, {
+			ohh: 'ahh',
+			circular:
+				'Circular reference between `$.context.customTrackingData` AND `$.context.customTrackingData.circular`',
+		});
+	});
 });

--- a/libraries/o-tracking/test/utils.test.js
+++ b/libraries/o-tracking/test/utils.test.js
@@ -14,8 +14,8 @@ import {
 	sanitise,
 	assignIfUndefined,
 	filterProperties,
-	findCircularPathsIn,
-	containsCircularPaths,
+	removeCircularReferences,
+	safelyStringifyJson,
 	guid
 } from '../src/javascript/utils.js';
 
@@ -122,67 +122,388 @@ describe('Utils', function () {
 		});
 	});
 
-	describe('findCircularPathsIn', function() {
-		it('should return an empty array if object contains no circular references', function() {
-			proclaim.deepStrictEqual(findCircularPathsIn({ a: 1, b: 2 }), []);
+	describe('removeCircularReferences', function () {
+		it('should handle circular references in objects', function () {
+			const object = {a: 1};
+			object.b = object; // Circular reference
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: 1,
+					b: 'Circular reference between `$` AND `$.b`',
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$.b`',
+			]);
 		});
 
-		it('should return an empty array if given a string literal', function() {
-			proclaim.deepStrictEqual(findCircularPathsIn(''), []);
+		it('should handle circular references in nested objects', function () {
+			const object = {
+				a: 1,
+				c: {},
+			};
+
+			object.c.d = object.c; // Circular reference
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: 1,
+					c: {
+						d: 'Circular reference between `$.c` AND `$.c.d`',
+					},
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$.c` AND `$.c.d`',
+			]);
 		});
 
-		it('should return an empty array if given a number literal', function() {
-			proclaim.deepStrictEqual(findCircularPathsIn(137), []);
+		it('should handle circular references in arrays', function () {
+			const array = [1, 2, 3];
+			array.push(array); // Circular reference
+
+			const {jsonString, warnings} = removeCircularReferences(array);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify([1, 2, 3, 'Circular reference between `$` AND `$[3]`'])
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$[3]`',
+			]);
 		});
 
-		it('should return an empty array if given a boolean literal', function() {
-			proclaim.deepStrictEqual(findCircularPathsIn(true), []);
+		it('should handle non-circular references in objects', function () {
+			const object = {
+				a: {
+					b: {
+						c: {
+							d: 1,
+						},
+					},
+				},
+			};
+			object.a.b.e = object.a.b.c;
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: {
+						b: {
+							c: {
+								d: 1,
+							},
+							e: {
+								d: 1,
+							},
+						},
+					},
+				})
+			);
+			proclaim.deepEqual(warnings, []);
 		});
 
-		it('should return an empty array if given null', function() {
-			proclaim.deepStrictEqual(findCircularPathsIn(null), []);
+		it('should handle complex structures with multiple circular references', function () {
+			const object = {
+				a: 1,
+				b: {
+					c: 2,
+				},
+				d: [],
+			};
+
+			object.b.e = object; // Circular reference
+			object.d.push(object.b); // Circular reference
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: 1,
+					b: {
+						c: 2,
+						e: 'Circular reference between `$` AND `$.b.e`',
+					},
+					d: [
+						{
+							c: 2,
+							e: 'Circular reference between `$` AND `$.b.e` AND `$.b.e.d[0].e`',
+						},
+					],
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$.b.e`',
+				'Circular reference between `$` AND `$.b.e` AND `$.b.e.d[0].e`',
+			]);
 		});
 
-		it('should return an array containing all the paths which are circular', function() {
-			const rootObject = {};
-			rootObject.a = rootObject;
-			rootObject.b = 2;
-			rootObject.c = '';
-			rootObject.d = null;
-			rootObject.e = true;
-			rootObject.f = [rootObject.a, 'carrot', rootObject];
-			rootObject.f.push(rootObject.f);
-			proclaim.deepStrictEqual(findCircularPathsIn(rootObject), [
-				'.a',
-				'.f[0]',
-				'.f[2]',
-				'.f[3]'
+		it('should handle circular references with array indices in the path', function () {
+			const object = {
+				a: [
+					{
+						b: 1,
+						c: 1,
+					},
+				],
+			};
+
+			object.a[0].d = object.a[0]; // Circular reference to the array element at index 1
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: [
+						{
+							b: 1,
+							c: 1,
+							d: 'Circular reference between `$.a[0]` AND `$.a[0].d`',
+						},
+					],
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$.a[0]` AND `$.a[0].d`',
+			]);
+		});
+
+		it('should handle deep nested circular references', function () {
+			const object = {
+				level1: {
+					level2: {
+						level3: {},
+					},
+				},
+			};
+
+			object.level1.level2.level3 = object.level1; // Circular reference to a higher level
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					level1: {
+						level2: {
+							level3:
+								'Circular reference between `$.level1` AND `$.level1.level2.level3`',
+						},
+					},
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$.level1` AND `$.level1.level2.level3`',
+			]);
+		});
+
+		it('should handle circular references in objects within arrays', function () {
+			const object = {
+				a: [],
+				b: [],
+			};
+
+			object.a[0] = object.b; // Circular reference to another object in the array
+			object.b[0] = object.a; // Circular reference to another object in the array
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: [['Circular reference between `$.a` AND `$.a[0][0]`']],
+					b: [['Circular reference between `$.b` AND `$.b[0][0]`']],
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$.a` AND `$.a[0][0]`',
+				'Circular reference between `$.b` AND `$.b[0][0]`',
+			]);
+		});
+
+		it('should handle self-referencing arrays', function () {
+			const array = [];
+			array[0] = array; // Array references itself
+
+			const {jsonString, warnings} = removeCircularReferences(array);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify(['Circular reference between `$` AND `$[0]`'])
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$[0]`',
+			]);
+		});
+
+		it('should handle circular references in mixed arrays and objects', function () {
+			const object = {
+				a: 1,
+				b: [
+					2,
+					{
+						c: 3,
+					},
+				],
+			};
+
+			object.b[1].ref = object; // Circular reference from an object in an array to the root
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: 1,
+					b: [
+						2,
+						{
+							c: 3,
+							ref: 'Circular reference between `$` AND `$.b[1].ref`',
+						},
+					],
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$.b[1].ref`',
+			]);
+		});
+
+		it('should handle circular references involving arrays and objects', function () {
+			const object = {
+				a: [
+					{
+						b: 1,
+					},
+				],
+			};
+
+			object.a.push(object); // Circular reference from array to object
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: [
+						{
+							b: 1,
+						},
+						'Circular reference between `$` AND `$.a[1]`',
+					],
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$.a[1]`',
+			]);
+		});
+
+		it('should handle empty objects', function () {
+			const object = {};
+			object.ref = object; // Circular reference in an empty object
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					ref: 'Circular reference between `$` AND `$.ref`',
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$.ref`',
+			]);
+		});
+
+		it('should handle empty arrays', function () {
+			const array = [];
+			array.push(array); // Circular reference in an empty array
+
+			const {jsonString, warnings} = removeCircularReferences(array);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify(['Circular reference between `$` AND `$[0]`'])
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$` AND `$[0]`',
+			]);
+		});
+
+		it('should handle circular references in large complex objects', function () {
+			const object = {
+				a: {
+					b: {
+						c: {
+							d: 1,
+						},
+					},
+				},
+				e: {
+					f: {
+						g: 2,
+					},
+				},
+			};
+
+			object.a.b.c.ref = object.e.f; // Circular reference
+			object.e.f.ref = object.a.b; // Circular reference
+
+			const {jsonString, warnings} = removeCircularReferences(object);
+			proclaim.deepEqual(
+				jsonString,
+				JSON.stringify({
+					a: {
+						b: {
+							c: {
+								d: 1,
+								ref: {
+									g: 2,
+									ref: 'Circular reference between `$.a.b` AND `$.a.b.c.ref.ref`',
+								},
+							},
+						},
+					},
+					e: {
+						f: {
+							g: 2,
+							ref: {
+								c: {
+									d: 1,
+									ref: 'Circular reference between `$.e.f` AND `$.e.f.ref.c.ref`',
+								},
+							},
+						},
+					},
+				})
+			);
+			proclaim.deepEqual(warnings, [
+				'Circular reference between `$.a.b` AND `$.a.b.c.ref.ref`',
+				'Circular reference between `$.e.f` AND `$.e.f.ref.c.ref`',
 			]);
 		});
 	});
 
-	describe('containsCircularPaths', function() {
-		it('should return false if object contains no circular references', function() {
-			proclaim.isFalse(containsCircularPaths({ a: 1, b: 2 }));
+	describe('safelyStringifyJson', function () {
+		it('should return a JSON string if object contains no circular references', function () {
+			proclaim.strictEqual(safelyStringifyJson({a: 1, b: 2}), '{"a":1,"b":2}');
 		});
 
-		it('should return false if given a string literal', function() {
-			proclaim.isFalse(containsCircularPaths(''));
+		it('should return a JSON empty string if given a string literal', function () {
+			proclaim.strictEqual(safelyStringifyJson(''), '""');
 		});
 
-		it('should return false if given a number literal', function() {
-			proclaim.isFalse(containsCircularPaths(137));
+		it('should return a JSON number if given a number literal', function () {
+			proclaim.strictEqual(safelyStringifyJson(137), '137');
 		});
 
-		it('should return false if given a boolean literal', function() {
-			proclaim.isFalse(containsCircularPaths(true));
+		it('should return the string true if given a boolean literal', function () {
+			proclaim.strictEqual(safelyStringifyJson(true), 'true');
 		});
 
-		it('should return false if given null', function() {
-			proclaim.isFalse(containsCircularPaths(null));
+		it('should return the string null if given null', function () {
+			proclaim.strictEqual(safelyStringifyJson(null), 'null');
 		});
 
-		it('should return true if given an object which contains circular references', function() {
+		it('should throw an informative error listing all the paths which are circular', function (done) {
 			const rootObject = {};
 			rootObject.a = rootObject;
 			rootObject.b = 2;
@@ -191,7 +512,36 @@ describe('Utils', function () {
 			rootObject.e = true;
 			rootObject.f = [rootObject.a, 'carrot', rootObject];
 			rootObject.f.push(rootObject.f);
-			proclaim.isTrue(containsCircularPaths(rootObject));
+
+			const onerror = window.onerror;
+			let errorMessage;
+			window.onerror = function errorHandler(message) {
+				errorMessage = message;
+			};
+
+			safelyStringifyJson(rootObject);
+
+			setTimeout(() => {
+				proclaim.include(errorMessage, 'AssertionError');
+				proclaim.include(
+					errorMessage,
+					'Circular reference between `$` AND `$.a`'
+				);
+				proclaim.include(
+					errorMessage,
+					'Circular reference between `$` AND `$.a` AND `$.a.f[0]`'
+				);
+				proclaim.include(
+					errorMessage,
+					'Circular reference between `$` AND `$.a` AND `$.a.f[0]` AND `$.a.f[2]`'
+				);
+				proclaim.include(
+					errorMessage,
+					'Circular reference between `$.a.f` AND `$.a.f[3]`'
+				);
+				window.onerror = onerror;
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION
[This conversation](https://financialtimes.slack.com/archives/C07U72QTQCA/p1730548886171719?thread_ts=1730484139.054259&cid=C07U72QTQCA) uncovered an issue whereby multiple offline calls to `track()` could potentially share object references (for example, in the additional `context` object).

The previous `containsCircularPaths()` implementation wasn't really looking for **circular** paths, but rather multiple references to the same object. See the [original PR](https://github.com/Financial-Times/o-tracking/pull/263) and [issue](https://github.com/Financial-Times/o-tracking/issues/115).

A use-case which is common in an offline-first application such as FT App - queueing multiple events to be stored and sent when next online - is somewhat likely to include a shared reference across the events at some point in the event tracking. This causes an `o-tracking does not support circular references in the analytics data` error, which discards the whole queue of events.

## Describe your changes
This implementation is based on https://github.com/sindresorhus/decircular and https://github.com/sindresorhus/decircular, and draws on the utility of `JSON.serialize()`'s [**replacer** parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). 

Circular references are removed before sending over the network, or storing in LocalStorage. They are replaced with a string reference (e.g. ``Circular reference between `$.context.customTrackingData` AND `$.context.customTrackingData.circular` ``), and an error is thrown in the next event loop to warn that the data has been modified.

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
