### PR TITLE
Remove o-buttons as an o-message dependency

### DIFF
--- a/components/o-message/README.md
+++ b/components/o-message/README.md
@@ -6,8 +6,8 @@
 - [Message Types](#message-types)
 - [Markup](#markup)
 - [JavaScript](#javascript)
-	- [Construction](#construction)
-	- [Options](#options)
+  - [Construction](#construction)
+  - [Options](#options)
 - [Sass](#sass)
 - [Migration](#migration)
 - [Contact](#contact)
@@ -22,12 +22,12 @@ It can be initialised declaratively if markup is provided on the page, or it can
 Check out [how to include Origami components in your project](https://origami.ft.com/documentation/components/#including-origami-components-in-your-project) to get started with `o-message`.
 
 ## Message Types
+
 `o-message` provides three types of messages: **alert**, **notice**, and **action**.
 
 - An **alert** message should be used as feedback to a users interaction with a product (e.g. payment declined warning). Unlike other messages, alert messages have an icon.
 - A **notice** message should be used to provide information or warnings about a product. (e.g. beta version of a product).
 - An **action** message should be used as a static call to action, usually within or below main content, that is not necessarily a response to a user's interaction with a product (e.g. requesting feedback in general).
-
 
 You can find a demo for each of the messages above in the [Origami registry](https://registry.origami.ft.com/components/o-message).
 
@@ -37,12 +37,11 @@ An 'inner' message is meant to sit within a smaller container, as it stacks info
 In addition to layout, messages can accept another variation: state.
 However, not every message accepts every state, or every layout, and not every message works for every brand. Please check the table below against the needs of your product. If you need a message that is not available to you, please [get in touch](#contact) with the Origami team.
 
-| | state support | layout support | brand support
----|:---|:---|:---
-**action message** | `inform`, `inform-inverse` | default | internal, whitelabel
-**alert message** | `success`, `neutral`, `error` | default, inner | all
-**notice message** | `inform`, `feedback`, `warning`, `warning-light` | default, inner | core: `inform` or `feedback` state only <br> internal: all states <br> whitelabel: `inform` state only
-
+|                    | state support                                    | layout support | brand support                                                                                          |
+| ------------------ | :----------------------------------------------- | :------------- | :----------------------------------------------------------------------------------------------------- |
+| **action message** | `inform`, `inform-inverse`                       | default        | internal, whitelabel                                                                                   |
+| **alert message**  | `success`, `neutral`, `error`                    | default, inner | all                                                                                                    |
+| **notice message** | `inform`, `feedback`, `warning`, `warning-light` | default, inner | core: `inform` or `feedback` state only <br> internal: all states <br> whitelabel: `inform` state only |
 
 ## Markup
 
@@ -57,11 +56,15 @@ _Note: as mentioned in the description of the [message types](#message-types), n
 This example illustrates the basic markup for a successful alert message:
 
 ```html
-<div class="o-message o-message--alert o-message--success" data-o-component="o-message">
+<div
+	class="o-message o-message--alert o-message--success"
+	data-o-component="o-message"
+>
 	<div class="o-message__container">
 		<div class="o-message__content">
 			<p class="o-message__content-main">
 				<span class="o-message__content-highlight">Oops.</span>
+			</p>
 		</div>
 	</div>
 </div>
@@ -134,12 +137,18 @@ If you have applied the `o-message--inner` modifier to your message, you can add
 ```
 
 For any message, you can highlight any portion of copy within a paragraph by using the markup like this:
+
 ```html
-<div class="o-message o-message--alert o-message--success" data-o-component="o-message">
+<div
+	class="o-message o-message--alert o-message--success"
+	data-o-component="o-message"
+>
 	<div class="o-message__container">
 		<div class="o-message__content">
 			<p class="o-message__content-main">
-				The quick brown fox did <span class="o-message__content-highlight">not</span> jump over the lazy dogs.
+				The quick brown fox did
+				<span class="o-message__content-highlight">not</span> jump over the lazy
+				dogs.
 			</p>
 		</div>
 	</div>
@@ -147,22 +156,28 @@ For any message, you can highlight any portion of copy within a paragraph by usi
 ```
 
 [Sass](#sass) users may create custom messages with a highlight colour. This is useful to highlight key words in the message. To apply the highlight colour to message copy use the class `o-message__content-highlight-color`.
+
 ```html
-<div class="o-message o-message--alert o-message--success" data-o-component="o-message">
+<div
+	class="o-message o-message--alert o-message--success"
+	data-o-component="o-message"
+>
 	<div class="o-message__container">
 		<div class="o-message__content">
-				<p class="o-message__content-main">
-					<span class="o-message__content-highlight">
-						Hurray<span class="o-message__content-highlight-color">thing</span>happened
-					</span>
-					The quick brown fox jumped over the lazy dogs!
-				</p>
+			<p class="o-message__content-main">
+				<span class="o-message__content-highlight">
+					Hurray<span class="o-message__content-highlight-color">thing</span
+					>happened
+				</span>
+				The quick brown fox jumped over the lazy dogs!
+			</p>
 		</div>
 	</div>
 </div>
 ```
 
 For **action messages only**, you can centralise the text with a specific class (`.o-message__content--center-align`):
+
 ```diff
 <div class="o-message o-message--action o-message--inform" data-o-component="o-message">
 	<div class="o-message__container">
@@ -177,10 +192,13 @@ For **action messages only**, you can centralise the text with a specific class 
 ```
 
 ## JavaScript
+
 No code will run automatically unless you are using the Build Service. You must either construct an `o-message` object or fire an o.DOMContentLoaded event, which `o-message` listens for.
 
 ### Construction
+
 If you have set up your message declaratively, use the following to initialise your message.
+
 ```js
 import Message from '@financial-times/o-message';
 Message.init();
@@ -197,15 +215,17 @@ const importantMessage = new Message(null, {
 	state: 'error',
 	content: {
 		highlight: 'Something has gone wrong.',
-		detail: 'The quick brown fox did not jump over the lazy dogs.'
-	}
+		detail: 'The quick brown fox did not jump over the lazy dogs.',
+	},
 });
 ```
 
 ### Options
+
 `o-message` allows for several configuration options that will change the type of message and its visual styling.
 
 The only required options are listed in the example _above_. These are:
+
 - `type`: String. The o-message variant. The available variants are 'action', 'alert' and 'notice'.
 - `state`: String. All messages require a state, and you must supply one that combines with the type of message you've chosen, as listed in the [message types](#message-types)
 - `content.detail`: String. The detail about the nature of a message.
@@ -215,17 +235,17 @@ The following options are not required, and all have a default value:
 - `autoOpen`: Boolean. Whether to open the message automatically, defaults to `true`.
 - `parentElement`: String. This determines the element that the message will be appended to. If none is declared, it will automatically append to the body, or an element with the data attribute `data-o-component=o-message`, defaults to `null`.
 - `content`: Object. Holds the following values for text properties:
-	- `highlight`: String. The highlighted text in a message. Defaults to `null`
-	- `additionalInfo`: String. More information about the message –  only applies to a message with an `inner` layout. Defaults to `null`
+  - `highlight`: String. The highlighted text in a message. Defaults to `null`
+  - `additionalInfo`: String. More information about the message – only applies to a message with an `inner` layout. Defaults to `null`
 - `actions`: Object. Holds the following values for text properties:
-	- `primary`:  Object. Holds the following values for button properties:
-		- `text`: String. text value of the button. Defaults to `null`
-		- `url`: String. The URL the button links to. Defaults to `null`
-		- `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
-	- `secondary`: Object. Holds the following values for link properties:
-		- `text`: String. text value of the link. Defaults to `null`
-		- `url`: String. The URL the link links to. Defaults to `null`
-		- `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
+  - `primary`: Object. Holds the following values for button properties:
+    - `text`: String. text value of the button. Defaults to `null`
+    - `url`: String. The URL the button links to. Defaults to `null`
+    - `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
+  - `secondary`: Object. Holds the following values for link properties:
+    - `text`: String. text value of the link. Defaults to `null`
+    - `url`: String. The URL the link links to. Defaults to `null`
+    - `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
 - `close`: Boolean. Whether or not to display the close button. Defaults to `true`.
 
 For example, to configure the `close` icon to not display:
@@ -247,6 +267,7 @@ const importantMessage = new Message(null, {
 ## Sass
 
 You can include all styles and variations for every message type by calling:
+
 ```scss
 @include oMessage();
 ```
@@ -254,20 +275,30 @@ You can include all styles and variations for every message type by calling:
 You can also be more specific about which message styles and variations you would like to output by using an `$opts` map:
 
 ```scss
-@include oMessage($opts: (
-	'types': ('action', 'notice'),
-	'states': ('inform', 'warning'),
-	'layouts': ('inner')
-));
+@include oMessage(
+	$opts: (
+		'types': (
+			'action',
+			'notice',
+		),
+		'states': (
+			'inform',
+			'warning',
+		),
+		'layouts': (
+			'inner',
+		),
+	)
+);
 ```
 
 Options include:
 
-| Feature             | Description                                                                                                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| types               | The message to support (e.g. alert, notice, action) see [message types](#message-types).                                                    |
-| state               | The kinds of messages to support (e.g. 'inform', 'warning', 'error') see [message types](#message-types).                                   |
-| layouts             | By default messages should span the page, to support messages within content pass the 'inner' option. See [message types](#message-types).  |
+| Feature | Description                                                                                                                                |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| types   | The message to support (e.g. alert, notice, action) see [message types](#message-types).                                                   |
+| state   | The kinds of messages to support (e.g. 'inform', 'warning', 'error') see [message types](#message-types).                                  |
+| layouts | By default messages should span the page, to support messages within content pass the 'inner' option. See [message types](#message-types). |
 
 ### Custom Message
 
@@ -275,36 +306,48 @@ To create a new message with a unique look call `oMessageAddSate`. The mixin acc
 
 - `name`: The name of your state. This is used for the modifier class output o-message--{name}.
 - `opts`: A map of options for your state. Note colours may be an [o-colors](https://registry.origami.ft.com/components/o-colors) colour name or a hex value:
-	- `foreground-color`: The colour used for message text, and the button where a highlight colour has not been given.
-	- `background-color`: The background colour used for the message.
-	- `icon`: The [o-icons](https://registry.origami.ft.com/components/o-icons) icon name to show in an alert message. Required only for your state to support an alert message type.
-	- `button-type` (optional): The type of [o-buttons](https://registry.origami.ft.com/components/o-buttons) button the message should have. One of `primary` or `secondary` (defaults to `secondary`).
-	- `highlight-color` (optional): The highlight colour is used for the message button. It can also be used to highlight message copy with the CSS class `o-message__content-highlight-color`.
+  - `foreground-color`: The colour used for message text, and the button where a highlight colour has not been given.
+  - `background-color`: The background colour used for the message.
+  - `icon`: The [o-icons](https://registry.origami.ft.com/components/o-icons) icon name to show in an alert message. Required only for your state to support an alert message type.
+  - `button-type` (optional): The type of button. One of `primary` or `secondary` (defaults to `secondary`).
+  - `highlight-color` (optional): The highlight colour is used for the message button. It can also be used to highlight message copy with the CSS class `o-message__content-highlight-color`.
 - `types`: A list of [message types](#message-types) your state supports, one or more of (`alert`, `notice`, `action`).
 
 ```scss
 // Outputs CSS for a custom message state called "pikachu"
 // Outputs a modifier class `o-message--pikachu`
 @include oMessageAddState(
-	$name: 'pikachu', // the custom state is named "pikachu"
-	$opts: (
-	'background-color': 'slate', // slate message
-	'foreground-color': 'white', // white text
-	'highlight-color': 'lemon', // lemon highlights with `o-message__content-highlight-color` and a lemon button
-	'button-type': 'primary', // a primary o-buttons button`o-message__content-highlight` highlight copy
-	'icon': 'user', // show a 'user' o-icons icon if used as an alert
-), $types: ('notice', 'alert')); // this state should work with notice and alert message types
+	$name: 'pikachu',
+	// the custom state is named "pikachu"
+	$opts:
+		(
+			// slate message
+			'background-color': 'slate',
+			// white text
+			'foreground-color': 'white',
+			// lemon highlights with `o-message__content-highlight-color` and a lemon button
+			'highlight-color': 'lemon',
+			// a primary button`o-message__content-highlight` highlight copy
+			'button-type': 'primary',
+			// show a 'user' o-icons icon if used as an alert
+			'icon': 'user',
+		),
+	$types: (
+		'notice',
+		'alert',
+	)
+); // this state should work with notice and alert message types
 ```
 
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-⚠ maintained | 4 | 4.2 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated  | 2 | 2.4 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.0 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+|  ✨ active   |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ⚠ maintained |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.4         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                          N/A                          |
 
 ## Contact
 

--- a/components/o-message/demos/src/demo.scss
+++ b/components/o-message/demos/src/demo.scss
@@ -1,5 +1,7 @@
 @import '../../main';
 
+@import '@financial-times/o-buttons/main';
+@include oButtons();
 @include oMessage();
 @import '@financial-times/o-fonts/main';
 @include oFonts();
@@ -7,35 +9,43 @@
 @include oNormalise();
 
 body {
-  background: oColorsByUsecase('page', 'background');
+	background: oColorsByUsecase('page', 'background');
 }
 
 .o-message {
-  margin-top: 20px;
-  margin-bottom: 20px;
+	margin-top: 20px;
+	margin-bottom: 20px;
 }
 
 .list-of-demo-buttons {
-  display: inline-block;
+	display: inline-block;
 }
 
 .demo-button {
-  @include oButtonsContent(('type': 'secondary'));
-  margin: 10px;
+	@include oButtonsContent(
+		(
+			'type': 'secondary',
+		)
+	);
+	margin: 10px;
 }
 
 .demo-inner,
 .demo-inner-message {
-  margin: auto;
-  max-width: 400px;
+	margin: auto;
+	max-width: 400px;
 }
 
 @if oBrandIs('core') or oBrandIs('internal') {
-  @include oMessageAddState('pikachu', (
-          'foreground-color': 'white',
-          'background-color': 'slate',
-          'highlight-color': 'lemon',
-          'button-type': 'primary',
-          'icon': 'user',
-  ), $types: ('notice', 'alert'));
+	@include oMessageAddState(
+		'pikachu',
+		(
+			'foreground-color': 'white',
+			'background-color': 'slate',
+			'highlight-color': 'lemon',
+			'button-type': 'primary',
+			'icon': 'user',
+		),
+		$types: ('notice', 'alert')
+	);
 }

--- a/components/o-message/main.scss
+++ b/components/o-message/main.scss
@@ -1,7 +1,7 @@
 @import '@financial-times/math';
 @import '@financial-times/o-spacing/main';
 @import '@financial-times/o-brand/main';
-@import '@financial-times/o-buttons/main';
+@import '@financial-times/o-private-foundation/main';
 @import '@financial-times/o-colors/main';
 @import '@financial-times/o-grid/main';
 @import '@financial-times/o-icons/main';
@@ -22,11 +22,28 @@
 ///     	'states': ('error', 'success'),
 ///     ));
 /// @param {Map} $opts ['types': ('alert', 'notice', 'action), 'states': ('error', 'success', 'inform', 'neutral', 'inform-inverse', 'warning', 'warning-light', 'feedback'), 'layouts': ('inner')]
-@mixin oMessage($opts: (
-	'types': ('action', 'alert', 'notice'),
-	'states': ('error', 'success', 'neutral', 'inform', 'inform-inverse', 'warning', 'warning-light', 'feedback'),
-	'layouts': ('inner')
-)) {
+@mixin oMessage(
+	$opts: (
+		'types': (
+			'action',
+			'alert',
+			'notice',
+		),
+		'states': (
+			'error',
+			'success',
+			'neutral',
+			'inform',
+			'inform-inverse',
+			'warning',
+			'warning-light',
+			'feedback',
+		),
+		'layouts': (
+			'inner',
+		),
+	)
+) {
 	$types: map-get($opts, 'types');
 	$states: map-get($opts, 'states');
 	$layouts: map-get($opts, 'layouts');
@@ -43,7 +60,8 @@
 			@include oGridContainer($bleed: true);
 			display: flex;
 			align-items: baseline;
-			padding: $_o-message-default-block-spacing $_o-message-default-inline-spacing;
+			padding: $_o-message-default-block-spacing
+				$_o-message-default-inline-spacing;
 		}
 
 		// Content
@@ -55,7 +73,8 @@
 			margin-left: -#{$_o-message-default-content-spacing};
 			margin-bottom: -#{$_o-message-default-content-spacing};
 			& > * {
-				margin: 0 0 $_o-message-default-content-spacing $_o-message-default-content-spacing;
+				margin: 0 0 $_o-message-default-content-spacing
+					$_o-message-default-content-spacing;
 			}
 		}
 
@@ -64,7 +83,10 @@
 		}
 
 		.o-message__content-highlight {
-			@include oTypographySans($weight: 'semibold', $include-font-family: false);
+			@include oTypographySans(
+				$weight: 'semibold',
+				$include-font-family: false
+			);
 		}
 
 		.o-message__content-main a,
@@ -81,7 +103,6 @@
 		}
 
 		.o-message__actions__primary {
-			@include oButtonsContent();
 			margin-right: $_o-message-default-content-spacing;
 			&:only-child {
 				margin-right: 0;
@@ -98,7 +119,7 @@
 	// The is defensive CSS. No close icon should be added when the close
 	// attribute is set to false, hence it does not support the deprecated
 	// `data-close` option.
-	.o-message[data-o-message-close="false"] .o-message__close {
+	.o-message[data-o-message-close='false'] .o-message__close {
 		display: none;
 	}
 
@@ -122,8 +143,14 @@
 		// configured otherwise, create space to accommodate the close button
 		// with padding, so the close button can be added by JS without reflow.
 		// @deprecated the `data-close` attribute is deprecated in favour of `data-o-message-close`.
-		.o-message--notice:not([data-close="false"]):not([data-o-message-close="false"]) .o-message__container,
-		.o-message--alert:not([data-close="false"]):not([data-o-message-close="false"]) .o-message__container {
+		.o-message--notice:not([data-close='false']):not(
+				[data-o-message-close='false']
+			)
+			.o-message__container,
+		.o-message--alert:not([data-close='false']):not(
+				[data-o-message-close='false']
+			)
+			.o-message__container {
 			padding-right: $_o-message-close-inline-spacing;
 		}
 
@@ -159,7 +186,11 @@
 		.o-message--alert .o-message__container {
 			// Add padding for the icon to sit in:
 			// whitespace, icon, whitespace.
-			padding-left: calc(#{$alert-icon-left-padding} + #{$true-alert-icon-size} + #{$alert-icon-right-padding});
+			padding-left: calc(
+				#{$alert-icon-left-padding} +
+					#{$true-alert-icon-size} +
+					#{$alert-icon-right-padding}
+			);
 			&:before {
 				content: '';
 				position: absolute;
@@ -198,7 +229,8 @@
 	// E.g. success, error, inform, etc.
 
 	@each $state in $states {
-		$state-supported: index($o-message-states, $state) and _oMessageSupports($state);
+		$state-supported: index($o-message-states, $state) and
+			_oMessageSupports($state);
 		@if $state-supported {
 			$state-types: map-get($_o-message-states-to-types, $state);
 			@include oMessageAddState(

--- a/components/o-message/package.json
+++ b/components/o-message/package.json
@@ -1,46 +1,47 @@
 {
-  "name": "@financial-times/o-message",
-  "version": "5.4.4",
-  "description": "Provides message elements for alerting, informing or making calls to action.",
-  "keywords": [
-    "message",
-    "alert",
-    "notice",
-    "cta",
-    "banner"
-  ],
-  "homepage": "https://registry.origami.ft.com/components/o-message",
-  "bugs": {
-    "url": "https://github.com/Financial-Times/origami/issues/new?labels=o-message,components",
-    "email": "origami.support@ft.com"
-  },
-  "license": "MIT",
-  "type": "module",
-  "browser": "main.js",
-  "scripts": {
-    "start": "npx serve ./demos/local",
-    "build": "bash ../../scripts/component/build.bash",
-    "test": "bash ../../scripts/component/test.bash",
-    "debug:js": "bash ../../scripts/component/debug-js.bash",
-    "lint": "bash ../../scripts/component/lint.bash",
-    "watch": "bash ../../scripts/component/watch.bash"
-  },
-  "peerDependencies": {
-    "@financial-times/math": "^1.0.0",
-    "@financial-times/o-brand": "^4.1.0",
-    "@financial-times/o-buttons": "^7.8.0",
-    "@financial-times/o-colors": "^6.5.0",
-    "@financial-times/o-grid": "^6.0.0",
-    "@financial-times/o-icons": "^7.0.1",
-    "@financial-times/o-spacing": "^3.0.0",
-    "@financial-times/o-typography": "^7.4.1"
-  },
-  "devDependencies": {
-    "@financial-times/o-fonts": "^5",
-    "@financial-times/o-normalise": "^3.3.0"
-  },
-  "engines": {
-    "npm": ">7"
-  },
-  "private": false
+	"name": "@financial-times/o-message",
+	"version": "5.4.4",
+	"description": "Provides message elements for alerting, informing or making calls to action.",
+	"keywords": [
+		"message",
+		"alert",
+		"notice",
+		"cta",
+		"banner"
+	],
+	"homepage": "https://registry.origami.ft.com/components/o-message",
+	"bugs": {
+		"url": "https://github.com/Financial-Times/origami/issues/new?labels=o-message,components",
+		"email": "origami.support@ft.com"
+	},
+	"license": "MIT",
+	"type": "module",
+	"browser": "main.js",
+	"scripts": {
+		"start": "npx serve ./demos/local",
+		"build": "bash ../../scripts/component/build.bash",
+		"test": "bash ../../scripts/component/test.bash",
+		"debug:js": "bash ../../scripts/component/debug-js.bash",
+		"lint": "bash ../../scripts/component/lint.bash",
+		"watch": "bash ../../scripts/component/watch.bash"
+	},
+	"peerDependencies": {
+		"@financial-times/math": "^1.0.0",
+		"@financial-times/o-brand": "^4.1.0",
+		"@financial-times/o-private-foundation": "^0.0.0",
+		"@financial-times/o-colors": "^6.5.0",
+		"@financial-times/o-grid": "^6.0.0",
+		"@financial-times/o-icons": "^7.0.1",
+		"@financial-times/o-spacing": "^3.0.0",
+		"@financial-times/o-typography": "^7.4.1"
+	},
+	"devDependencies": {
+		"@financial-times/o-fonts": "^5",
+		"@financial-times/o-normalise": "^3.3.0",
+		"@financial-times/o-buttons": "^7.8.0"
+	},
+	"engines": {
+		"npm": ">7"
+	},
+	"private": false
 }

--- a/components/o-message/src/scss/_mixins.scss
+++ b/components/o-message/src/scss/_mixins.scss
@@ -11,7 +11,7 @@
 ///     	    'background-color': 'slate', // slate message
 ///     	    'foreground-color': 'white', // white text
 ///     	    'highlight-color': 'lemon', // lemon highlights with `o-message__content-highlight-color` and a lemon button
-///     	    'button-type': 'primary', // a primary o-buttons button`o-message__content-highlight` highlight copy
+///     	    'button-type': 'primary', // a primary button`o-message__content-highlight` highlight copy
 ///     	    'icon': 'user', // show a 'user' o-icons icon if used as an alert
 ///     ), $types: ('notice', 'alert')); // this state should work with notice and alert message types
 /// @access public
@@ -59,7 +59,7 @@
 			$foreground-color,
 			$background-color
 		);
-		@if($foreground-contrast < 4.5) {
+		@if ($foreground-contrast < 4.5) {
 			@error ('#{$error-message}: The foreground colour ' +
 			'"#{$foreground-color-arg}" and background colour ' +
 			'"#{$background-color-arg}" do not pass WCAG AA contrast checks.');
@@ -72,7 +72,7 @@
 			$highlight-color,
 			$background-color
 		);
-		@if($highlight-contrast < 4.5) {
+		@if ($highlight-contrast < 4.5) {
 			@error ('#{$error-message}: The highlight colour ' +
 			'"#{$highlight-color-arg}" and background colour ' +
 			'"#{$background-color-arg}" do not pass WCAG AA contrast checks.');
@@ -89,7 +89,7 @@
 		justify-content: _oMessageGet('align', $from: $opts);
 	}
 
-	&:not([data-o-message-close="false"]) .o-message__container {
+	&:not([data-o-message-close='false']) .o-message__container {
 		@if _oMessageGet('align', $from: $opts) == 'center' {
 			padding-left: $_o-message-close-inline-spacing;
 		}
@@ -105,9 +105,9 @@
 	.o-message__content-additional a {
 		@include oTypographyLink(
 			$theme: (
-				'base':  $foreground-color,
-				'hover':  $foreground-color,
-				'context':  $background-color
+				'base': $foreground-color,
+				'hover': $foreground-color,
+				'context': $background-color,
 			),
 			$include-base-styles: false
 		);
@@ -118,22 +118,24 @@
 		$button-type: _oMessageGet('button-type', $from: $opts);
 		$button-type: if($button-type, $button-type, 'secondary');
 		$button-color: if($highlight-color, $highlight-color, $foreground-color);
-		@include oButtonsContent((
-			'type': $button-type,
-			'theme': (
+		@include oPrivateButtonsContentWithThemeOverride(
+			$opts: (
+				'type': $button-type,
+			),
+			$theme-override: (
 				'color': $button-color,
-				'context': $background-color
+				'context': $background-color,
 			)
-		), $include-base-styles: false);
+		);
 	}
 
 	// action link
 	.o-message__actions__secondary {
 		@include oTypographyLink(
 			$theme: (
-				'base':  $foreground-color,
-				'hover':  $foreground-color,
-				'context':  $background-color
+				'base': $foreground-color,
+				'hover': $foreground-color,
+				'context': $background-color,
 			),
 			$include-base-styles: false
 		);
@@ -149,12 +151,20 @@
 
 	@if $supports-alert-type and $state-icon {
 		&.o-message--alert .o-message__container:before {
-			@include oIconsContent($state-icon, $foreground-color, $_o-message-alert-icon-size);
+			@include oIconsContent(
+				$state-icon,
+				$foreground-color,
+				$_o-message-alert-icon-size
+			);
 			vertical-align: middle;
 		}
 	}
 
 	.o-message__close {
-		@include oIconsContent('cross', $foreground-color, $_o-message-close-icon-size);
+		@include oIconsContent(
+			'cross',
+			$foreground-color,
+			$_o-message-close-icon-size
+		);
 	}
 }

--- a/components/o-message/stories/docs/sassdoc.md
+++ b/components/o-message/stories/docs/sassdoc.md
@@ -67,7 +67,7 @@ a Pikachu (lemon/slate) state for notice and alert messages.
 	    'background-color': 'slate', // slate message
 	    'foreground-color': 'white', // white text
 	    'highlight-color': 'lemon', // lemon highlights with `o-message__content-highlight-color` and a lemon button
-	    'button-type': 'primary', // a primary o-buttons button`o-message__content-highlight` highlight copy
+	    'button-type': 'primary', // a primary button`o-message__content-highlight` highlight copy
 	    'icon': 'user', // show a 'user' o-icons icon if used as an alert
 ), $types: ('notice', 'alert')); // this state should work with notice and alert message types
 ```

--- a/components/o-private-foundation/src/scss/o-buttons/custom-themes.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/custom-themes.scss
@@ -1,0 +1,631 @@
+/// oPrivateButtonsContent but with a custom theme.
+/// @param {Map} $opts [('type': 'null', 'size': null, 'icon': null, 'icon-only': false)] - The kind of button styles to output.
+/// @param {Map} $theme-override - The button theme to output. Either a default theme 'inverse' or custom theme map with properties `name`, `color`, and optional `context` key.
+@mixin oPrivateButtonsContentWithThemeOverride(
+	$opts: (
+		'type': null,
+		'size': null,
+		'icon': null,
+		'icon-only': false,
+	),
+	$theme-override
+) {
+	$type: map-get($opts, 'type');
+	$type: if($type, $type, 'primary');
+	$generated-colors: _oPrivateButtonsGenerateColors($type, $theme-override);
+
+	@include _oPrivateButtonsBase($opts);
+	@include _oPrivateButtonsTheme($generated-colors);
+}
+
+/// Generate the colours for a button type and theme, either an existing theme
+/// or a new theme map.
+///
+/// @example
+///		// $colors: _oPrivateButtonsGetColors('primary', ('color': 'white', 'context': 'slate'));
+///		// (
+///		// 	"color": black,
+///		// 	"background": #ffffff,
+///		// 	"border": transparent,
+///		// 	"hover-background": #c9cacc,
+///		// 	"hover-color": black,
+///		// 	"focus-background": #c9cacc,
+///		// 	"focus-color": black,
+///		// 	"active-background": #9d9fa3,
+///		// 	"active-color": black,
+///		// 	"hover-border": transparent,
+///		// 	"focus-border": transparent,
+///		// 	"active-border": transparent
+///		// )
+///
+/// @param {String} $type
+/// @param {String|Map} $theme
+/// @return {Map} - Button colours.
+@function _oPrivateButtonsGenerateColors($type, $theme: null) {
+	@if ($type != 'primary' and $type != 'secondary' and $type != 'ghost') {
+		@error 'Expected a button type of "secondary" or "primary" or "ghost".';
+	}
+
+	// Get button colour from custom theme map or brand config, see _brand.scss.
+	$color: map-get($theme, 'color');
+	$context-color: map-get($theme, 'context');
+
+	// Get button context, which is the background colour the button is placed on.
+	$page-background-usecase: oColorsByUsecase('page', 'background');
+	$context-color: if($context-color, $context-color, $page-background-usecase);
+
+	// Get button colours depending on button type.
+	$color-map: ();
+	@if ($type == 'primary') {
+		$color-map: _oPrivateButtonsGetPrimaryButtonColors($color, $context-color);
+	}
+
+	@if ($type == 'secondary') {
+		$color-map: _oPrivateButtonsGetSecondaryButtonColors(
+			$color,
+			$context-color
+		);
+	}
+
+	@if ($type == 'ghost') {
+		$color-map: _oPrivateButtonsGetGhostButtonColors($color, $context-color);
+	}
+
+	// If a button state does not have a property configured, set it to the
+	// default button colour.
+	@each $property in ('color', 'background', 'border') {
+		@each $state in ('hover', 'focus', 'active') {
+			$state-color: map-get($color-map, '#{$state}-#{$property}');
+			@if (not $state-color) {
+				$color-map: map-merge(
+					$color-map,
+					(
+						'#{$state}-#{$property}': map-get($color-map, $property),
+					)
+				);
+			}
+		}
+	}
+	@return $color-map;
+}
+
+/// For a colour and context colour (the background colour behind the button),
+/// generate primary button colours and overrides for each button state.
+///
+/// @example
+///     $colors: _oPrivateButtonsGetPrimaryButtonColors('lemon', 'slate');
+///     // (
+///     //  "color": black,
+///     //  "background": #ffec1a,
+///     //  "border": transparent,
+///     //  "hover-background": #ccbd14,
+///     //  "hover-color": black,
+///     //  "focus-background": #ccbd14,
+///     //  "focus-color": black,
+///     //  "active-background": #a69911,
+///     //  "active-color": black
+///     // )
+///
+/// @param {String|Color} $color - The button colour e.g. 'teal' (from `o-colors` palette).
+/// @param {String|Color} $context-color - The page colour behind the button (from `o-colors` palette).
+/// @return {Map} - Colours for a primary button. Including overrides for each button state.
+@function _oPrivateButtonsGetPrimaryButtonColors($color, $context-color) {
+	$color-arg: $color;
+	$context-color-arg: $context-color;
+	$default-background: if(
+		type-of($color) == 'string',
+		oColorsByName($color),
+		$color
+	);
+	$context-color: if(
+		type-of($context-color) == 'string',
+		oColorsByName($context-color),
+		$context-color
+	);
+	$default-context: $context-color == oColorsByUsecase('page', 'background');
+
+	// The default button text colour is black/white on the default page background.
+	// If a different context has been given the text colour matches if possible,
+	// or is mixed to be darker/lighter for higher contrast.
+	// o-buttons does custom contrast checks
+	$default-base-color: oColorsGetTextColor(
+		$color,
+		100,
+		$minimum-contrast: null
+	);
+	$default-color: if(
+		$default-context,
+		$default-base-color,
+		_oPrivateButtonsGetMixColor(
+			$color-a: $context-color,
+			$color-b: $default-base-color,
+			$contrast-color: $default-background,
+			$contrast-aim: 4.5,
+			$preferred-mix: 100,
+			$minimum-mix: 0,
+		)
+	);
+
+	// Derive the hover/focus/active background colour from the default
+	// background colour.
+	$hover-focus-background: null;
+	$active-background: null;
+
+	// If the background color may be tinted use tints, otherwise use a mix.
+	$is-tint: oColorsGetToneDetails($default-background);
+	@if ($is-tint) {
+		// The hover/focus background tint should be lower than the default
+		// button background. Preferably with a contrast ratio of at least 1.5,
+		// but should not have a tint value lower than ten e.g. teal-10.
+		$hover-focus-background: _oPrivateButtonsGetDarkerTint(
+			$tint: $default-background,
+			$contrast-aim: 1.5,
+			$minimum-tint-value: 10,
+		);
+
+		// The interactive background tint should be darker than the
+		// hover/focus background too.
+		$active-background: _oPrivateButtonsGetDarkerTint(
+			$tint: $hover-focus-background,
+			$contrast-aim: 1.5,
+			$minimum-tint-value: 0,
+		);
+	} @else {
+		// When lightening buttons with a mix use white. Except for the
+		// core brand where a slate button should be mixed with paper.
+		$light-mix: if(
+			oBrandIs('core') and $default-background == oColorsByName('slate'),
+			oColorsByName('paper'),
+			'white'
+		);
+
+		// When darkening buttons with a mix use black. Except for the
+		// core and internal brands, where buttons on slate should be mixed
+		// with slate.
+		$dark-mix: if(
+			(oBrandIs('core') or oBrandIs('internal')) and
+				$context-color ==
+				oColorsByName('slate'),
+			oColorsByName('slate'),
+			'black'
+		);
+
+		// Make the button darker for hover/focus states, and
+		// darker still for active states. Unless the button color has low
+		// luminance, in which case make the button lighter instead.
+		// E.g. white: 1, claret: 0.07451, slate: 0.02307
+		$color-luminance: oColorsColorLuminance($default-background);
+		$mix-color: if($color-luminance > 0.05, $dark-mix, $light-mix);
+
+		// Mix the background colour to make the hover/focus state darker or
+		// lighter. The contrast should be at least 1.5. If not try lowering
+		// the button colour until a minimum mix value we'll accept is reached.
+		$hover-focus-background: _oPrivateButtonsGetMixColor(
+			$color-a: $color,
+			$color-b: $mix-color,
+			$contrast-color: $color,
+			$contrast-aim: 1.5,
+			$preferred-mix: 80,
+			$minimum-mix: 60,
+		);
+
+		// The active background tint should have at least a contrast of 1.5
+		// against the hover/focus background colour.
+		$active-background: _oPrivateButtonsGetMixColor(
+			$color-a: $color,
+			$color-b: $mix-color,
+			$contrast-color: $hover-focus-background,
+			$contrast-aim: 1.5,
+			$preferred-mix: 70,
+			$minimum-mix: 50,
+		);
+	}
+
+	// Generate the hover/focus state text colour.
+	// The text colour is black/white on the default page background.
+	// If a different context has been given the text colour matches if possible,
+	// or is mixed to be darker/lighter for higher contrast.
+	$hover-focus-base-color: oColorsGetTextColor(
+		$hover-focus-background,
+		100,
+		$minimum-contrast: null
+	);
+	$hover-focus-color: if(
+		$default-context,
+		$hover-focus-base-color,
+		_oPrivateButtonsGetMixColor(
+			$color-a: $context-color,
+			$color-b: $hover-focus-base-color,
+			$contrast-color: $hover-focus-background,
+			$contrast-aim: 4.5,
+			$preferred-mix: 100,
+			$minimum-mix: 0,
+		)
+	);
+
+	// Generate the active state text colour.
+	// The text colour is black/white on the default page background.
+	// If a different context has been given the text colour matches if possible,
+	// or is mixed to be darker/lighter for higher contrast.
+	$active-base-color: oColorsGetTextColor(
+		$active-background,
+		100,
+		$minimum-contrast: null
+	);
+	$active-color: if(
+		$default-context,
+		$active-base-color,
+		_oPrivateButtonsGetMixColor(
+			$color-a: $context-color,
+			$color-b: $active-base-color,
+			$contrast-color: $active-background,
+			$contrast-aim: 4.5,
+			$preferred-mix: 100,
+			$minimum-mix: 0,
+		)
+	);
+
+	// Confirm the contrast of default state.
+	$contrast-error-message: 'Could not create an accessible primary button of colour "#{$color-arg}" for a background context "#{$context-color-arg}".';
+	$default-contrast-ratio: oColorsGetContrastRatio(
+		$default-color,
+		$default-background
+	);
+	@if ($default-contrast-ratio < 4.5) {
+		@error ($contrast-error-message + ' The default text and background colour do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the focus/hover state contrast.
+	$hover-contrast-ratio: oColorsGetContrastRatio(
+		$hover-focus-color,
+		$hover-focus-background
+	);
+	@if ($hover-contrast-ratio < 4.5) {
+		@error ($contrast-error-message + ' The text and background colour of the hover and focus state do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the active state contrast.
+	$active-contrast-ratio: oColorsGetContrastRatio(
+		$active-color,
+		$active-background
+	);
+	@if ($active-contrast-ratio < 4.5) {
+		@error ($contrast-error-message + ' The text and background colour of the active state do not pass WCAG AA contrast checks.');
+	}
+
+	@return (
+		'color': $default-color,
+		'background': $default-background,
+		'border': transparent,
+		'hover-background': $hover-focus-background,
+		'hover-color': $hover-focus-color,
+		'focus-background': $hover-focus-background,
+		'focus-color': $hover-focus-color,
+		'active-background': $active-background,
+		'active-color': $active-color
+	);
+}
+
+/// For a colour and context colour (the background colour behind the button),
+/// generate secondary button colours and overrides for each button state.
+///
+/// @example
+///		$colors: _oPrivateButtonsGetSecondaryButtonColors('lemon', 'slate');
+///		// (
+///		// 	"color": #ffec1a,
+///		// 	"background": transparent,
+///		// 	"border": #ffec1a,
+///		// 	"hover-background": rgba(255, 236, 26, 0.15),
+///		// 	"hover-color": #ffec1a,
+///		// 	"focus-background": rgba(255, 236, 26, 0.15),
+///		// 	"focus-color": #ffec1a,
+///		// 	"active-background": #ffec1a,
+///		// 	"active-color": black
+///		// )
+///
+/// @param {String|Color} $color - The button colour e.g. 'teal' (from `o-colors` palette).
+/// @param {String|Color} $context-color - The page colour behind the button (from `o-colors` palette).
+/// @return {Map} - Colours for a secondary button. Including overrides for each button state.
+@function _oPrivateButtonsGetSecondaryButtonColors($color, $context-color) {
+	$default-color: if(
+		type-of($color) == 'string',
+		oColorsByName($color),
+		$color
+	);
+	$default-background: transparent;
+	$default-background-opaque: if(
+		type-of($context-color) == 'string',
+		oColorsByName($context-color),
+		$context-color
+	);
+
+	// Get hover/focus colors:
+	// The secondary button hover/focus background is transparent.
+	// It should be 15% opacity if the contrast ratio against the button
+	// copy is passes WCAG AA contrast checks, otherwise use 10%.
+	$hover-focus-background-mix: _oPrivateButtonsGetMix(
+		$color-a: $color,
+		$color-b: $context-color,
+		$contrast-color: $color,
+		$contrast-aim: 4.5,
+		$preferred-mix: 15,
+		$minimum-mix: 10,
+	);
+	// Use transparency so the button may be used on a different background
+	// context, and trust the user to test accessibility in their app.
+	// But use an opaque mix to test contrast with the known context.
+	$hover-focus-background: oColorsMix(
+		$color,
+		transparent,
+		$hover-focus-background-mix
+	);
+	$hover-focus-background-opaque: oColorsMix(
+		$color,
+		$context-color,
+		$hover-focus-background-mix
+	);
+	// If the hover/focus state doesn't have high enough contrast darken/lighten
+	// the button foreground colour until it does.
+	$hover-focus-color: _oPrivateButtonsGetMixColor(
+		$color-a: $color,
+		$color-b: oColorsGetTextColor($hover-focus-background-opaque, 100),
+		$contrast-color: $hover-focus-background-opaque,
+		$contrast-aim: 4.5,
+		$preferred-mix: 100,
+		$minimum-mix: 0,
+	);
+
+	// Get active colours.
+	$active-background: $default-color;
+	$active-color: oColorsGetTextColor($active-background, 100);
+
+	// Confirm the contrast of default state.
+	$contrast-error-message: 'Could not create an accessible secondary button of colour "#{$color}" for a background context "#{$context-color}".';
+	$default-contrast-ratio: oColorsGetContrastRatio(
+		$default-color,
+		$default-background-opaque
+	);
+	@if $default-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The default text and background colour do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the focus/hover state contrast.
+	$hover-contrast-ratio: oColorsGetContrastRatio(
+		$hover-focus-color,
+		$hover-focus-background-opaque
+	);
+	@if $hover-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The text and background colour of the hover and focus state do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the active state contrast.
+	$active-contrast-ratio: oColorsGetContrastRatio(
+		$active-color,
+		$active-background
+	);
+	@if $active-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The text and background colour of the active state do not pass WCAG AA contrast checks.');
+	}
+
+	@return (
+		'color': $default-color,
+		'background': $default-background,
+		'border': $default-color,
+		'hover-background': $hover-focus-background,
+		'hover-color': $hover-focus-color,
+		'focus-background': $hover-focus-background,
+		'focus-color': $hover-focus-color,
+		'active-background': $active-background,
+		'active-color': $active-color
+	);
+}
+
+/// For a colour and context colour (the background colour behind the button),
+/// generate ghost button colours and overrides for each button state.
+///
+/// @example
+///		$colors: _oPrivateButtonsGetGhostButtonColors('lemon', 'slate');
+///		// (
+///		// 	"color": #ffec1a,
+///		// 	"background": transparent,
+///		// 	"border": #ffec1a,
+///		// 	"hover-background": rgba(255, 236, 26, 0.15),
+///		// 	"hover-color": #ffec1a,
+///		// 	"focus-background": rgba(255, 236, 26, 0.15),
+///		// 	"focus-color": #ffec1a,
+///		// 	"active-background": #ffec1a,
+///		// 	"active-color": black
+///		// )
+///
+/// @param {String|Color} $color - The button colour e.g. 'teal' (from `o-colors` palette).
+/// @param {String|Color} $context-color - The page colour behind the button (from `o-colors` palette).
+/// @return {Map} - Colours for a ghost button. Including overrides for each button state.
+@function _oPrivateButtonsGetGhostButtonColors($color, $context-color) {
+	$default-color: if(
+		type-of($color) == 'string',
+		oColorsByName($color),
+		$color
+	);
+	$default-background: transparent;
+	$default-background-opaque: if(
+		type-of($context-color) == 'string',
+		oColorsByName($context-color),
+		$context-color
+	);
+
+	// Get hover/focus colors:
+	// The secondary button hover/focus background is transparent.
+	// It should be 15% opacity if the contrast ratio against the button
+	// copy is passes WCAG AA contrast checks, otherwise use 10%.
+	$hover-focus-background-mix: _oPrivateButtonsGetMix(
+		$color-a: $color,
+		$color-b: $context-color,
+		$contrast-color: $color,
+		$contrast-aim: 4.5,
+		$preferred-mix: 15,
+		$minimum-mix: 10,
+	);
+	// Use transparency so the button may be used on a different background
+	// context, and trust the user to test accessibility in their app.
+	// But use an opaque mix to test contrast with the known context.
+	$hover-focus-background: oColorsMix(
+		$color,
+		transparent,
+		$hover-focus-background-mix
+	);
+	$hover-focus-background-opaque: oColorsMix(
+		$color,
+		$context-color,
+		$hover-focus-background-mix
+	);
+	// If the hover/focus state doesn't have high enough contrast darken/lighten
+	// the button foreground colour until it does.
+	$hover-focus-color: _oPrivateButtonsGetMixColor(
+		$color-a: $color,
+		$color-b: oColorsGetTextColor($hover-focus-background-opaque, 100),
+		$contrast-color: $hover-focus-background-opaque,
+		$contrast-aim: 4.5,
+		$preferred-mix: 100,
+		$minimum-mix: 0,
+	);
+
+	// Get active colours.
+	$active-background: $default-color;
+	$active-color: oColorsGetTextColor($active-background, 100);
+
+	// Confirm the contrast of default state.
+	$contrast-error-message: 'Could not create an accessible ghost button of colour "#{$color}" for a background context "#{$context-color}".';
+	$default-contrast-ratio: oColorsGetContrastRatio(
+		$default-color,
+		$default-background-opaque
+	);
+	@if $default-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The default text and background colour do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the focus/hover state contrast.
+	$hover-contrast-ratio: oColorsGetContrastRatio(
+		$hover-focus-color,
+		$hover-focus-background-opaque
+	);
+	@if $hover-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The text and background colour of the hover and focus state do not pass WCAG AA contrast checks.');
+	}
+	// Confirm the active state contrast.
+	$active-contrast-ratio: oColorsGetContrastRatio(
+		$active-color,
+		$active-background
+	);
+	@if $active-contrast-ratio < 4.5 {
+		@error ($contrast-error-message + ' The text and background colour of the active state do not pass WCAG AA contrast checks.');
+	}
+
+	@return (
+		'color': $default-color,
+		'background': $default-background,
+		'border': $default-background,
+		'hover-background': $hover-focus-background,
+		'hover-color': $hover-focus-color,
+		'focus-background': $hover-focus-background,
+		'focus-color': $hover-focus-color,
+		'active-background': $active-background,
+		'active-color': $active-color
+	);
+}
+
+/// Mix two colours, a and b, at the preferred mix percentage. If the contrast
+/// of the mix does not meet the contrast ratio aimed for try a lower mix
+/// percentage incrementally until either the contrast meets our aim or the
+/// minimum mix percentage is reached.
+///
+/// @param {Color|String} $color-a - the colour to mix
+/// @param {Color|String} $color-b - the colour to mix
+/// @param {Color} $contrast-color - the colour to compare the mix contrast ratio against
+/// @param {Number} $contrast-aim - the desired contrast ratio between the mix and contrast colour
+/// @param {Number} $preferred-mix - the preferable percentage to mix colours a and b
+/// @param {Number} $minimum-mix - the minimum percentage to mix colours a and b by if the aimed for contrast ratio is not met
+/// @param {Color} - A mix of colours a and b.
+@function _oPrivateButtonsGetMixColor(
+	$color-a,
+	$color-b,
+	$contrast-color,
+	$contrast-aim,
+	$preferred-mix,
+	$minimum-mix
+) {
+	$mix: _oPrivateButtonsGetMix(
+		$color-a,
+		$color-b,
+		$contrast-color,
+		$contrast-aim,
+		$preferred-mix,
+		$minimum-mix
+	);
+	@return oColorsMix($color-a, $color-b, $mix);
+}
+
+/// The mix percentage used by `_oPrivateButtonsGetMixColor`.
+/// @see _oPrivateButtonsGetMixColor
+///
+/// @param {Color|String} $color-a - the colour to mix
+/// @param {Color|String} $color-b - the colour to mix
+/// @param {Color} $contrast-color - the colour to compare the mix contrast ratio against
+/// @param {Number} $contrast-aim - the desired contrast ratio between the mix and contrast colour
+/// @param {Number} $preferred-mix - the preferable percentage to mix colours a and b
+/// @param {Number} $minimum-mix - the minimum percentage to mix colours a and b by if the aimed for contrast ratio is not met
+/// @param {Number} - A mix percentage for colours a and b
+@function _oPrivateButtonsGetMix(
+	$color-a,
+	$color-b,
+	$contrast-color,
+	$contrast-aim,
+	$preferred-mix,
+	$minimum-mix
+) {
+	$decrement: 5;
+	$value: $preferred-mix;
+	@while $value >= $minimum-mix {
+		$mix: oColorsMix($color-a, $color-b, $value);
+		$ratio: oColorsGetContrastRatio($mix, $contrast-color);
+		@if $ratio >= $contrast-aim {
+			@return $value;
+		}
+		$value: $value - $decrement;
+	}
+	@return $minimum-mix;
+}
+
+/// For a given tint colour return a darker tint which either meets the contrast
+/// ratio we're aiming for or is the lowest tint we can use.
+/// Start with a decrement of 10, then decrement by 5 onward.
+///
+// This contrast ratio and decrement is arbitrary, chosen
+// to recreate as close as possible colours chosen by the design
+// team (each button state used to be specified manually).
+@function _oPrivateButtonsGetDarkerTint(
+	$tint,
+	$contrast-aim,
+	$minimum-tint-value
+) {
+	// Current tint.
+	$tint-details: oColorsGetToneDetails($tint);
+	$tint-color: map-get($tint-details, 'color-name');
+	$tint-brightness: map-get($tint-details, 'brightness');
+	// Lower the tint value.
+	// Ensure the initial tint value isn't lower than the minimum value.
+	$initial-tint-decrement: 10;
+	$decrement: 5;
+	$initial-tint-value: $tint-brightness - $initial-tint-decrement;
+	$value: if(
+		$initial-tint-value > $minimum-tint-value,
+		$initial-tint-value,
+		$minimum-tint-value
+	);
+	// Return the new tint if the current decrement is of high enough contrast.
+	@while $value >= $minimum-tint-value {
+		$darker-tint: oColorsGetTone($tint-color, $value);
+		$ratio: oColorsGetContrastRatio($darker-tint, $tint);
+		@if $ratio >= $contrast-aim {
+			@return $darker-tint;
+		}
+		$value: $value - $decrement;
+	}
+	// No tint of a high enough contrast could be produced.
+	// Return the darkest tint we'll allow.
+	@return oColorsGetTone($tint-color, $minimum-tint-value);
+}

--- a/components/o-private-foundation/src/scss/o-buttons/main.scss
+++ b/components/o-private-foundation/src/scss/o-buttons/main.scss
@@ -1,3 +1,7 @@
+@import './custom-themes';
+
+/// Create a single button with a custom class.
+/// @param {Map} $opts [('type': 'null', 'theme': null, 'size': null, 'icon': null, 'icon-only': false)] - The kind of button styles to output.
 @mixin oPrivateButtonsContent(
 	$opts: (
 		'type': null,
@@ -11,6 +15,68 @@
 	$theme: if($theme, $theme, 'standard');
 	$type: map-get($opts, 'type');
 	$type: if($type, $type, 'primary');
+
+	@include _oPrivateButtonsBase($opts);
+
+	/* Type and theme specific styles */
+	@include _oPrivateButtonsTheme(
+		(
+			'color':
+				oPrivateFoundationGet('_o3-button-' + $type + '-' + $theme + '-color'),
+			'background':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-background'
+				),
+			'border':
+				oPrivateFoundationGet('_o3-button-' + $type + '-' + $theme + '-border'),
+			'hover-color':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-hover-color'
+				),
+			'hover-background':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-hover-background'
+				),
+			'hover-border':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-hover-border'
+				),
+			'focus-color':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-focus-color'
+				),
+			'focus-background':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-focus-background'
+				),
+			'focus-border':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-focus-border'
+				),
+			'active-color':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-active-color'
+				),
+			'active-background':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-active-background'
+				),
+			'active-border':
+				oPrivateFoundationGet(
+					'_o3-button-' + $type + '-' + $theme + '-active-border'
+				),
+		)
+	);
+}
+
+// Button styles shared across all types/theme.
+@mixin _oPrivateButtonsBase(
+	$opts: (
+		'size': null,
+		'icon': null,
+		'icon-only': false,
+	)
+) {
 	$icon-only: map-get($opts, 'icon-only');
 	$size: map-get($opts, 'size');
 	$icon: map-get($opts, 'icon');
@@ -87,64 +153,6 @@
 		cursor: default;
 	}
 
-	/* TYPE / THEME  */
-
-	color: oPrivateFoundationGet('_o3-button-' + $type + '-' + $theme + '-color');
-	background-color: oPrivateFoundationGet(
-		'_o3-button-' + $type + '-' + $theme + '-background'
-	);
-	border-color: oPrivateFoundationGet(
-		'_o3-button-' + $type + '-' + $theme + '-border'
-	);
-
-	&:hover {
-		color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-hover-color'
-		);
-		background-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-hover-background'
-		);
-		border-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-hover-border'
-		);
-	}
-
-	&:focus-visible {
-		outline: 0; // Undo standard o2 focus styles
-		color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-focus-color'
-		);
-		background-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-focus-background'
-		);
-		border-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-focus-border'
-		);
-	}
-
-	@include oPrivateNormaliseFocusApply() {
-		@include oPrivateNormaliseFocusContentForElementColour(
-			oPrivateFoundationGet(
-				'_o3-button-' + $type + '-' + $theme + '-focus-background'
-			)
-		);
-		// Ensure that the focus ring of a button is not hidden by
-		// adjacent buttons, e.g. in tabs or pagination contexts.
-		z-index: 1;
-	}
-
-	&:is(:active, [aria-selected='true'], [aria-current], [aria-pressed='true']) {
-		color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-active-color'
-		);
-		background-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-active-background'
-		);
-		border-color: oPrivateFoundationGet(
-			'_o3-button-' + $type + '-' + $theme + '-active-border'
-		);
-	}
-
 	/* ICON */
 	@if ($icon) {
 		--_o-pf-button-inline-padding-end: #{oPrivateFoundationGet('o3-spacing-s')};
@@ -189,5 +197,40 @@
 		&::before {
 			margin-right: 0;
 		}
+	}
+}
+
+// Button styles unique to a theme.
+@mixin _oPrivateButtonsTheme($theme) {
+	color: map-get($theme, 'color');
+	background-color: map-get($theme, 'background');
+	border-color: map-get($theme, 'border');
+
+	&:hover {
+		color: map-get($theme, 'hover-color');
+		background-color: map-get($theme, 'hover-background');
+		border-color: map-get($theme, 'hover-border');
+	}
+
+	&:focus-visible {
+		outline: 0; // Undo standard o2 focus styles
+		color: map-get($theme, 'focus-color');
+		background-color: map-get($theme, 'focus-background');
+		border-color: map-get($theme, 'focus-border');
+	}
+
+	@include oPrivateNormaliseFocusApply() {
+		@include oPrivateNormaliseFocusContentForElementColour(
+			map-get($theme, 'focus-background')
+		);
+		// Ensure that the focus ring of a button is not hidden by
+		// adjacent buttons, e.g. in tabs or pagination contexts.
+		z-index: 1;
+	}
+
+	&:is(:active, [aria-selected='true'], [aria-current], [aria-pressed='true']) {
+		color: map-get($theme, 'active-color');
+		background-color: map-get($theme, 'active-background');
+		border-color: map-get($theme, 'active-border');
 	}
 }


### PR DESCRIPTION
- Reluctantly port custom button colour Sass, to support messaging components.
- Remove o-buttons as an o-message dependency

I went for a different API to o-buttons to make it super clear where standard and non-standard themes are being used, to help us delete this in the future.