### PR TITLE
Begin applying use-case tokens to o3 components. 

### DIFF
--- a/components/o3-editorial-typography/details.css
+++ b/components/o3-editorial-typography/details.css
@@ -130,7 +130,7 @@ a.o3-editorial-typography-byline-author[data-o3-theme='inverse'] {
 		content: '';
 		width: var(--_o3-editorial-typography-quote-icon-size);
 		height: var(--_o3-editorial-typography-quote-icon-size);
-		mask-image: var(--o3-icon-speech-left);
+		mask-image: var(--o3-icon-quote-left);
 		mask-repeat: no-repeat;
 		mask-size: contain;
 		display: inline-block;
@@ -160,36 +160,27 @@ a.o3-editorial-typography-byline-author[data-o3-theme='inverse'] {
 }
 
 .o3-editorial-typography-pullquote__author {
-	font-family: var(--o3-typography-use-case-body-small-bold-font-family),
+	font-family: var(--o3-typography-use-case-body-base-highlight-font-family),
 		sans-serif;
-	font-size: var(--o3-typography-use-case-body-small-bold-font-size);
-	font-weight: var(--o3-typography-use-case-body-small-bold-font-weight);
-	line-height: var(--o3-typography-use-case-body-small-bold-line-height);
-}
-
-.o3-editorial-typography-pullquote__source {
-	font-family: var(--_o3-editorial-typography-pullquote-source-font-family),
-		sans-serif;
-	font-size: var(--_o3-editorial-typography-pullquote-source-font-size);
-	font-weight: var(--_o3-editorial-typography-pullquote-source-font-weight);
-	line-height: var(--_o3-editorial-typography-pullquote-source-line-height);
+	font-size: var(--o3-typography-use-case-body-base-highlight-font-size);
+	font-weight: var(--o3-typography-use-case-body-base-highlight-font-weight);
+	line-height: var(--o3-typography-use-case-body-base-highlight-line-height);
 }
 
 .o3-editorial-typography-blockquote__author {
-	font-family: var(--o3-typography-use-case-body-small-bold-font-family),
-		sans-serif;
-	font-size: var(--o3-typography-use-case-body-small-bold-font-size);
-	font-weight: var(--o3-typography-use-case-body-small-bold-font-weight);
-	line-height: var(--o3-typography-use-case-body-small-bold-line-height);
-	text-transform: uppercase;
+	font-family: var(--o3-typography-use-case-label-font-family), sans-serif;
+	font-size: var(--o3-typography-use-case-label-font-size);
+	font-weight: var(--o3-typography-use-case-label-font-weight);
+	line-height: var(--o3-typography-use-case-label-line-height);
+	text-transform: var(--o3-typography-use-case-label-text-case);
 }
 
 .o3-editorial-typography-blockquote__source {
-	font-family: var(--o3-typography-use-case-body-standard-font-family),
-		sans-serif;
-	font-size: var(--o3-typography-use-case-body-standard-font-size);
-	font-weight: var(--o3-typography-use-case-body-standard-font-weight);
-	line-height: var(--o3-typography-use-case-body-standard-line-height);
+	font-family: var(--o3-typography-use-case-detail-font-family), sans-serif;
+	font-size: var(--o3-typography-use-case-detail-font-size);
+	font-weight: var(--o3-typography-use-case-detail-font-weight);
+	line-height: var(--o3-typography-use-case-detail-line-height);
+	text-transform: var(--o3-typography-use-case-detail-text-case);
 }
 
 .o3-editorial-typography-big-number,

--- a/components/o3-editorial-typography/details.css
+++ b/components/o3-editorial-typography/details.css
@@ -180,7 +180,6 @@ a.o3-editorial-typography-byline-author[data-o3-theme='inverse'] {
 	font-size: var(--o3-typography-use-case-detail-font-size);
 	font-weight: var(--o3-typography-use-case-detail-font-weight);
 	line-height: var(--o3-typography-use-case-detail-line-height);
-	text-transform: var(--o3-typography-use-case-detail-text-case);
 }
 
 .o3-editorial-typography-big-number,

--- a/components/o3-editorial-typography/heading.css
+++ b/components/o3-editorial-typography/heading.css
@@ -1,8 +1,8 @@
 .o3-editorial-typography-headline {
-	font-family: var(--_o3-editorial-typography-headline-s-font-family), serif;
-	font-size: var(--_o3-editorial-typography-headline-s-font-size);
-	font-weight: var(--_o3-editorial-typography-headline-s-font-weight);
-	line-height: var(--_o3-editorial-typography-headline-s-line-height);
+	font-family: var(--o3-typography-use-case-headline-sm-font-family), serif;
+	font-size: var(--o3-typography-use-case-headline-sm-font-size);
+	font-weight: var(--o3-typography-use-case-headline-sm-font-weight);
+	line-height: var(--o3-typography-use-case-headline-sm-line-height);
 }
 
 .o3-editorial-typography-display {
@@ -43,9 +43,9 @@
 
 @media (min-width: 740px) {
 	.o3-editorial-typography-headline {
-		font-size: var(--_o3-editorial-typography-headline-m-font-size);
-		font-weight: var(--_o3-editorial-typography-headline-m-font-weight);
-		line-height: var(--_o3-editorial-typography-headline-m-line-height);
+		font-size: var(--o3-typography-use-case-headline-md-font-size);
+		font-weight: var(--o3-typography-use-case-headline-md-font-weight);
+		line-height: var(--o3-typography-use-case-headline-md-line-height);
 	}
 
 	.o3-editorial-typography-display {
@@ -57,9 +57,9 @@
 
 @media (min-width: 980px) {
 	.o3-editorial-typography-headline {
-		font-size: var(--_o3-editorial-typography-headline-l-font-size);
-		font-weight: var(--_o3-editorial-typography-headline-l-font-weight);
-		line-height: var(--_o3-editorial-typography-headline-l-line-height);
+		font-size: var(--o3-typography-use-case-headline-lg-font-size);
+		font-weight: var(--o3-typography-use-case-headline-lg-font-weight);
+		line-height: var(--o3-typography-use-case-headline-lg-line-height);
 	}
 
 	.o3-editorial-typography-display {

--- a/components/o3-editorial-typography/heading.css
+++ b/components/o3-editorial-typography/heading.css
@@ -22,23 +22,24 @@
 }
 
 .o3-editorial-typography-chapter {
-	font-family: var(--_o3-editorial-typography-chapter-font-family), sans-serif;
-	font-size: var(--_o3-editorial-typography-chapter-font-size);
-	font-weight: var(--_o3-editorial-typography-chapter-font-weight);
-	line-height: var(--_o3-editorial-typography-chapter-line-height);
+	font-family: var(--o3-typography-use-case-title-lg-font-family), sans-serif;
+	font-size: var(--o3-typography-use-case-title-lg-font-size);
+	font-weight: var(--o3-typography-use-case-title-lg-font-weight);
+	line-height: var(--o3-typography-use-case-title-lg-line-height);
 }
+
 .o3-editorial-typography-subheading {
-	font-family: var(--_o3-editorial-typography-subheading-font-family),
-		sans-serif;
-	font-size: var(--_o3-editorial-typography-subheading-font-size);
-	font-weight: var(--_o3-editorial-typography-subheading-font-weight);
-	line-height: var(--_o3-editorial-typography-subheading-line-height);
+	font-family: var(--o3-typography-use-case-title-md-font-family), sans-serif;
+	font-size: var(--o3-typography-use-case-title-md-font-size);
+	font-weight: var(--o3-typography-use-case-title-md-font-weight);
+	line-height: var(--o3-typography-use-case-title-md-line-height);
 }
+
 .o3-editorial-typography-label {
-	font-family: var(--_o3-editorial-typography-label-font-family), sans-serif;
-	font-size: var(--_o3-editorial-typography-label-font-size);
-	font-weight: var(--_o3-editorial-typography-label-font-weight);
-	line-height: var(--_o3-editorial-typography-label-line-height);
+	font-family: var(--o3-typography-use-case-body-base-font-family), sans-serif;
+	font-size: var(--o3-typography-use-case-body-base-font-size);
+	font-weight: var(--o3-typography-use-case-body-base-font-weight);
+	line-height: var(--o3-typography-use-case-body-base-line-height);
 }
 
 @media (min-width: 740px) {

--- a/components/o3-editorial-typography/stories/story-templates.tsx
+++ b/components/o3-editorial-typography/stories/story-templates.tsx
@@ -86,7 +86,7 @@ const HeadingTemplate: StoryObj = {
 	argTypes: {
 		...TemplateSBConfig.argTypes,
 		type: {
-			options: ['display', 'Heading', 'subheading', 'chapter', 'label'],
+			options: ['display', 'headline', 'subheading', 'chapter', 'label'],
 			control: {
 				type: 'radio',
 			},


### PR DESCRIPTION
Builds on #1923 with:

* Remaining heading tokens
* Quote tokens


Note that `o3-editorial-typography-pullquote-content` tokens have the wrong values – this needs to be updated in Token Studio and applied in Figma. Feedback left for the design team. Moving on for now.
