### PR TITLE
Replace o-buttons with o-private-foundation in o-table [OR-1051]

### DIFF
--- a/components/o-private-foundation/main.scss
+++ b/components/o-private-foundation/main.scss
@@ -1,4 +1,18 @@
 @use './src/scss/brand' with (
 	$o-brand: $o-brand
 );
+
+@forward './src/scss/brand' as o-private-foundation-*;
+
 @import './src/scss/variables';
+
+@import './src/scss/o-buttons/main';
+
+@font-face {
+	src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=Metric2-VF&system_code=origami&font_format=woff2')
+		format('woff2-variations');
+	font-family: 'metric 2 VF';
+	font-weight: 300 800;
+	font-style: normal;
+	font-display: swap;
+}

--- a/components/o-private-foundation/src/scss/o-buttons/main.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/main.scss
@@ -21,7 +21,7 @@
 	);
 	--_o-pf-button-font-weight: #{brand.get('o3-font-weight-semibold')};
 
-	/* SMALL BUTTON */
+	/* Button Sizes */
 	@if ($size == 'big') {
 		--_o-pf-button-min-width: 80px;
 		--_o-pf-button-min-height: 40px;

--- a/components/o-private-foundation/src/scss/o-buttons/main.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/main.scss
@@ -57,7 +57,7 @@
 	font-size: var(--_o-pf-button-font-size);
 	line-height: var(--_o-pf-button-lineheight);
 	font-weight: var(--_o-pf-button-font-weight);
-	font-family: #{brand.get('o3-font-family-metric')} + ', sans-serif';
+	font-family: '#{brand.get('o3-font-family-metric')}', 'sans-serif';
 	border: var(--_o-pf-button-border-size) solid transparent;
 	text-align: center;
 	text-decoration: none;
@@ -119,17 +119,15 @@
 		}
 
 		/*
-        Ensure iconography is maintained when forced colours is enabled.
-        E.g. Windows High Contrast Mode
-        https://drafts.csswg.org/css-color/#valdef-color-buttontext
-     */
+        	Ensure iconography is maintained when forced colours is enabled.
+        	E.g. Windows High Contrast Mode
+        	https://drafts.csswg.org/css-color/#valdef-color-buttontext
+     	*/
 		@media (forced-colors: active) {
-			/* stylelint-disable-next-line selector-no-qualifying-type */
-			#{&}:is(button)::before {
+			&:is(button)::before {
 				background-color: ButtonText;
 			}
-			/* stylelint-disable-next-line selector-no-qualifying-type */
-			#{&}:is(a)::before {
+			&:is(a)::before {
 				background-color: LinkText;
 			}
 		}

--- a/components/o-private-foundation/src/scss/o-buttons/main.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/main.scss
@@ -10,6 +10,7 @@
 	$theme: map-get($opts, 'theme');
 	$theme: if($theme, $theme, 'standard');
 	$type: map-get($opts, 'type');
+	$type: if($type, $type, 'primary');
 	$icon-only: map-get($opts, 'icon-only');
 	$size: map-get($opts, 'size');
 	$icon: map-get($opts, 'icon');
@@ -74,29 +75,41 @@
 
 	/* TYPE / THEME  */
 
-	color: brand.get('_o3-button-primary-standard-color');
-	background-color: brand.get('_o3-button-primary-standard-background');
-	border-color: brand.get('_o3-button-primary-standard-border');
+	color: brand.get('_o3-button-' + $type + '-' + $theme + '-color');
+	background-color: brand.get(
+		'_o3-button-' + $type + '-' + $theme + '-background'
+	);
+	border-color: brand.get('_o3-button-' + $type + '-' + $theme + '-border');
 
 	&:hover {
-		color: brand.get('_o3-button-primary-standard-hover-color');
-		background-color: brand.get('_o3-button-primary-standard-hover-background');
-		border-color: brand.get('_o3-button-primary-standard-hover-border');
+		color: brand.get('_o3-button-' + $type + '-' + $theme + '-hover-color');
+		background-color: brand.get(
+			'_o3-button-' + $type + '-' + $theme + '-hover-background'
+		);
+		border-color: brand.get(
+			'_o3-button-' + $type + '-' + $theme + '-hover-border'
+		);
 	}
 
 	&:focus-visible {
 		outline: 0; // Undo standard o2 focus styles
-		color: brand.get('_o3-button-primary-standard-focus-color');
-		background-color: brand.get('_o3-button-primary-standard-focus-background');
-		border-color: brand.get('_o3-button-primary-standard-focus-border');
+		color: brand.get('_o3-button-' + $type + '-' + $theme + '-focus-color');
+		background-color: brand.get(
+			'_o3-button-' + $type + '-' + $theme + '-focus-background'
+		);
+		border-color: brand.get(
+			'_o3-button-' + $type + '-' + $theme + '-focus-border'
+		);
 	}
 
 	&:is(:active, [aria-selected='true'], [aria-current], [aria-pressed='true']) {
-		color: brand.get('_o3-button-primary-standard-active-color');
+		color: brand.get('_o3-button-' + $type + '-' + $theme + '-active-color');
 		background-color: brand.get(
-			'_o3-button-primary-standard-active-background'
+			'_o3-button-' + $type + '-' + $theme + '-active-background'
 		);
-		border-color: brand.get('_o3-button-primary-standard-active-border');
+		border-color: brand.get(
+			'_o3-button-' + $type + '-' + $theme + '-active-border'
+		);
 	}
 
 	/* ICON */

--- a/components/o-private-foundation/src/scss/o-buttons/main.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/main.scss
@@ -1,0 +1,147 @@
+@mixin oPrivateButtonsContent(
+	$opts: (
+		'type': null,
+		'theme': null,
+		'size': null,
+		'icon': null,
+		'icon-only': false,
+	)
+) {
+	$theme: map-get($opts, 'theme');
+	$theme: if($theme, $theme, 'standard');
+	$type: map-get($opts, 'type');
+	$icon-only: map-get($opts, 'icon-only');
+	$size: map-get($opts, 'size');
+	$icon: map-get($opts, 'icon');
+
+	--_o-pf-button-border-size: 1px;
+	--_o-pf-button-icon-size: calc(
+		var(--_o-pf-button-min-height) - (var(--_o-pf-button-block-padding) * 2)
+	);
+	--_o-pf-button-font-weight: #{brand.get('o3-font-weight-semibold')};
+
+	/* SMALL BUTTON */
+	@if ($size == 'big') {
+		--_o-pf-button-min-width: 80px;
+		--_o-pf-button-min-height: 40px;
+
+		--_o-pf-button-inline-padding-start: #{brand.get('o3-spacing-2xs')};
+		--_o-pf-button-inline-padding-end: #{brand.get('o3-spacing-2xs')};
+		--_o-pf-button-block-padding: #{brand.get('o3-spacing-4xs')};
+
+		--_o-pf-button-font-size: #{brand.get('o3-font-size-metric2-negative-1')};
+		--_o-pf-button-lineheight: #{brand.get(
+				'o3-font-lineheight-metric2-negative-1'
+			)};
+	} @else {
+		--_o-pf-button-min-width: 60px;
+		--_o-pf-button-min-height: 28px;
+
+		--_o-pf-button-inline-padding-start: #{brand.get('o3-spacing-4xs')};
+		--_o-pf-button-inline-padding-end: #{brand.get('o3-spacing-4xs')};
+		--_o-pf-button-block-padding: #{brand.get('o3-spacing-5xs')};
+
+		--_o-pf-button-font-size: #{brand.get('o3-font-size-negative-2')};
+		--_o-pf-button-lineheight: #{brand.get('o3-font-lineheight-negative-2')};
+	}
+
+	min-width: var(--_o-pf-button-min-width);
+	min-height: var(--_o-pf-button-min-height);
+	padding: 0 var(--_o-pf-button-inline-padding-end) 0
+		var(--_o-pf-button-inline-padding-start);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	vertical-align: middle;
+	font-size: var(--_o-pf-button-font-size);
+	line-height: var(--_o-pf-button-lineheight);
+	font-weight: var(--_o-pf-button-font-weight);
+	font-family: #{brand.get('o3-font-family-metric')} + ', sans-serif';
+	border: var(--_o-pf-button-border-size) solid transparent;
+	text-align: center;
+	text-decoration: none;
+	cursor: pointer;
+	transition: 0.3s background-color, 0.15s color ease-out,
+		0.15s border-color ease-out;
+	appearance: none;
+
+	&[disabled] {
+		pointer-events: none;
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	/* TYPE / THEME  */
+
+	color: brand.get('_o3-button-primary-standard-color');
+	background-color: brand.get('_o3-button-primary-standard-background');
+	border-color: brand.get('_o3-button-primary-standard-border');
+
+	&:hover {
+		color: brand.get('_o3-button-primary-standard-hover-color');
+		background-color: brand.get('_o3-button-primary-standard-hover-background');
+		border-color: brand.get('_o3-button-primary-standard-hover-border');
+	}
+
+	&:focus-visible {
+		outline: 0; // Undo standard o2 focus styles
+		color: brand.get('_o3-button-primary-standard-focus-color');
+		background-color: brand.get('_o3-button-primary-standard-focus-background');
+		border-color: brand.get('_o3-button-primary-standard-focus-border');
+	}
+
+	&:is(:active, [aria-selected='true'], [aria-current], [aria-pressed='true']) {
+		color: brand.get('_o3-button-primary-standard-active-color');
+		background-color: brand.get(
+			'_o3-button-primary-standard-active-background'
+		);
+		border-color: brand.get('_o3-button-primary-standard-active-border');
+	}
+
+	/* ICON */
+	@if ($icon) {
+		--_o-pf-button-inline-padding-end: #{brand.get('o3-spacing-s')};
+		@if ($size != 'big') {
+			--_o-pf-button-inline-padding-end: #{brand.get('o3-spacing-4xs')};
+		}
+
+		&::before {
+			content: '';
+			width: var(--_o-pf-button-icon-size);
+			height: var(--_o-pf-button-icon-size);
+			mask-image: #{brand.get('o3-icons-ft-icon-' + $icon)};
+			mask-repeat: no-repeat;
+			mask-size: contain;
+			display: inline-block;
+			background-color: currentColor;
+			margin-right: #{brand.get('o3-spacing-4xs')};
+		}
+
+		/*
+        Ensure iconography is maintained when forced colours is enabled.
+        E.g. Windows High Contrast Mode
+        https://drafts.csswg.org/css-color/#valdef-color-buttontext
+     */
+		@media (forced-colors: active) {
+			/* stylelint-disable-next-line selector-no-qualifying-type */
+			#{&}:is(button)::before {
+				background-color: ButtonText;
+			}
+			/* stylelint-disable-next-line selector-no-qualifying-type */
+			#{&}:is(a)::before {
+				background-color: LinkText;
+			}
+		}
+	}
+
+	// ICON ONLY
+	@if ($icon-only) {
+		--_o-pf-button-min-width: var(--_o-pf-button-min-height);
+		--_o-pf-button-inline-padding-start: 0;
+		--_o-pf-button-inline-padding-end: 0;
+		&::before {
+			margin-right: 0;
+		}
+	}
+}

--- a/components/o-table/demos/src/demo.scss
+++ b/components/o-table/demos/src/demo.scss
@@ -1,16 +1,15 @@
-@import "./../../main";
+@import './../../main';
 @include oTable();
 @import '@financial-times/o-fonts/main';
 @include oFonts();
 
-@import "@financial-times/o-normalise/main";
+@import '@financial-times/o-normalise/main';
 @include oNormalise();
-@import "@financial-times/o-typography/main";
+@import '@financial-times/o-typography/main';
 @include oTypography();
-@import "@financial-times/o-forms/main";
+@import '@financial-times/o-forms/main';
 @include oForms();
-@import "@financial-times/o-buttons/main";
-@include oButtons();
+
 html {
 	background: oColorsByUsecase('page', 'background');
 }

--- a/components/o-table/main.scss
+++ b/components/o-table/main.scss
@@ -1,43 +1,45 @@
 // Dependancies
 @import '@financial-times/math';
-@import "@financial-times/o-spacing/main";
-@import "@financial-times/o-brand/main";
-@import "@financial-times/o-buttons/main";
-@import "@financial-times/o-colors/main";
-@import "@financial-times/o-grid/main";
-@import "@financial-times/o-icons/main";
-@import "@financial-times/o-typography/main";
-@import "@financial-times/o-visual-effects/main";
+@import '@financial-times/o-spacing/main';
+@import '@financial-times/o-brand/main';
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-grid/main';
+@import '@financial-times/o-icons/main';
+@import '@financial-times/o-typography/main';
+@import '@financial-times/o-visual-effects/main';
+@import '@financial-times/o-private-foundation/main';
 
 // Branding
-@import "src/scss/brand";
+@import 'src/scss/brand';
 // Main
-@import "src/scss/variables";
-@import "src/scss/base";
-@import "src/scss/borders";
-@import "src/scss/compact";
-@import "src/scss/container";
-@import "src/scss/lines";
-@import "src/scss/responsive-overflow";
-@import "src/scss/responsive-flat";
-@import "src/scss/responsive-scroll";
-@import "src/scss/row-headings";
-@import "src/scss/row-stripes";
-@import "src/scss/sort";
-@import "src/scss/wrapper";
+@import 'src/scss/variables';
+@import 'src/scss/base';
+@import 'src/scss/borders';
+@import 'src/scss/compact';
+@import 'src/scss/container';
+@import 'src/scss/lines';
+@import 'src/scss/responsive-overflow';
+@import 'src/scss/responsive-flat';
+@import 'src/scss/responsive-scroll';
+@import 'src/scss/row-headings';
+@import 'src/scss/row-stripes';
+@import 'src/scss/sort';
+@import 'src/scss/wrapper';
 
 /// Outputs all features and styles available.
 /// @param {list} $opts [('responsive-overflow', 'responsive-flat', 'responsive-scroll', 'lines', 'compact', 'stripes', 'row-headings')] - Table features to output. Defaults to all table features.
 /// @access public
-@mixin oTable($opts: (
-	'responsive-overflow',
-	'responsive-flat',
-	'responsive-scroll',
-	'lines',
-	'compact',
-	'stripes',
-	'row-headings',
-)) {
+@mixin oTable(
+	$opts: (
+		'responsive-overflow',
+		'responsive-flat',
+		'responsive-scroll',
+		'lines',
+		'compact',
+		'stripes',
+		'row-headings',
+	)
+) {
 	$overflow-enabled: index($opts, 'responsive-overflow');
 	$flat-enabled: index($opts, 'responsive-flat');
 	$scroll-enabled: index($opts, 'responsive-scroll');

--- a/components/o-table/package.json
+++ b/components/o-table/package.json
@@ -32,16 +32,15 @@
 	"peerDependencies": {
 		"@financial-times/math": "^1.0.0",
 		"@financial-times/o-brand": "^4.1.0",
-		"@financial-times/o-buttons": "^7.0.0",
 		"@financial-times/o-colors": "^6.5.0",
 		"@financial-times/o-grid": "^6.0.0",
 		"@financial-times/o-icons": "^7.0.1",
 		"@financial-times/o-spacing": "^3.0.0",
 		"@financial-times/o-typography": "^7.4.1",
-		"@financial-times/o-visual-effects": "^4.0.1"
+		"@financial-times/o-visual-effects": "^4.0.1",
+		"@financial-times/o-private-foundation": "^0.0.0"
 	},
 	"devDependencies": {
-		"@financial-times/o-buttons": "^7.8.0",
 		"@financial-times/o-fonts": "^5",
 		"@financial-times/o-forms": "^9.9.0",
 		"@financial-times/o-normalise": "^3.3.0",

--- a/components/o-table/src/js/Tables/OverflowTable.js
+++ b/components/o-table/src/js/Tables/OverflowTable.js
@@ -27,10 +27,17 @@ class OverflowTable extends BaseTable {
 	 */
 	constructor(rootEl, sorter, opts = {}) {
 		super(rootEl, sorter, opts);
-		this._opts = Object.assign({
-			expanded: this.rootEl.hasAttribute('data-o-table-expanded') ? this.rootEl.getAttribute('data-o-table-expanded') !== 'false' : null,
-			minimumRowCount: this.rootEl.getAttribute('data-o-table-minimum-row-count')
-		}, this._opts);
+		this._opts = Object.assign(
+			{
+				expanded: this.rootEl.hasAttribute('data-o-table-expanded')
+					? this.rootEl.getAttribute('data-o-table-expanded') !== 'false'
+					: null,
+				minimumRowCount: this.rootEl.getAttribute(
+					'data-o-table-minimum-row-count'
+				),
+			},
+			this._opts
+		);
 		// Add scroll and expander controls immediately.
 		this._addControlsToDom();
 		// Defer other tasks.
@@ -61,7 +68,10 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} is the table expanded?
 	 */
 	isExpanded() {
-		const expand = this._expand === undefined ? Boolean(this._opts.expanded) : Boolean(this._expand);
+		const expand =
+			this._expand === undefined
+				? Boolean(this._opts.expanded)
+				: Boolean(this._expand);
 		return this.canExpand() && expand;
 	}
 
@@ -72,7 +82,10 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} is the table contracted?
 	 */
 	isContracted() {
-		const expand = this._expand === undefined ? Boolean(this._opts.expanded) : Boolean(this._expand);
+		const expand =
+			this._expand === undefined
+				? Boolean(this._opts.expanded)
+				: Boolean(this._expand);
 		return this.canExpand() && !expand;
 	}
 
@@ -83,7 +96,11 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} can the table expand and contract?
 	 */
 	canExpand() {
-		return typeof this._opts.expanded === 'boolean' && this._minimumRowCount < this.tableRows.length - this._filteredTableRows.length;
+		return (
+			typeof this._opts.expanded === 'boolean' &&
+			this._minimumRowCount <
+				this.tableRows.length - this._filteredTableRows.length
+		);
 	}
 
 	/**
@@ -118,26 +135,31 @@ class OverflowTable extends BaseTable {
 		this._updateRowAriaHidden();
 		this._updateControls();
 
-		this._expanderUpdateScheduled = window.requestAnimationFrame(function () {
-			this.rootEl.setAttribute('data-o-table-expanded', Boolean(expand));
-			this.container.classList.toggle('o-table-container--expanded', expand);
-			this.container.classList.toggle('o-table-container--contracted', contract);
-			expanderButton.style.display = canExpand ? '' : 'none';
+		this._expanderUpdateScheduled = window.requestAnimationFrame(
+			function () {
+				this.rootEl.setAttribute('data-o-table-expanded', Boolean(expand));
+				this.container.classList.toggle('o-table-container--expanded', expand);
+				this.container.classList.toggle(
+					'o-table-container--contracted',
+					contract
+				);
+				expanderButton.style.display = canExpand ? '' : 'none';
 
-			if (!canExpand) {
-				this.rootEl.removeAttribute('aria-expanded');
-			}
+				if (!canExpand) {
+					this.rootEl.removeAttribute('aria-expanded');
+				}
 
-			if (expand) {
-				expanderButton.textContent = 'Show fewer';
-				this.rootEl.setAttribute('aria-expanded', true);
-			}
+				if (expand) {
+					expanderButton.textContent = 'Show fewer';
+					this.rootEl.setAttribute('aria-expanded', true);
+				}
 
-			if (contract) {
-				expanderButton.textContent = 'Show more';
-				this.rootEl.setAttribute('aria-expanded', false);
-			}
-		}.bind(this));
+				if (contract) {
+					expanderButton.textContent = 'Show more';
+					this.rootEl.setAttribute('aria-expanded', false);
+				}
+			}.bind(this)
+		);
 	}
 
 	/**
@@ -176,17 +198,25 @@ class OverflowTable extends BaseTable {
 	_getTableHeight() {
 		if (this.isContracted()) {
 			const maxTableHeight = super._getTableHeight();
-			if (!this._contractedWrapperHeight || this._contractedWrapperHeight > maxTableHeight) {
+			if (
+				!this._contractedWrapperHeight ||
+				this._contractedWrapperHeight > maxTableHeight
+			) {
 				const rowsToHide = this._rowsToHide;
-				const buttonHeight = this.controls.expanderButton.getBoundingClientRect().height;
-				const extraHeight = rowsToHide ? rowsToHide[0].getBoundingClientRect().height / 2 : 0;
-				this._contractedWrapperHeight = maxTableHeight + buttonHeight + extraHeight;
+				const buttonHeight =
+					this.controls.expanderButton.getBoundingClientRect().height;
+				const extraHeight = rowsToHide
+					? rowsToHide[0].getBoundingClientRect().height / 2
+					: 0;
+				this._contractedWrapperHeight =
+					maxTableHeight + buttonHeight + extraHeight;
 			}
 			return this._contractedWrapperHeight;
 		}
 
 		if (this.isExpanded()) {
-			const buttonHeight = this.controls.expanderButton.getBoundingClientRect().height;
+			const buttonHeight =
+				this.controls.expanderButton.getBoundingClientRect().height;
 			return super._getTableHeight() + buttonHeight;
 		}
 
@@ -203,56 +233,91 @@ class OverflowTable extends BaseTable {
 		if (this.overlayWrapper && !this.controls) {
 			const supportsArrows = OverflowTable._supportsArrows();
 			const overlayWrapperHtml = `
-				${this.wrapper ? `
+				${
+					this.wrapper
+						? `
 					<div class="o-table-overflow-fade-overlay"></div>
-				` : ''}
+				`
+						: ''
+				}
 				<div class="o-table-overflow-control-overlay">
-					${this.wrapper && supportsArrows ? `
+					${
+						this.wrapper && supportsArrows
+							? `
 						<div class="o-table-control o-table-control--back o-table-control--hide">
-							<button aria-label="visually scroll table back" disabled="true" class="o-buttons o-buttons--primary o-buttons--big o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-left"></button>
+							<button aria-label="visually scroll table back" disabled="true"></button>
 						</div>
-					` : ''}
+					`
+							: ''
+					}
 
-					${this.wrapper && supportsArrows ? `
+					${
+						this.wrapper && supportsArrows
+							? `
 						<div class="o-table-control o-table-control--forward o-table-control--hide">
-							<button aria-label="visually scroll table forward" disabled="true" class="o-buttons o-buttons--primary o-buttons--big o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-right"></button>
+							<button aria-label="visually scroll table forward" disabled="true"></button>
 						</div>
-					` : ''}
+					`
+							: ''
+					}
 
-					${typeof this._opts.expanded === 'boolean' ? `
+					${
+						typeof this._opts.expanded === 'boolean'
+							? `
 						<div class="o-table-control o-table-control--expander">
-							<button class="o-buttons o-buttons--primary o-buttons--big">Show fewer</button>
+							<button>Show fewer</button>
 						</div>
-					` : ''}
+					`
+							: ''
+					}
 				</div>
 			`;
 
 			const range = document.createRange();
 			range.selectNode(this.overlayWrapper);
-			const overlayFragment = range.createContextualFragment(overlayWrapperHtml);
+			const overlayFragment =
+				range.createContextualFragment(overlayWrapperHtml);
 
 			this.controls = {
-				controlsOverlay: overlayFragment.querySelector('.o-table-overflow-control-overlay'),
-				fadeOverlay: overlayFragment.querySelector('.o-table-overflow-fade-overlay'),
-				expanderButton: overlayFragment.querySelector('.o-table-control--expander'),
-				forwardButton: overlayFragment.querySelector('.o-table-control--forward'),
-				backButton: overlayFragment.querySelector('.o-table-control--back')
+				controlsOverlay: overlayFragment.querySelector(
+					'.o-table-overflow-control-overlay'
+				),
+				fadeOverlay: overlayFragment.querySelector(
+					'.o-table-overflow-fade-overlay'
+				),
+				expanderButton: overlayFragment.querySelector(
+					'.o-table-control--expander'
+				),
+				forwardButton: overlayFragment.querySelector(
+					'.o-table-control--forward'
+				),
+				backButton: overlayFragment.querySelector('.o-table-control--back'),
 			};
 
 			// Add controls to the dom.
 			this._updateControlOverlayPosition();
-			window.requestAnimationFrame(function() {
-				this.overlayWrapper.appendChild(overlayFragment);
-			}.bind(this));
+			window.requestAnimationFrame(
+				function () {
+					this.overlayWrapper.appendChild(overlayFragment);
+				}.bind(this)
+			);
 		}
 	}
 
 	_updateControlOverlayPosition() {
-		const theadHeight = this.thead ? this.thead.getBoundingClientRect().height : 0;
-		const captionHeight = this.tableCaption ? this.tableCaption.getBoundingClientRect().height : 0;
-		window.requestAnimationFrame(function () {
-			this.controls.controlsOverlay.style['top'] = `${theadHeight + captionHeight}px`;
-		}.bind(this));
+		const theadHeight = this.thead
+			? this.thead.getBoundingClientRect().height
+			: 0;
+		const captionHeight = this.tableCaption
+			? this.tableCaption.getBoundingClientRect().height
+			: 0;
+		window.requestAnimationFrame(
+			function () {
+				this.controls.controlsOverlay.style['top'] = `${
+					theadHeight + captionHeight
+				}px`;
+			}.bind(this)
+		);
 	}
 
 	/**
@@ -267,8 +332,8 @@ class OverflowTable extends BaseTable {
 			// eslint-disable-next-line no-console
 			console.warn(
 				'Controls to scroll table left/right could not be added to "o-table" as it is missing markup. ' +
-				'Please add the container and wrapper elements according to the documentation https://registry.origami.ft.com/components/o-table.',
-				{ table: this.rootEl }
+					'Please add the container and wrapper elements according to the documentation https://registry.origami.ft.com/components/o-table.',
+				{table: this.rootEl}
 			);
 		}
 
@@ -287,14 +352,14 @@ class OverflowTable extends BaseTable {
 			const scrollForward = function () {
 				this.wrapper.scrollBy({
 					left: document.body.clientWidth / 2,
-					behavior: 'smooth'
+					behavior: 'smooth',
 				});
 			}.bind(this);
 			this.controls.forwardButton.addEventListener('click', scrollForward);
 			this._listeners.push({
 				element: this.controls.forwardButton,
 				scrollForward,
-				type: 'click'
+				type: 'click',
 			});
 		}
 
@@ -303,14 +368,14 @@ class OverflowTable extends BaseTable {
 			const scrollBackward = function () {
 				this.wrapper.scrollBy({
 					left: -(document.body.clientWidth / 2),
-					behavior: 'smooth'
+					behavior: 'smooth',
 				});
 			}.bind(this);
 			this.controls.backButton.addEventListener('click', scrollBackward);
 			this._listeners.push({
 				element: this.controls.backButton,
 				scrollBackward,
-				type: 'click'
+				type: 'click',
 			});
 		}
 
@@ -318,12 +383,18 @@ class OverflowTable extends BaseTable {
 		const updateScroll = function () {
 			if (!this._controlUpdateScheduled) {
 				this._controlUpdateScheduled = true;
-				window.setTimeout(function () {
-					this._controlUpdateScheduled = false;
-					this._fromEnd = this.wrapper.scrollWidth - this.wrapper.clientWidth - this.wrapper.scrollLeft;
-					this._fromStart = this.wrapper.scrollLeft;
-					this._updateControls();
-				}.bind(this), 33);
+				window.setTimeout(
+					function () {
+						this._controlUpdateScheduled = false;
+						this._fromEnd =
+							this.wrapper.scrollWidth -
+							this.wrapper.clientWidth -
+							this.wrapper.scrollLeft;
+						this._fromStart = this.wrapper.scrollLeft;
+						this._updateControls();
+					}.bind(this),
+					33
+				);
 			}
 		}.bind(this);
 
@@ -335,11 +406,14 @@ class OverflowTable extends BaseTable {
 			const arrowFadeObserverConfig = {
 				root: this.controls.controlsOverlay,
 				threshold: 1.0,
-				rootMargin: `-20px 0px ${this.canExpand() ? '0px' : '-20px'} 0px`
+				rootMargin: `-20px 0px ${this.canExpand() ? '0px' : '-20px'} 0px`,
 			};
-			const arrowFadeObserver = new IntersectionObserver(function(entries) {
-				entries.forEach(function(entry) {
-					entry.target.setAttribute('data-o-table-intersection', entry.intersectionRatio !== 1);
+			const arrowFadeObserver = new IntersectionObserver(function (entries) {
+				entries.forEach(function (entry) {
+					entry.target.setAttribute(
+						'data-o-table-intersection',
+						entry.intersectionRatio !== 1
+					);
 					updateScroll();
 				});
 			}, arrowFadeObserverConfig);
@@ -355,7 +429,7 @@ class OverflowTable extends BaseTable {
 		this.wrapper.addEventListener('scroll', updateScroll);
 		window.addEventListener('resize', updateScroll);
 		window.addEventListener('load', updateScroll);
-		this._listeners.push({ element: this.wrapper, updateScroll, type: 'scroll' });
+		this._listeners.push({element: this.wrapper, updateScroll, type: 'scroll'});
 		this._listeners.push({element: window, updateScroll, type: 'resize'});
 		this._listeners.push({element: window, updateScroll, type: 'load'});
 	}
@@ -373,7 +447,7 @@ class OverflowTable extends BaseTable {
 		if (!this.container || !this.overlayWrapper || !this.wrapper) {
 			throw new Error(
 				'Controls to expand/contract the table could not be added to "o-table" as it is missing markup.' +
-				'Please add the container and wrapper element according to the documentation https://registry.origami.ft.com/components/o-table.'
+					'Please add the container and wrapper element according to the documentation https://registry.origami.ft.com/components/o-table.'
 			);
 		}
 
@@ -386,10 +460,14 @@ class OverflowTable extends BaseTable {
 			const toggleExpanded = function () {
 				if (this.isExpanded()) {
 					const expanderButtonContainer = this.controls.expanderButton;
-					const buttonOffset = expanderButtonContainer.getBoundingClientRect().top;
+					const buttonOffset =
+						expanderButtonContainer.getBoundingClientRect().top;
 					this.contractTable();
 					window.requestAnimationFrame(() => {
-						const top = window.pageYOffset + expanderButtonContainer.getBoundingClientRect().top - buttonOffset;
+						const top =
+							window.pageYOffset +
+							expanderButtonContainer.getBoundingClientRect().top -
+							buttonOffset;
 						window.scroll(null, top);
 					});
 				} else {
@@ -397,7 +475,11 @@ class OverflowTable extends BaseTable {
 				}
 			}.bind(this);
 			this.controls.expanderButton.addEventListener('click', toggleExpanded);
-			this._listeners.push({element: this.controls.expanderButton, toggleExpanded, type: 'click'});
+			this._listeners.push({
+				element: this.controls.expanderButton,
+				toggleExpanded,
+				type: 'click',
+			});
 		}
 
 		this._updateExpander();
@@ -416,18 +498,33 @@ class OverflowTable extends BaseTable {
 
 		// Toggle fade.
 		const canScrollTable = this._canScrollTable;
-		window.requestAnimationFrame(function () {
-			this.controls.fadeOverlay.classList.toggle('o-table-overflow-fade-overlay--scroll', canScrollTable);
-			this.controls.fadeOverlay.style.setProperty('--o-table-fade-from-end', `${Math.min(this._fromEnd, 10)}px`);
-			this.controls.fadeOverlay.style.setProperty('--o-table-fade-from-start', `${Math.min(this._fromStart, 10)}px`);
-		}.bind(this));
+		window.requestAnimationFrame(
+			function () {
+				this.controls.fadeOverlay.classList.toggle(
+					'o-table-overflow-fade-overlay--scroll',
+					canScrollTable
+				);
+				this.controls.fadeOverlay.style.setProperty(
+					'--o-table-fade-from-end',
+					`${Math.min(this._fromEnd, 10)}px`
+				);
+				this.controls.fadeOverlay.style.setProperty(
+					'--o-table-fade-from-start',
+					`${Math.min(this._fromStart, 10)}px`
+				);
+			}.bind(this)
+		);
 
 		// Toggle arrow dock.
 		const showArrowDock = this._showArrowDock;
-		window.requestAnimationFrame(function () {
-			this.controls.controlsOverlay.classList.toggle('o-table-overflow-control-overlay--arrow-dock', showArrowDock);
-		}.bind(this));
-
+		window.requestAnimationFrame(
+			function () {
+				this.controls.controlsOverlay.classList.toggle(
+					'o-table-overflow-control-overlay--arrow-dock',
+					showArrowDock
+				);
+			}.bind(this)
+		);
 
 		// Update forward/back scroll controls.
 		if (OverflowTable._supportsArrows()) {
@@ -449,13 +546,19 @@ class OverflowTable extends BaseTable {
 		const showStickyArrows = this._stickyArrows;
 		const canScrollTable = this._canScrollTable;
 		const arrowsDocked = this._showArrowDock && !showStickyArrows;
-		const scrolledToBoundary = this._fromEnd <= 0 && element === this.controls.forwardButton || this._fromStart <= 0 && element === this.controls.backButton;
-		const hideAtBoundary = !arrowsDocked && (!this._stickyArrows || this._stickyArrows && !this._canScrollPastTable);
-		const outsideTable = element.getAttribute('data-o-table-intersection') === 'true';
+		const scrolledToBoundary =
+			(this._fromEnd <= 0 && element === this.controls.forwardButton) ||
+			(this._fromStart <= 0 && element === this.controls.backButton);
+		const hideAtBoundary =
+			!arrowsDocked &&
+			(!this._stickyArrows ||
+				(this._stickyArrows && !this._canScrollPastTable));
+		const outsideTable =
+			element.getAttribute('data-o-table-intersection') === 'true';
 		const elementButton = element.querySelector('button');
 		window.requestAnimationFrame(() => {
 			// Show scroll control if the table does not fit within the viewport.
-			element.style.display = canScrollTable ? '': 'none';
+			element.style.display = canScrollTable ? '' : 'none';
 			// Make arrows sticky if table is tall and can be scrolled past.
 			element.classList.toggle('o-table-control--sticky', showStickyArrows);
 			// Place the arrows in the dock if they are not sticky.
@@ -486,7 +589,9 @@ class OverflowTable extends BaseTable {
 	 */
 	get _minimumRowCount() {
 		const minimumRowCount = this._opts.minimumRowCount;
-		return isNaN(parseInt(minimumRowCount, 10)) ? 20 : parseInt(minimumRowCount, 10);
+		return isNaN(parseInt(minimumRowCount, 10))
+			? 20
+			: parseInt(minimumRowCount, 10);
 	}
 
 	/**
@@ -504,9 +609,16 @@ class OverflowTable extends BaseTable {
 	 * @returns {Node[]} the rows that will disappear when collapsing
 	 */
 	get _rowsHiddenByExpander() {
-		const visibleRowCount = Math.min(this.tableRows.length, this._minimumRowCount);
-		const nonFilteredRows = this.tableRows.filter(row => this._filteredTableRows.indexOf(row) === -1);
-		return this.isContracted() ? nonFilteredRows.slice(visibleRowCount, nonFilteredRows.length) : [];
+		const visibleRowCount = Math.min(
+			this.tableRows.length,
+			this._minimumRowCount
+		);
+		const nonFilteredRows = this.tableRows.filter(
+			row => this._filteredTableRows.indexOf(row) === -1
+		);
+		return this.isContracted()
+			? nonFilteredRows.slice(visibleRowCount, nonFilteredRows.length)
+			: [];
 	}
 
 	/**
@@ -524,7 +636,10 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} is the table too big for the viewport?
 	 */
 	get _tableTallerThanViewport() {
-		return this.container.getBoundingClientRect().height > document.documentElement.clientHeight;
+		return (
+			this.container.getBoundingClientRect().height >
+			document.documentElement.clientHeight
+		);
 	}
 
 	/**
@@ -534,7 +649,11 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} is the table so big that the viewport can scroll past it by over 50%?
 	 */
 	get _canScrollPastTable() {
-		return this.container.getBoundingClientRect().bottom + document.documentElement.clientHeight / 2 < document.documentElement.getBoundingClientRect().bottom;
+		return (
+			this.container.getBoundingClientRect().bottom +
+				document.documentElement.clientHeight / 2 <
+			document.documentElement.getBoundingClientRect().bottom
+		);
 	}
 
 	/**
@@ -544,7 +663,12 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} should the dock be shown?
 	 */
 	get _showArrowDock() {
-		return OverflowTable._supportsArrows() && this._canScrollTable && this._canScrollPastTable && this.canExpand();
+		return (
+			OverflowTable._supportsArrows() &&
+			this._canScrollTable &&
+			this._canScrollPastTable &&
+			this.canExpand()
+		);
 	}
 
 	/**
@@ -562,7 +686,11 @@ class OverflowTable extends BaseTable {
 	 * @returns {boolean} is stickiness supported by the user's browser?
 	 */
 	static _supportsArrows() {
-		return typeof CSS !== 'undefined' && (CSS.supports("position", "sticky") || CSS.supports('position', '-webkit-sticky'));
+		return (
+			typeof CSS !== 'undefined' &&
+			(CSS.supports('position', 'sticky') ||
+				CSS.supports('position', '-webkit-sticky'))
+		);
 	}
 }
 

--- a/components/o-table/src/scss/_responsive-overflow.scss
+++ b/components/o-table/src/scss/_responsive-overflow.scss
@@ -18,18 +18,11 @@
 		left: 0;
 		pointer-events: none;
 
-
 		.o-table-control {
 			display: inline-block;
 			background: _oTableGet('table-background');
 			pointer-events: all;
 			transition: 1s opacity ease-in-out;
-			button {
-				@include oButtonsContent((
-					'type': 'primary',
-					'size': 'big'
-				));
-			}
 		}
 
 		.o-table-control--expander {
@@ -39,6 +32,12 @@
 			bottom: 0;
 			text-align: center;
 			button {
+				@include oPrivateButtonsContent(
+					(
+						'type': 'primary',
+						'size': 'big',
+					)
+				);
 				width: 100%;
 			}
 		}
@@ -53,26 +52,18 @@
 			z-index: 1;
 		}
 
-		.o-table-control--back button,
-		.o-table-control--forward button {
-			@include oButtonsContent((
-				'size': 'big',
-				'icon-only': true
-			), $include-base-styles: false);
-		}
-
 		.o-table-control--back {
 			left: 0; //absolute
 			float: left; //sticky
 			margin: 0 10px;
 			button {
-				@include oButtonsContent(
+				@include oPrivateButtonsContent(
 					$opts: (
 						'type': 'primary',
-						'icon': 'arrow-left'
-					),
-					$include-base-styles: false,
-					$include-base-icon-styles: false
+						'icon': 'arrow-left',
+						'size': 'big',
+						'icon-only': true,
+					)
 				);
 			}
 		}
@@ -82,13 +73,13 @@
 			float: right; //sticky
 			margin: 0 10px;
 			button {
-				@include oButtonsContent(
+				@include oPrivateButtonsContent(
 					$opts: (
 						'type': 'primary',
-						'icon': 'arrow-right'
-					),
-					$include-base-styles: false,
-					$include-base-icon-styles: false
+						'icon': 'arrow-right',
+						'size': 'big',
+						'icon-only': true,
+					)
 				);
 			}
 		}
@@ -114,7 +105,9 @@
 			bottom: 0;
 			height: 40px;
 			pointer-events: none;
-			border-color: oButtonsGetColor('default', 'background', $type: 'primary');
+			border-color: o-private-foundation-get(
+				'_o3-button-primary-standard-background'
+			);
 			border-style: solid;
 			width: 1px;
 		}
@@ -159,7 +152,16 @@
 	// Show horizontal fade when the table is scrolled.
 	.o-table-overflow-fade-overlay--scroll {
 		@if _oTableGet('table-background') {
-			background: linear-gradient(to right, _oTableGet('table-background') 2px, rgba(_oTableGet('table-background'), 0) var(--o-table-fade-from-start)), linear-gradient(to left, _oTableGet('table-background') 2px, rgba(_oTableGet('table-background'), 0) var(--o-table-fade-from-end));
+			background: linear-gradient(
+					to right,
+					_oTableGet('table-background') 2px,
+					rgba(_oTableGet('table-background'), 0) var(--o-table-fade-from-start)
+				),
+				linear-gradient(
+					to left,
+					_oTableGet('table-background') 2px,
+					rgba(_oTableGet('table-background'), 0) var(--o-table-fade-from-end)
+				);
 		}
 	}
 
@@ -172,7 +174,11 @@
 			bottom: 0;
 			left: 0;
 			right: 0;
-			background: linear-gradient(to top, _oTableGet('table-background') 30px, rgba(_oTableGet('table-background'), 0) 80px);
+			background: linear-gradient(
+				to top,
+				_oTableGet('table-background') 30px,
+				rgba(_oTableGet('table-background'), 0) 80px
+			);
 			pointer-events: none;
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3319,7 +3319,6 @@
 				"ftdomdelegate": "^5.0.0"
 			},
 			"devDependencies": {
-				"@financial-times/o-buttons": "^7.8.0",
 				"@financial-times/o-fonts": "^5",
 				"@financial-times/o-forms": "^9.9.0",
 				"@financial-times/o-normalise": "^3.3.0",
@@ -3331,10 +3330,10 @@
 			"peerDependencies": {
 				"@financial-times/math": "^1.0.0",
 				"@financial-times/o-brand": "^4.1.0",
-				"@financial-times/o-buttons": "^7.0.0",
 				"@financial-times/o-colors": "^6.5.0",
 				"@financial-times/o-grid": "^6.0.0",
 				"@financial-times/o-icons": "^7.0.1",
+				"@financial-times/o-private-foundation": "^0.0.0",
 				"@financial-times/o-spacing": "^3.0.0",
 				"@financial-times/o-typography": "^7.4.1",
 				"@financial-times/o-visual-effects": "^4.0.1"


### PR DESCRIPTION
Takes o3-button and refactors to work in an o2 world. Slightly
odd use of Sass/CSS Custom Properties, with Sass conditionals
used to output duplicate CSS Custom Properties which override
each other in the same declaration. This was the safest way
to reuse o3 styles by effectively replacing class names for
Sass if statements. It's also more readable and simple than o2
Sass. Despite duplicating some properties, CSS output and
performance will be improved by moving away from the Origami
Image Service for coloured icons.

Currently supports:
- Types
- Themes
- Sizes
- Icons
- Icons only

Does not yet support:
- Custom theme maps

Will not support:
- Outputting CSS granularly. There are not many buttons left in
o2 components, and bundle size is reduced overall as noted above.

Other things of note:
- `o-private-foundation-get` allows other o2 components to grab tokens directly.
- Added Metric2 variable font