### PR TITLE
fix: Realign o header services to designs

### DIFF
--- a/components/o-header-services/src/scss/_secondary-nav.scss
+++ b/components/o-header-services/src/scss/_secondary-nav.scss
@@ -148,6 +148,7 @@
 		);
 		border-color: _oHeaderServicesGet('nav-border');
 		border-width: 0 1px 0 0;
+		border-radius: 0;
 		min-width: $_o-header-services-button-icon-size;
 		left: 0;
 	}
@@ -163,6 +164,7 @@
 		);
 		border-color: _oHeaderServicesGet('nav-border');
 		border-width: 0 0 0 1px;
+		border-radius: 0;
 		min-width: $_o-header-services-button-icon-size;
 		right: 0;
 	}

--- a/components/o-header-services/src/scss/_secondary-nav.scss
+++ b/components/o-header-services/src/scss/_secondary-nav.scss
@@ -127,13 +127,13 @@
 		transition: opacity 0.5s $o-pf-visual-effects-timing-fade;
 
 		&[disabled] {
-			opacity: 0;
+			display: none;
 			pointer-events: none;
 		}
 	}
 
-	.o-header-services:not([data-o-header-services-js])
-		.o-header-services__scroll-button {
+	.o-header-services:not([data-o-header-services-js]),
+	.o-header-services__scroll-button {
 		display: none;
 	}
 


### PR DESCRIPTION
## Describe your changes

o-header-services should not receive the new button designs (rounded edges) and should instead be square

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
