### PR TITLE
[OR-1212]: o-labels failing tests

### DIFF
--- a/components/o-labels/test/scss/_mixins.test.scss
+++ b/components/o-labels/test/scss/_mixins.test.scss
@@ -1,4 +1,3 @@
-
 @include describe('oLabels mixins') {
 
 	@include describe('_oLabelsBaseContent') {
@@ -7,6 +6,7 @@
 				@include output() {
 					@include _oLabelsBaseContent;
 				}
+
 				@include contains() {
 					$expected-vertical-padding: calc(#{oSpacingByName('s1')} - #{1px});
 					$expected-horizontal-padding: calc(#{oSpacingByName('s2')} - #{1px});
@@ -23,9 +23,11 @@
 					@include output($selector: false) {
 						@include _oLabelsSize('big');
 					}
+
 					@include contains($selector: false) {
 						$expected-vertical-padding: calc(#{oSpacingByName('s2')} - #{1px});
 						$expected-horizontal-padding: calc(#{oSpacingByName('s2')} - #{1px});
+
 						.o-labels--big {
 							padding: $expected-vertical-padding $expected-horizontal-padding;
 						}
@@ -42,9 +44,11 @@
 					@include output($selector: false) {
 						@include _oLabelsSize('small');
 					}
+
 					@include contains($selector: false) {
 						$expected-vertical-padding: calc(#{2px} - #{1px});
 						$expected-horizontal-padding: calc(#{4px} - #{1px});
+
 						.o-labels--small {
 							padding: $expected-vertical-padding $expected-horizontal-padding;
 						}
@@ -63,12 +67,14 @@
 							@include oLabelsContent($opts: ('size': 'small'));
 						}
 					}
+
 					@include expect($selector: false) {
 						.o-example-label {
 							font-size: 12px;
 							line-height: 1;
 							padding: calc(#{2px} - #{1px}) calc(#{4px} - #{1px});
 						}
+
 						.o-typography--loading-sans .o-example-label {
 							font-size: 10.44px;
 						}
@@ -76,6 +82,7 @@
 				}
 			}
 		}
+
 		@include describe('with "state" and no "size"') {
 			@include it('outputs state styles only') {
 				@include assert() {
@@ -84,25 +91,27 @@
 							@include oLabelsContent($opts: ('state': 'content-commercial'));
 						}
 					}
+
 					@include expect() {
 						.o-example-label {
-							background-color: #008040;
+							background-color: rgb(0, 127.50102, 64.16718);
+							; // #008040
 							color: white;
 						}
 					}
 				}
 			}
 		}
+
 		@include describe('with a custom "state" and no "size"') {
 			@include it('outputs custom state styles only') {
 				@include assert() {
 					@include output() {
 						.o-example-label {
-							@include oLabelsContent($opts: ('state': (
-								'background-color': hotpink
-							)));
+							@include oLabelsContent($opts: ('state': ('background-color': hotpink)));
 						}
 					}
+
 					@include expect() {
 						.o-example-label {
 							background-color: hotpink;
@@ -112,6 +121,7 @@
 				}
 			}
 		}
+
 		@include describe('with "state" and "size"') {
 			@include it('outputs state and size styles') {
 				@include assert() {
@@ -120,9 +130,10 @@
 							@include oLabelsContent($opts: ('size': 'small', 'state': 'content-commercial'));
 						}
 					}
+
 					@include expect($selector: false) {
 						.o-example-label {
-							background-color: #008040;
+							background-color: rgb(0, 127.50102, 64.16718); // #008040
 							color: white;
 							font-size: 12px;
 							line-height: 1;
@@ -136,12 +147,14 @@
 				}
 			}
 		}
+
 		@include describe('with "base"') {
 			@include it('outputs fundamental label styles required by all labels') {
 				@include assert() {
 					@include output() {
 						@include oLabelsContent($opts: ('base': true));
 					}
+
 					@include contains() {
 						box-sizing: border-box;
 					}


### PR DESCRIPTION
## Describe your changes

Update the tests to use colours from rgb with decimals. See [W3.org](https://www.w3.org/TR/css-color-4/) for an explainer why to use this ahead of normal rgb or hex values.

## Issue ticket number and link

[OR-1212](https://financialtimes.atlassian.net/browse/OR-1212)

## Link to Figma designs

N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
