### PR TITLE
[OR-1207]: o-colors failing test

### DIFF
--- a/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
+++ b/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
@@ -127,8 +127,8 @@
 			right: 20px;
 		}
 
+		/* stylelint-disable-next-line selector-max-id */
 		#add-mix {
-			//stylelint-disable-line selector-max-id
 			background-image: none;
 			font-size: inherit;
 			float: none;


### PR DESCRIPTION
## Describe your changes
Updating the exclusion in stylelint that will exclude the `#add-mix` correctly.

## Issue ticket number and link
[OR-1207](https://financialtimes.atlassian.net/browse/OR-1207)

## Additional comments
This is part of the ongoing work to check and remedy the failing tests in the `2025-release` branch ahead of its migration/deployment.


[OR-1207]: https://financialtimes.atlassian.net/browse/OR-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ