### PR TITLE
[OR-1220]: Fix failing test for o-visual-effects

### DIFF
--- a/components/o-visual-effects/test/scss/_mixins.test.scss
+++ b/components/o-visual-effects/test/scss/_mixins.test.scss
@@ -1,10 +1,12 @@
 @include test-module('oVisualEffects') {
 	@include test('Outputs timing css custom properties and shadow classes by default') {
+
 		// css custom properties for timing functions by default
 		@include assert {
 			@include output($selector: false) {
 				@include oVisualEffects();
 			}
+
 			@include contains($selector: false) {
 				:root {
 					--o-visual-effects-timing-slide: cubic-bezier(1, 0, 0.5, 1.275);
@@ -13,24 +15,29 @@
 				}
 			}
 		}
+
 		// box shadow styles by default
 		@include assert {
 			@include output($selector: false) {
 				@include oVisualEffects();
 			}
+
 			@include contains($selector: false) {
 				.o-visual-effects-shadow-low {
-					box-shadow: 0 1px 2px rgba(77, 72, 69, 0.25), 0 4px 6px rgba(77, 72, 69, 0.1);
+					box-shadow: 0 1px 2px rgba(76.5, 72.3, 68.7, 0.25), 0 4px 6px rgba(76.5, 72.3, 68.7, 0.1);
 				}
 			}
 		}
 	}
+
 	@include test('Outputs nothing with an empty options map') {
 		@include assert {
 			@include output() {
 				@include oVisualEffects($opts: ());
 			}
-			@include expect() { // stylelint-disable-line block-no-empty
+
+			@include expect() {
+				// stylelint-disable-line block-no-empty
 			}
 		}
 	}


### PR DESCRIPTION
## Describe your changes

With the recommendation to use decimal points in rgb colours from W3.org. See https://www.w3.org/TR/css-color-4/ for further context. It makes sense to update the tests to use rgb with decimal points from this point onwards.

Yes, it's just one test being updated. :)

## Issue ticket number and link

[OR-1220](https://financialtimes.atlassian.net/browse/OR-1220)

## Link to Figma designs

N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1220]: https://financialtimes.atlassian.net/browse/OR-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ