### PR TITLE
chore: change from hex to rgb in tests

### DIFF
--- a/components/o-colors/test/scss/_functions.test.scss
+++ b/components/o-colors/test/scss/_functions.test.scss
@@ -21,26 +21,27 @@
 			@include assert-equal(oColorsByName('org-b2c-light'), (#99c6fb));
 			@include assert-equal(oColorsByName('transparent'), (transparent));
 		}
+
 		@include it('returns an error if `$color-name` is not a string') {
 			@include assert-equal(oColorsByName(null),
-			('ERROR: `$color-name` should be a string but found "null" of type "null".'));
+				('ERROR: `$color-name` should be a string but found "null" of type "null".'));
 		}
 	}
 
 	@include describe('oColorsMix') {
 		@include it('returns a color based on background and base color') {
-			@include assert-equal(oColorsMix(), (#33302e));
-			@include assert-equal(oColorsMix($color: 'candy'), (#ff96b6));
-			@include assert-equal(oColorsMix('candy'), (#ff96b6));
-			@include assert-equal(oColorsMix($background: 'lemon'), (#332f05));
-			@include assert-equal(oColorsMix($percentage: 20), (#ccc1b7));
-			@include assert-equal(oColorsMix($color: 'claret', $background: 'wheat', $percentage: 50), (#c67786));
-			@include assert-equal(oColorsMix('claret', 'wheat', 50), (#c67786));
+			@include assert-equal(oColorsMix(), (rgb(51, 48.2, 45.8))); // #33302e
+			@include assert-equal(oColorsMix($color: 'candy'), (rgb(255, 149.8, 181.8))); // #ff96b6
+			@include assert-equal(oColorsMix('candy'), (rgb(255, 149.8, 181.8))); // #ff96b6
+			@include assert-equal(oColorsMix($background: 'lemon'), (rgb(51, 47.2, 5.2))); // #332f05
+			@include assert-equal(oColorsMix($percentage: 20), (rgb(204, 192.8, 183.2))); // #ccc1b7
+			@include assert-equal(oColorsMix($color: 'claret', $background: 'wheat', $percentage: 50), (rgb(197.5, 119, 133.5))); // #c67786
+			@include assert-equal(oColorsMix('claret', 'wheat', 50), (rgb(197.5, 119, 133.5))); // #c67786
 			@include assert-equal(oColorsMix('black', 'transparent', 50), rgba(0, 0, 0, 0.5));
 		}
 
 		@include it('mixes FT colours, not web colours, when a string is not explicitly passed') {
-			@include assert-equal(oColorsMix(paper, wheat, 30), (#f6e4d5));
+			@include assert-equal(oColorsMix(paper, wheat, 30), (rgb(245.9, 228.4, 212.9))); // #f6e4d5
 		}
 	}
 
@@ -89,38 +90,32 @@
 		}
 
 		@include it('returns a tone for custom palette colours that allow tones') {
-			@include oColorsSetColor(
-				'o-example/olive-with-tones-allowed',
+			@include oColorsSetColor('o-example/olive-with-tones-allowed',
 				#808000,
-				('allow-tones': true)
-			);
-			@include assert-equal(
-				oColorsGetTone('o-example/olive-with-tones-allowed', 100),
+				('allow-tones': true));
+			@include assert-equal(oColorsGetTone('o-example/olive-with-tones-allowed', 100),
 				hsl(60, 100%, 50%),
-				$inspect: true
-			);
+				$inspect: true);
 		}
 
 		@include it('returns an error for default palette colours which do not allow tones') {
 			@include assert-equal(oColorsGetTone('black', 10),
-			('ERROR: "black" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
-			$inspect: true);
+				('ERROR: "black" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
+				$inspect: true);
 			@include assert-equal(oColorsGetTone('white', 10),
-			('ERROR: "white" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
-			$inspect: true);
+				('ERROR: "white" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
+				$inspect: true);
 			@include assert-equal(oColorsGetTone('slate', 10),
-			('ERROR: "slate" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
-			$inspect: true);
+				('ERROR: "slate" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
+				$inspect: true);
 		}
 
 		@include it('returns an error for default palette colours which do not allow tones') {
-			@include oColorsSetColor(
-				'o-example/olive-without-tones',
-				#808000
-			);
+			@include oColorsSetColor('o-example/olive-without-tones',
+				#808000);
 			@include assert-equal(oColorsGetTone('o-example/olive-without-tones', 100),
-			('ERROR: "o-example/olive-without-tones" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
-			$inspect: true);
+				('ERROR: "o-example/olive-without-tones" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
+				$inspect: true);
 		}
 	}
 
@@ -137,85 +132,99 @@
 
 	@include describe('oColorsGetPaletteDetails') {
 		@include it('returns default palette colours without a namespace') {
-			$palette-names: ();
-			@each $color-map in oColorsGetPaletteDetails() {
-				$name: map-get($color-map, 'name');
-				$palette-names: append($palette-names, $name);
-			}
-			$has-paper: index($palette-names, 'paper') != null;
-			@include assert-equal($has-paper, true);
+			$palette-names: (
+			);
+
+		@each $color-map in oColorsGetPaletteDetails() {
+			$name: map-get($color-map, 'name');
+			$palette-names: append($palette-names, $name);
 		}
 
-		@include it('returns custom palette colours with a namespace') {
-			$example-color: #808000;
-			@include oColorsSetColor('o-example/palette-details-test', $example-color);
-
-			$palette-names: ();
-			@each $color-map in oColorsGetPaletteDetails() {
-				$name: map-get($color-map, 'name');
-				$palette-names: append($palette-names, $name);
-			}
-			$has-test-color: index($palette-names, 'o-example/palette-details-test') != null;
-			@include assert-equal($has-test-color, true);
-		}
+		$has-paper: index($palette-names, 'paper') !=null;
+		@include assert-equal($has-paper, true);
 	}
 
-	@include describe('oColorsGetTextColor') {
-		@include it('returns a text color based on background colour and opacity percentage') {
-			@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), #1a1817);
-			@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-80'), 100), white);
-			@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-90'), 100), black);
-		}
-		@include it('returns a text color based on background colour name and opacity percentage') {
-			@include assert-equal(oColorsGetTextColor('paper'), #1a1817);
-			@include assert-equal(oColorsGetTextColor('oxford-80', 100), white);
-			@include assert-equal(oColorsGetTextColor('oxford-90', 100), black);
-		}
-		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
-			@include assert-equal(oColorsGetTextColor('black-40', 50),
-			('ERROR: The text colour generated for "black-40" at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 aa-normal required contrast ratio of at least 4.5:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
-		}
-		@include it('throws an error for an invalid contrast ratio check') {
-			@include assert-equal(oColorsGetTextColor('black-40', 50, 'aaaaaaaa-large'),
+	@include it('returns custom palette colours with a namespace') {
+		$example-color: #808000;
+		@include oColorsSetColor('o-example/palette-details-test', $example-color);
+
+		$palette-names: (
+		);
+
+	@each $color-map in oColorsGetPaletteDetails() {
+		$name: map-get($color-map, 'name');
+		$palette-names: append($palette-names, $name);
+	}
+
+	$has-test-color: index($palette-names, 'o-example/palette-details-test') !=null;
+	@include assert-equal($has-test-color, true);
+}
+}
+
+@include describe('oColorsGetTextColor') {
+	@include it('returns a text color based on background colour and opacity percentage') {
+		@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), rgb(25.5, 24.1, 22.9)); // #1a1817
+		@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-80'), 100), white);
+		@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-90'), 100), black);
+	}
+
+	@include it('returns a text color based on background colour name and opacity percentage') {
+		@include assert-equal(oColorsGetTextColor('paper'), rgb(25.5, 24.1, 22.9)); // #1a1817
+		@include assert-equal(oColorsGetTextColor('oxford-80', 100), white);
+		@include assert-equal(oColorsGetTextColor('oxford-90', 100), black);
+	}
+
+	@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
+		@include assert-equal(oColorsGetTextColor('black-40', 50),
+			('ERROR: The text colour generated for "black-40" at 50% opacity has a contrast ratio of "2.9" and does not pass the WCAG 2.1 aa-normal required contrast ratio of at least 4.5:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
+	}
+
+	@include it('throws an error for an invalid contrast ratio check') {
+		@include assert-equal(oColorsGetTextColor('black-40', 50, 'aaaaaaaa-large'),
 			('ERROR: The minimum contrast must by one of "aa-normal, aa-large, aaa-normal, aaa-large" or `null`. Found ""aaaaaaaa-large"".'));
-		}
-		@include it('throws an error if a text color and background does not pass a custom contrast ratio check') {
-			@include assert-equal(oColorsGetTextColor('black-40', 50, 'aa-large'),
-			('ERROR: The text colour generated for "black-40" at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 aa-large required contrast ratio of at least 3:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
-		}
-		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and `$minimum-contrast` is set the `null`') {
-			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $minimum-contrast: null),  #4d4945);
-		}
 	}
 
-	@include describe('oColorsColorBrightness') {
-		@include test('returns the % of brightness in a color') {
-			@include assert-equal(round(oColorsColorBrightness(#ffffff)), 100%);
-			@include assert-equal(round(oColorsColorBrightness(#000000)), 0%);
-			@include assert-equal(round(oColorsColorBrightness(#fff1e5)), 96%);
-		}
-		@include test('returns the % of brightness in a palette color') {
-			@include assert-equal(round(oColorsColorBrightness('teal')), 41%);
-		}
+	@include it('throws an error if a text color and background does not pass a custom contrast ratio check') {
+		@include assert-equal(oColorsGetTextColor('black-40', 50, 'aa-large'),
+			('ERROR: The text colour generated for "black-40" at 50% opacity has a contrast ratio of "2.9" and does not pass the WCAG 2.1 aa-large required contrast ratio of at least 3:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
 	}
 
-	@include describe('oColorsColorLuminance') {
-		@include test('returns luminance of a color as float') {
-			@include assert-equal(oColorsColorLuminance(#ffffff), 1);
-			@include assert-equal(oColorsColorLuminance(#000000), 0);
-		}
-		@include test('returns luminance of a palette color as float') {
-			@include assert-equal(oColorsColorLuminance('teal'), 0.1460094504, $inspect: true);
-		}
+	@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and `$minimum-contrast` is set the `null`') {
+		@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $minimum-contrast: null), rgb(76.5, 72.3, 68.7)); // #4d4945
+	}
+}
+
+@include describe('oColorsColorBrightness') {
+	@include test('returns the % of brightness in a color') {
+		@include assert-equal(round(oColorsColorBrightness(#ffffff)), 100%);
+		@include assert-equal(round(oColorsColorBrightness(#000000)), 0%);
+		@include assert-equal(round(oColorsColorBrightness(#fff1e5)), 96%);
 	}
 
-	@include describe('oColorsGetContrastRatio') {
-		@include test('calculate the contrast ratio between two colors') {
-			@include assert-equal(oColorsGetContrastRatio(#ffffff, #fff1e5), 1.1, $inspect: true);
-			@include assert-equal(oColorsGetContrastRatio(#000000, #fff1e5), 18.96, $inspect: true);
-		}
-		@include test('calculate the contrast ratio between two palette colors') {
-			@include assert-equal(oColorsGetContrastRatio('paper', 'black-10'), 1.24, $inspect: true);
-		}
+	@include test('returns the % of brightness in a palette color') {
+		@include assert-equal(round(oColorsColorBrightness('teal')), 41%);
 	}
+}
+
+@include describe('oColorsColorLuminance') {
+	@include test('returns luminance of a color as float') {
+		@include assert-equal(oColorsColorLuminance(#ffffff), 1);
+		@include assert-equal(oColorsColorLuminance(#000000), 0);
+	}
+
+	@include test('returns luminance of a palette color as float') {
+		@include assert-equal(oColorsColorLuminance('teal'), 0.1460094504, $inspect: true);
+	}
+}
+
+@include describe('oColorsGetContrastRatio') {
+	@include test('calculate the contrast ratio between two colors') {
+		@include assert-equal(oColorsGetContrastRatio(#ffffff, #fff1e5), 1.1, $inspect: true);
+		@include assert-equal(oColorsGetContrastRatio(#000000, #fff1e5), 18.96, $inspect: true);
+	}
+
+	@include test('calculate the contrast ratio between two palette colors') {
+		@include assert-equal(oColorsGetContrastRatio('paper', 'black-10'), 1.24, $inspect: true);
+	}
+}
 }

--- a/components/o-colors/test/scss/_mixins.test.scss
+++ b/components/o-colors/test/scss/_mixins.test.scss
@@ -13,6 +13,7 @@
 				}
 			}
 		}
+
 		@include it('outputs usecase custom properties by default') {
 			@include assert() {
 				@include output($selector: false) {
@@ -26,6 +27,7 @@
 				}
 			}
 		}
+
 		@include it('outputs usecase classes by default') {
 			@include assert() {
 				@include output($selector: false) {
@@ -43,9 +45,7 @@
 		@include it('outputs palette custom properties with only the "palette-custom-properties" option') {
 			@include assert() {
 				@include output($selector: false) {
-					@include oColors($opts: (
-						'palette-custom-properties': true
-					));
+					@include oColors($opts: ('palette-custom-properties': true));
 				}
 
 				@include contains($selector: false) {
@@ -59,18 +59,17 @@
 		@include it('outputs only usecase custom properties with only the "usecase-custom-properties" option') {
 			@include assert() {
 				@include output($selector: false) {
-					@include oColors($opts: (
-						'usecase-custom-properties': true
-					));
+					@include oColors($opts: ('usecase-custom-properties': true));
 				}
 
 				@include expect($selector: false) {
 					:root {
-						--o-colors-page-background: #fff1e5;
-						--o-colors-box-background: #f2dfce;
-						--o-colors-body-text: #33302e;
-						--o-colors-muted-text: #ccc1b7;
-						--o-colors-link-text: #0d7680;
+						--o-colors-page-background: #fff1e5; // #fff1e5
+						--o-colors-box-background: #f2dfce; // #f2dfce
+						--o-colors-body-text: rgb(51, 48.2, 45.8); // #33302e
+						--o-colors-muted-text: rgb(204, 192.8, 183.2);
+						; // #ccc1b7
+						--o-colors-link-text: #0d7680; // #0d7680
 						--o-colors-link-hover-text: hsl(185.2173913043, 81.5602836879%, 16.5234375%);
 					}
 				}
@@ -80,9 +79,7 @@
 		@include it('outputs only usecase classes with only the "usecase-classes" option') {
 			@include assert() {
 				@include output($selector: false) {
-					@include oColors($opts: (
-						'usecase-classes': true
-					));
+					@include oColors($opts: ('usecase-classes': true));
 				}
 
 				@include expect($selector: false) {
@@ -95,11 +92,13 @@
 					}
 
 					.o-colors-body-text {
-						color: #33302e;
+						color: rgb(51, 48.2, 45.8);
+						; // #33302e
 					}
 
 					.o-colors-muted-text {
-						color: #ccc1b7;
+						color: rgb(204, 192.8, 183.2);
+						; // #ccc1b7
 					}
 				}
 			}
@@ -111,12 +110,14 @@
 			@include oColorsSetColor('o-example/olive', #808000);
 			@include assert-equal(oColorsByName('o-example/olive'), (#808000));
 		}
+
 		@include it('override a default o-colors palette color') {
 			@include oColorsSetColor('o-colors/paper', #808000);
 			@include assert-equal(oColorsByName('paper'), (#808000));
 			// reset paper color
 			@include oColorsSetColor('o-colors/paper', #fff1e5);
 		}
+
 		@include it('set a custom color twice with the same value') {
 			// if a component is imported twice it may attempt
 			// to set a colour twice
@@ -127,48 +128,43 @@
 
 	@include describe('oColorSetUseCase') {
 		@include it('add a custom use case property') {
-			@include oColorsSetUseCase('o-colors/test-case', (
-				'text': 'candy'
-			));
+			@include oColorsSetUseCase('o-colors/test-case', ('text': 'candy'
+				));
 			@include assert-equal(oColorsByUsecase(test-case, text), oColorsByName('candy'));
 		}
+
 		@include it('add a custom use case property for a custom colour') {
 			// A custom colour set by an "o-example" component.
 			$example-color: #808000;
 			@include oColorsSetColor('o-example/paper', $example-color);
 			// A custom usecase by an "o-example" component, using a custom colour.
-			@include oColorsSetUseCase('o-example/page', (
-				'background': 'o-example/paper'
-			));
+			@include oColorsSetUseCase('o-example/page', ('background': 'o-example/paper'
+				));
 			// Assert able to get the new "o-example" usecase.
-			@include assert-equal(
-				oColorsByUsecase('o-example/page', 'background'),
-				$example-color
-			);
+			@include assert-equal(oColorsByUsecase('o-example/page', 'background'),
+				$example-color);
 		}
+
 		@include it('add a custom use case property for a colour mix') {
 			$mix: oColorsMix('teal', 'slate', 50);
-			@include oColorsSetUseCase('o-example/mix', (
-				'background': $mix
-			));
+			@include oColorsSetUseCase('o-example/mix', ('background': $mix));
 			// Assert able to get the new "o-example" mix usecase.
 			@include assert-equal(oColorsByUsecase('o-example/mix', 'background'), $mix);
 		}
+
 		@include it('override a default o-colors custom use case property') {
-			@include oColorsSetUseCase('o-colors/page', (
-				'background': 'candy'
-			));
+			@include oColorsSetUseCase('o-colors/page', ('background': 'candy'
+				));
 			@include assert-equal(oColorsByUsecase('page', 'background'), oColorsByName('candy'));
 		}
+
 		@include it('set a usecase twice with the same value') {
 			// if a component is imported twice it may attempt
 			// to set a usecase twice
-			@include oColorsSetUseCase('o-example/page-set-twice', (
-				'background': 'candy'
-			));
-			@include oColorsSetUseCase('o-example/page-set-twice', (
-				'background': 'candy'
-			));
+			@include oColorsSetUseCase('o-example/page-set-twice', ('background': 'candy'
+				));
+			@include oColorsSetUseCase('o-example/page-set-twice', ('background': 'candy'
+				));
 			@include assert-equal(oColorsByUsecase('o-example/page-set-twice', 'background'), oColorsByName('candy'));
 		}
 	}


### PR DESCRIPTION
## Describe your changes

Testing the colours in `o-colors` now isn't being matched with hex codes, but rather rgb values with decimals which makes it even more specific and is a new standard that was recommended in February 2024 - See https://www.w3.org/TR/css-color-4/.

As a subsequent reaction, it was failing tests so this is just updating them to use rgb values with decimals. Colour me surprised, it all passed tests locally and on GitHub Actions too!

## Issue ticket number and link

[OR-1207](https://financialtimes.atlassian.net/browse/OR-1207)

## Link to Figma designs

N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1207]: https://financialtimes.atlassian.net/browse/OR-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ