### PR TITLE
or-1119: use typography use cases in o3-forms.

### DIFF
--- a/components/o3-form/src/css/components/checkbox.css
+++ b/components/o3-form/src/css/components/checkbox.css
@@ -128,8 +128,9 @@
 .o3-form-input-checkbox__label {
 	display: flex;
 	align-items: center;
-	font-size: var(--o3-typography-use-case-body-small-font-size);
-	line-height: var(--o3-typography-use-case-body-small-line-height);
-	font-weight: var(--o3-typography-use-case-body-small-font-weight);
+	font-family: var(--o3-typography-use-case-body-lg-font-family);
+	font-size: var(--o3-typography-use-case-body-lg-font-size);
+	font-weight: var(--o3-typography-use-case-body-lg-font-weight);
+	line-height: var(--o3-typography-use-case-body-lg-line-height);
 	color: var(--o3-color-use-case-body-text);
 }

--- a/components/o3-form/src/css/components/error-summary.css
+++ b/components/o3-form/src/css/components/error-summary.css
@@ -18,7 +18,10 @@
 	.o3-form__error-summary__heading {
 		margin-left: var(--o3-spacing-4xs);
 		& > span {
-			font-weight: var(--o3-font-weight-medium);
+			font-family: var(--o3-typography-use-case-body-highlight-font-family);
+			font-size: var(--o3-typography-use-case-body-highlight-font-size);
+			font-weight: var(--o3-typography-use-case-body-highlight-font-weight);
+			line-height: var(--o3-typography-use-case-body-highlight-line-height);
 			color: var(--o3-color-use-case-error-text);
 			display: inline-block;
 			margin-bottom: var(--o3-spacing-4xs);

--- a/components/o3-form/src/css/components/feedback.css
+++ b/components/o3-form/src/css/components/feedback.css
@@ -1,8 +1,10 @@
 .o3-form-feedback__error {
 	display: flex;
 	align-items: center;
-	font-size: var(--o3-font-size-metric2-negative-1);
-	line-height: var(--o3-font-lineheight-metric2-negative-1);
+	font-family: var(--o3-typography-use-case-detail-font-family);
+	font-size: var(--o3-typography-use-case-detail-font-size);
+	font-weight: var(--o3-typography-use-case-detail-font-weight);
+	line-height: var(--o3-typography-use-case-detail-line-height);
 	color: var(--o3-color-use-case-error-text);
 }
 

--- a/components/o3-form/src/css/components/form-field.css
+++ b/components/o3-form/src/css/components/form-field.css
@@ -20,9 +20,10 @@
 	.o3-form-field__label,
 	.o3-form-field__title,
 	.o3-form-field__legend {
-		font-size: var(--o3-font-size-metric2-0);
-		line-height: var(--o3-font-lineheight-metric2-0);
-		font-weight: var(--o3-font-weight-semibold);
+		font-family: var(--o3-typography-use-case-body-highlight-font-family);
+		font-size: var(--o3-typography-use-case-body-highlight-font-family);
+		font-weight: var(--o3-typography-use-case-body-highlight-font-weight);
+		line-height: var(--o3-typography-use-case-body-highlight-line-height);
 		color: var(--o3-color-use-case-body-text);
 
 		&.o3-form-field--optional::after {
@@ -34,9 +35,10 @@
 	}
 
 	.o3-form-input__description {
-		font-size: var(--o3-font-size-metric2-0);
-		line-height: var(--o3-font-lineheight-metric2-0);
-		font-weight: var(--o3-font-weight-regular);
+		font-family: var(--o3-typography-use-case-body-base-font-family);
+		font-size: var(--o3-typography-use-case-body-base-font-family);
+		font-weight: var(--o3-typography-use-case-body-base-font-weight);
+		line-height: var(--o3-typography-use-case-body-base-line-height);
 		color: var(--o3-color-use-case-body-text);
 	}
 

--- a/components/o3-form/src/css/components/form-field.css
+++ b/components/o3-form/src/css/components/form-field.css
@@ -45,8 +45,3 @@
 		margin-top: calc(-1 * var(--o3-spacing-4xs));
 	}
 }
-
-.o3-form-field__feedback--error {
-	color: var(--o3-color-use-case-error);
-	font-size: var(--o3-font-size-metric2-negative-1);
-}

--- a/components/o3-form/src/css/components/password-input.css
+++ b/components/o3-form/src/css/components/password-input.css
@@ -5,8 +5,8 @@
     max-width: var(--o3-grid-columns-to-span-width, 100%);
     margin-top: var(--o3-spacing-3xs);
 
-    font-family: var(--o3-typography-use-case-body-lg-font-family);
-    font-size: var(--o3-typography-use-case-body-lg-font-size);
-    font-weight: var(--o3-typography-use-case-body-lg-font-weight);
-    line-height: var(--o3-typography-use-case-body-lg-line-height);
+    font-family: var(--o3-typography-use-case-body-base-font-family);
+    font-size: var(--o3-typography-use-case-body-base-font-size);
+    font-weight: var(--o3-typography-use-case-body-base-font-weight);
+    line-height: var(--o3-typography-use-case-body-base-line-height);
 }

--- a/components/o3-form/src/css/components/password-input.css
+++ b/components/o3-form/src/css/components/password-input.css
@@ -5,6 +5,8 @@
     max-width: var(--o3-grid-columns-to-span-width, 100%);
     margin-top: var(--o3-spacing-3xs);
 
-    font-size: var(--o3-font-size-metric2-negative-1);
-    line-height: var(--o3-font-lineheight-metric2-negative-1);
+    font-family: var(--o3-typography-use-case-body-lg-font-family);
+    font-size: var(--o3-typography-use-case-body-lg-font-size);
+    font-weight: var(--o3-typography-use-case-body-lg-font-weight);
+    line-height: var(--o3-typography-use-case-body-lg-line-height);
 }

--- a/components/o3-form/src/css/components/radio-button.css
+++ b/components/o3-form/src/css/components/radio-button.css
@@ -94,9 +94,9 @@
 .o3-form-input-radio-button__label {
 	display: flex;
 	align-items: center;
-	font-size: var(--o3-typography-use-case-body-small-font-size);
-	line-height: var(--o3-typography-use-case-body-small-line-height);
-	font-weight: var(--o3-typography-use-case-body-small-font-weight);
-	font-family: var(--o3-typography-use-case-body-small-font-family);
+	font-size: var(--o3-typography-use-case-body-lg-font-size);
+	font-weight: var(--o3-typography-use-case-body-lg-font-weight);
+	font-family: var(--o3-typography-use-case-body-lg-font-family);
+	line-height: var(--o3-typography-use-case-body-lg-line-height);
 	color: var(--o3-color-use-case-body-text);
 }

--- a/components/o3-form/src/css/components/text-input.css
+++ b/components/o3-form/src/css/components/text-input.css
@@ -4,8 +4,10 @@
     background-color: var(--_o3-form-color-use-case-background);
 	box-sizing: border-box;
     border-radius: var(--_o3-form-input-border-radius);
-    font-size: var(--o3-font-size-metric2-1);
-    line-height: var(--o3-font-lineheight-metric2-1);
+    font-family: var(--o3-typography-use-case-body-lg-font-family);
+    font-size: var(--o3-typography-use-case-body-lg-font-size);
+    font-weight: var(--o3-typography-use-case-body-lg-font-weight);
+    line-height: var(--o3-typography-use-case-body-lg-line-height);
     --o3-grid-columns-to-span-count: 4;
     max-width: var(--_o3-form-text-input-max-width, var(--o3-grid-columns-to-span-width));
     min-height: 44px;


### PR DESCRIPTION
## Describe your changes
* Uses o3-typography's use case tokens in o3-form components.
* Removes unused class.

**note:** merge preserving commit history providing commits stay concise.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [x] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
