### PR TITLE
chore: Make base type tokens tokens.

### DIFF
--- a/apps/dictionary/src/transforms/private-prefix.js
+++ b/apps/dictionary/src/transforms/private-prefix.js
@@ -1,7 +1,18 @@
 import {tokenStudioThemeToBrand, getTokenStudioThemes} from '../utils.js';
 
 const privatePrefix = token => {
-	return isTokenStudioSource(token) ? `_${token.name}` : token.name;
+	const isSourceExceptionForEngineering = token => {
+		// We do not want to export our typography scale in Figma for end users.
+		// However to support migration efforts we want it to still be available in the engineering token set.
+		if (token.filePath.includes('base/typography')) {
+			return true;
+		}
+		return false;
+	};
+
+	return isTokenStudioSource(token) && !isSourceExceptionForEngineering(token)
+		? `_${token.name}`
+		: token.name;
 };
 
 /*Get token theme from brand in token set file path.*/

--- a/apps/dictionary/tokens/$themes.json
+++ b/apps/dictionary/tokens/$themes.json
@@ -16,7 +16,7 @@
       "core/base/border-radius": "enabled",
       "sustainable-views/base/border-radius": "disabled",
       "internal/base/border-radius": "disabled",
-      "core/base/typography": "enabled",
+      "core/base/typography": "source",
       "core/use-case/focus": "enabled"
     },
     "$figmaStyleReferences": {
@@ -230,7 +230,7 @@
       "core/professional/components/o3-form": "source",
       "sustainable-views/base/border-radius": "disabled",
       "internal/base/border-radius": "disabled",
-      "core/base/typography": "enabled",
+      "core/base/typography": "source",
       "core/use-case/focus": "enabled"
     },
     "$figmaStyleReferences": {
@@ -434,7 +434,7 @@
       "internal/use-case/typography": "enabled",
       "internal/components/o3-form": "source",
       "internal/components/o3-form/use-case": "source",
-      "internal/base/typography": "enabled",
+      "internal/base/typography": "source",
       "internal/use-case/focus": "enabled",
       "internal/base/border-radius": "enabled"
     },
@@ -589,9 +589,9 @@
       "whitelabel/base/border-radius": "enabled",
       "sustainable-views/base/border-radius": "disabled",
       "internal/base/border-radius": "disabled",
-      "core/base/typography": "enabled",
+      "core/base/typography": "source",
       "core/use-case/focus": "source",
-      "whitelabel/base/typography": "enabled",
+      "whitelabel/base/typography": "source",
       "whitelabel/use-case/focus": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:9567:451",
@@ -666,7 +666,7 @@
       "sustainable-views/use-case/typography": "enabled",
       "sustainable-views/components/o3-form": "source",
       "sustainable-views/components/o3-form/use-case": "source",
-      "sustainable-views/base/typography": "enabled",
+      "sustainable-views/base/typography": "source",
       "sustainable-views/use-case/focus": "enabled",
       "sustainable-views/base/border-radius": "enabled",
       "internal/base/border-radius": "disabled"


### PR DESCRIPTION
We do not want to export our typography scale in Figma for end users, as we have specific usecases now. It is a bit of a pain to exclude the generated Figma variables or styles from publihsing. To support migration efforts we want it to still be available in the engineering token set.

I have rebuilt tokens and there are no changes to the built CSS, which we expect.