### PR TITLE
fix: restore o-header buttons to design

### DIFF
--- a/components/o-header/main.scss
+++ b/components/o-header/main.scss
@@ -70,6 +70,7 @@
 						'theme': 'mono',
 					)
 				);
+				border-radius: 0;
 			}
 		}
 

--- a/components/o-header/src/scss/_mixins.scss
+++ b/components/o-header/src/scss/_mixins.scss
@@ -123,7 +123,7 @@
 	display: flex;
 	align-items: center;
 	gap: 4px;
-	padding: 6px 8px;
+	padding: 4px 8px;
 	color: _oHeaderGet('header-ask-ft-button-text');
 	background-color: _oHeaderGet('header-ask-ft-button-background');
 	border-radius: 4px;

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -208,6 +208,7 @@
 				'size': 'big',
 			)
 		);
+		border-radius: 0;
 	}
 
 	//

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -149,7 +149,7 @@
 	}
 
 	.o-header__drawer-button {
-		display: block;
+		width: 100%;
 	}
 
 	//

--- a/components/o-header/src/scss/features/_drawer.scss
+++ b/components/o-header/src/scss/features/_drawer.scss
@@ -18,11 +18,7 @@
 			border-right: 1px solid _oHeaderGet('drawer-border');
 			// use a 2D transform because 3D are unsupported by IE9
 			transform: translateX(-100%);
-			transform: translate3d(
-				-100%,
-				0,
-				0
-			); // stylelint-disable-line declaration-block-no-duplicate-properties
+			transform: translate3d(-100%, 0, 0); // stylelint-disable-line declaration-block-no-duplicate-properties
 
 			// this is literally the specification example for will-change
 			will-change: transform;
@@ -38,11 +34,7 @@
 			&.o-header__drawer--open {
 				// use a 2D transform because 3D are unsupported by IE9
 				transform: translateX(0);
-				transform: translate3d(
-					0,
-					0,
-					0
-				); // stylelint-disable-line declaration-block-no-duplicate-properties
+				transform: translate3d(0, 0, 0); // stylelint-disable-line declaration-block-no-duplicate-properties
 			}
 		}
 	}

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -66,6 +66,7 @@
 				'size': 'big',
 			)
 		);
+		border-radius: 0;
 		display: flex;
 		gap: 10px;
 		align-items: center;

--- a/components/o-header/src/scss/features/_transparent.scss
+++ b/components/o-header/src/scss/features/_transparent.scss
@@ -51,6 +51,7 @@
 					'theme': 'inverse',
 				)
 			);
+			border-radius: 0;
 		}
 
 		.o-header__nav-link,


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
