### PR TITLE
chore: Use standard type usecases within o-forms

### DIFF
--- a/components/o-forms/src/scss/_checkbox.scss
+++ b/components/o-forms/src/scss/_checkbox.scss
@@ -65,7 +65,7 @@
 
 		input[type='checkbox'] ~ .o-forms-input__label {
 			display: inline-block;
-			padding: $_o-forms-spacing-half 0 0 $_o-forms-spacing-controls;
+			padding: 0 0 0 $_o-forms-spacing-controls;
 			vertical-align: top;
 
 			&:before {

--- a/components/o-forms/src/scss/_radio-box.scss
+++ b/components/o-forms/src/scss/_radio-box.scss
@@ -23,6 +23,7 @@
 				transition: 0.3s background-color, 0.15s color ease-out;
 				width: 100%;
 				height: 100%;
+				max-height: 28px;
 				display: inline-flex;
 				align-items: center;
 				justify-content: center;
@@ -38,7 +39,6 @@
 			width: 100%;
 			height: 100%;
 			cursor: pointer;
-
 
 			@if $disabled {
 				&:disabled + .o-forms-input__label {
@@ -89,13 +89,15 @@
 		}
 
 		input[type='radio'] {
-
 			& + .o-forms-input__label {
 				color: _oFormsGet('controls-base', $from: $theme);
 			}
 
 			&:not(:checked):not(:disabled):hover + .o-forms-input__label {
-				background-color: rgba(_oFormsGet('controls-base', $from: $theme), 0.15);
+				background-color: rgba(
+					_oFormsGet('controls-base', $from: $theme),
+					0.15
+				);
 			}
 
 			&:focus {
@@ -103,7 +105,10 @@
 
 				& + .o-forms-input__label {
 					$default-text: _oFormsGet('default-text', $theme);
-					@if $default-text and oPrivateColorsColorBrightness($default-text) > 65% {
+					@if $default-text and
+						oPrivateColorsColorBrightness($default-text) >
+						65%
+					{
 						@include oPrivateNormaliseFocusContentInverse();
 					} @else {
 						@include oPrivateNormaliseFocusContent();
@@ -124,7 +129,10 @@
 				&:focus-visible {
 					& + .o-forms-input__label {
 						$default-text: _oFormsGet('default-text', $theme);
-						@if $default-text and oPrivateColorsColorBrightness($default-text) > 65% {
+						@if $default-text and
+							oPrivateColorsColorBrightness($default-text) >
+							65%
+						{
 							@include oPrivateNormaliseFocusContentInverse();
 						} @else {
 							@include oPrivateNormaliseFocusContent();
@@ -139,7 +147,7 @@
 
 				&.o-forms-input__label--negative {
 					background-color: _oFormsGet(
-							'controls-negative-checked-background',
+						'controls-negative-checked-background',
 						$from: $theme
 					);
 				}

--- a/components/o-forms/src/scss/_radio-round.scss
+++ b/components/o-forms/src/scss/_radio-round.scss
@@ -4,8 +4,7 @@
 @mixin _oFormsRadioRound($disabled: null, $themes: ()) {
 	.o-forms-input--radio-round {
 		.o-forms-input__label {
-			padding: $_o-forms-spacing-half 0 $_o-forms-spacing-half
-				$_o-forms-spacing-controls;
+			padding: 0 0 0 $_o-forms-spacing-controls;
 			display: inline-block;
 
 			&:before,

--- a/components/o-forms/src/scss/shared/_base.scss
+++ b/components/o-forms/src/scss/shared/_base.scss
@@ -6,13 +6,24 @@
 	.o-forms-field,
 	.o-forms-title,
 	.o-forms-input {
-		@include oPrivateTypographySans(0);
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
 	}
 
 	.o-forms-field {
 		display: flex;
 		flex-direction: column;
-		margin-bottom: $_o-forms-spacing-six;
+		margin-bottom: $_o-forms-spacing-eight;
 		position: relative;
 
 		label {
@@ -27,27 +38,69 @@
 	}
 
 	.o-forms-field--optional .o-forms-title__main:after {
-		@include oPrivateTypographySans($scale: 1);
 		content: 'Optional';
-		color: _oFormsGet('default-prompt-text');
-		font-weight: 400;
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
+		color: oPrivateFoundationGet('o3-color-use-case-muted-text');
 		margin-left: oPrivateFoundationGet('o3-spacing-3xs');
 	}
 
 	.o-forms-title__main {
-		@include oPrivateTypographySans($weight: 'semibold', $scale: 1);
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-weight'
+		);
 		display: block;
 	}
 
 	.o-forms-input__label__main {
-		@include oPrivateTypographySans($weight: 'regular');
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-weight'
+		);
 		display: block;
 	}
 
 	.o-forms-input__label__prompt,
 	.o-forms-title__prompt {
-		@include oPrivateTypographySans($scale: 1);
-		margin-top: oPrivateFoundationGet('o3-spacing-5xs');
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
 		color: _oFormsGet('default-prompt-text');
 		display: block;
 	}

--- a/components/o-forms/src/scss/shared/_brand.scss
+++ b/components/o-forms/src/scss/shared/_brand.scss
@@ -1,7 +1,11 @@
 /// Helper for `o-brand` function.
 /// @access private
 @function _oFormsGet($variables, $from: null) {
-	@return oBrandGet($component: 'o-forms', $variables: $variables, $from: $from);
+	@return oBrandGet(
+		$component: 'o-forms',
+		$variables: $variables,
+		$from: $from
+	);
 }
 
 /// Helper for `o-brand` function.
@@ -11,8 +15,8 @@
 }
 
 $_o-forms-shared-brand-config: (
-	default-text: oPrivateFoundationGet('o3-color-palette-black-80'),
-	default-prompt-text: oPrivateFoundationGet('o3-color-palette-black-60'),
+	default-text: oPrivateFoundationGet('o3-color-use-case-body-text'),
+	default-prompt-text: oPrivateFoundationGet('o3-color-use-case-body-text'),
 	default-border: oPrivateFoundationGet('o3-color-palette-black-50'),
 	default-background: oPrivateFoundationGet('o3-color-palette-white'),
 	radio-background: transparent,
@@ -20,7 +24,8 @@ $_o-forms-shared-brand-config: (
 	disabled-base: oPrivateFoundationGet('o3-color-palette-black-10'),
 	controls-checked-base: oPrivateFoundationGet('o3-color-palette-white'),
 	toggle: oPrivateFoundationGet('o3-color-palette-black'),
-	toggle-knob: oPrivateColorsMix('o3-color-palette-black', 'o3-color-palette-white', 10),
+	toggle-knob:
+		oPrivateColorsMix('o3-color-palette-black', 'o3-color-palette-white', 10),
 	toggle-knob-selected: oPrivateFoundationGet('o3-color-palette-white'),
 	toggle-disabled: oPrivateFoundationGet('o3-color-palette-black-20'),
 	toggle-knob-disabled: oPrivateFoundationGet('o3-color-palette-black-40'),
@@ -28,81 +33,138 @@ $_o-forms-shared-brand-config: (
 );
 
 @if oBrandIs('core') or oBrandIs('internal') {
-	$_o-forms-shared-brand-config: map-merge($_o-forms-shared-brand-config, (
-		toggle-selected: oPrivateFoundationGet('o3-color-palette-teal-50'),
-		controls-base: oPrivateFoundationGet('o3-color-palette-teal-50'),
-		controls-negative-checked-background: oPrivateFoundationGet('o3-color-palette-teal-30'),
-		toggle-inverse-selected: oPrivateFoundationGet('o3-color-palette-teal-100'),
-		invalid-base: oPrivateFoundationGet('o3-color-palette-crimson'),
-		invalid-base-inverse: oPrivateFoundationGet('o3-color-palette-white'),
-		invalid-base-color-inverse: oPrivateFoundationGet('o3-color-palette-black'),
-		valid-base: oPrivateColorsMix('o3-color-palette-jade', 'o3-color-palette-black', 80),
-		toggle-inverse-knob: oPrivateFoundationGet('o3-color-palette-slate'),
-	)) !global;
+	$_o-forms-shared-brand-config: map-merge(
+		$_o-forms-shared-brand-config,
+		(
+			toggle-selected: oPrivateFoundationGet('o3-color-palette-teal-50'),
+			controls-base: oPrivateFoundationGet('o3-color-palette-teal-50'),
+			controls-negative-checked-background:
+				oPrivateFoundationGet('o3-color-palette-teal-30'),
+			toggle-inverse-selected:
+				oPrivateFoundationGet('o3-color-palette-teal-100'),
+			invalid-base: oPrivateFoundationGet('o3-color-palette-crimson'),
+			invalid-base-inverse: oPrivateFoundationGet('o3-color-palette-white'),
+			invalid-base-color-inverse:
+				oPrivateFoundationGet('o3-color-palette-black'),
+			valid-base:
+				oPrivateColorsMix(
+					'o3-color-palette-jade',
+					'o3-color-palette-black',
+					80
+				),
+			toggle-inverse-knob: oPrivateFoundationGet('o3-color-palette-slate'),
+		)
+	) !global;
 }
 
 @if oBrandIs('core') {
-	@include oBrandDefine('o-forms', 'core', (
-		'variables': map-merge($_o-forms-shared-brand-config, (
-			invalid-base-border-inverse: oPrivateFoundationGet('o3-color-palette-claret-100'),
-			error-summary-background-inverse: rgba(oPrivateFoundationGet('o3-color-palette-claret-100'), 0.11),
-			error-summary-border-inverse: oPrivateFoundationGet('o3-color-palette-claret-100'),
-			'professional': (
-				default-text: oPrivateFoundationGet('o3-color-palette-black-80'),
-				controls-base: oPrivateFoundationGet('o3-color-palette-slate'),
-				controls-negative-checked-background: oPrivateFoundationGet('o3-color-palette-slate'),
-				radio-background: oPrivateFoundationGet('o3-color-palette-slate'),
-				default-border: oPrivateFoundationGet('o3-color-palette-black-50'),
-				controls-checked-base: oPrivateFoundationGet('o3-color-palette-white'),
+	@include oBrandDefine(
+		'o-forms',
+		'core',
+		(
+			'variables':
+				map-merge(
+					$_o-forms-shared-brand-config,
+					(
+						invalid-base-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-claret-100'),
+						error-summary-background-inverse:
+							rgba(oPrivateFoundationGet('o3-color-palette-claret-100'), 0.11),
+						error-summary-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-claret-100'),
+						'professional': (
+							default-text: oPrivateFoundationGet('o3-color-palette-black-80'),
+							controls-base: oPrivateFoundationGet('o3-color-palette-slate'),
+							controls-negative-checked-background:
+								oPrivateFoundationGet('o3-color-palette-slate'),
+							radio-background: oPrivateFoundationGet('o3-color-palette-slate'),
+							default-border: oPrivateFoundationGet('o3-color-palette-black-50'),
+							controls-checked-base:
+								oPrivateFoundationGet('o3-color-palette-white'),
+						),
+						'professional-inverse': (
+							default-text: oPrivateFoundationGet('o3-color-palette-white'),
+							controls-base: oPrivateFoundationGet('o3-color-palette-mint'),
+							default-border: oPrivateFoundationGet('o3-color-palette-mint'),
+							controls-checked-base:
+								oPrivateFoundationGet('o3-color-palette-slate'),
+						),
+						'ft-live': (
+							default-text: oPrivateFoundationGet('o3-color-palette-white'),
+							controls-base: oPrivateFoundationGet('o3-color-palette-ft-pink'),
+							default-border: oPrivateFoundationGet('o3-color-palette-ft-pink'),
+							controls-checked-base:
+								oPrivateFoundationGet('o3-color-palette-slate'),
+						),
+					)
+				),
+			'supports-variants': (
+				'professional',
+				'professional-inverse',
+				'ft-live',
 			),
-			'professional-inverse': (
-				default-text: oPrivateFoundationGet('o3-color-palette-white'),
-				controls-base: oPrivateFoundationGet('o3-color-palette-mint'),
-				default-border: oPrivateFoundationGet('o3-color-palette-mint'),
-				controls-checked-base: oPrivateFoundationGet('o3-color-palette-slate'),
-			),
-			'ft-live': (
-				default-text: oPrivateFoundationGet('o3-color-palette-white'),
-				controls-base: oPrivateFoundationGet('o3-color-palette-ft-pink'),
-				default-border: oPrivateFoundationGet('o3-color-palette-ft-pink'),
-				controls-checked-base: oPrivateFoundationGet('o3-color-palette-slate')
-			),
-		)),
-		'supports-variants': (
-			'professional',
-			'professional-inverse',
-			'ft-live'
 		)
-	));
+	);
 }
 
 @if oBrandIs('internal') {
-	@include oBrandDefine('o-forms', 'internal', (
-		'variables': map-merge($_o-forms-shared-brand-config, (
-			invalid-base-border-inverse: oPrivateFoundationGet('o3-color-palette-crimson'),
-			error-summary-background-inverse: rgba(oPrivateFoundationGet('o3-color-palette-crimson'), 0.11),
-			error-summary-border-inverse: oPrivateFoundationGet('o3-color-palette-crimson'),
-			radio-background:  oPrivateFoundationGet('o3-color-palette-white')
-		)),
-		'supports-variants': ()
-	));
+	@include oBrandDefine(
+		'o-forms',
+		'internal',
+		(
+			'variables':
+				map-merge(
+					$_o-forms-shared-brand-config,
+					(
+						invalid-base-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-crimson'),
+						error-summary-background-inverse:
+							rgba(oPrivateFoundationGet('o3-color-palette-crimson'), 0.11),
+						error-summary-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-crimson'),
+						radio-background: oPrivateFoundationGet('o3-color-palette-white'),
+					)
+				),
+			'supports-variants': (),
+		)
+	);
 }
 
 @if oBrandIs('whitelabel') {
-	@include oBrandDefine('o-forms', 'whitelabel', (
-		'variables': map-merge($_o-forms-shared-brand-config, (
-			controls-base: oPrivateFoundationGet('o3-color-palette-black'),
-			controls-negative-checked-background: oPrivateFoundationGet('o3-color-palette-black'),
-			toggle-inverse-selected: oPrivateFoundationGet('o3-color-palette-white'),
-			toggle-inverse-knob: oPrivateFoundationGet('o3-color-palette-black'),
-			invalid-base: oPrivateFoundationGet('o3-color-palette-crimson'),
-			invalid-base-inverse: oPrivateFoundationGet('o3-color-palette-white'),
-			invalid-base-color-inverse: oPrivateFoundationGet('o3-color-palette-black'),
-			invalid-base-border-inverse: oPrivateFoundationGet('o3-color-palette-crimson'),
-			valid-base: oPrivateColorsMix('o3-color-palette-jade', 'o3-color-palette-black', 80),
-			error-summary-background-inverse: rgba(oPrivateFoundationGet('o3-color-palette-crimson'), 0.11),
-			error-summary-border-inverse: oPrivateFoundationGet('o3-color-palette-crimson'),
-		)),
-		'supports-variants': ()
-	));
+	@include oBrandDefine(
+		'o-forms',
+		'whitelabel',
+		(
+			'variables':
+				map-merge(
+					$_o-forms-shared-brand-config,
+					(
+						controls-base: oPrivateFoundationGet('o3-color-palette-black'),
+						controls-negative-checked-background:
+							oPrivateFoundationGet('o3-color-palette-black'),
+						toggle-inverse-selected:
+							oPrivateFoundationGet('o3-color-palette-white'),
+						toggle-inverse-knob: oPrivateFoundationGet('o3-color-palette-black'),
+						invalid-base: oPrivateFoundationGet('o3-color-palette-crimson'),
+						invalid-base-inverse:
+							oPrivateFoundationGet('o3-color-palette-white'),
+						invalid-base-color-inverse:
+							oPrivateFoundationGet('o3-color-palette-black'),
+						invalid-base-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-crimson'),
+						valid-base:
+							oPrivateColorsMix(
+								'o3-color-palette-jade',
+								'o3-color-palette-black',
+								80
+							),
+						error-summary-background-inverse:
+							rgba(oPrivateFoundationGet('o3-color-palette-crimson'), 0.11),
+						error-summary-border-inverse:
+							oPrivateFoundationGet('o3-color-palette-crimson'),
+					)
+				),
+			'supports-variants': (),
+		)
+	);
 }

--- a/components/o-forms/src/scss/shared/_control-inputs.scss
+++ b/components/o-forms/src/scss/shared/_control-inputs.scss
@@ -54,6 +54,7 @@
 /// @access private
 /// @output Shared styles for box-style containers
 @mixin _oFormsControlsBoxContainer {
+	// As with buttons, does not align to a standard type usecase.
 	@include oPrivateTypographySans($scale: -1, $weight: 'semibold');
 	line-height: unset;
 	box-sizing: border-box;

--- a/components/o-forms/src/scss/shared/_error-summary.scss
+++ b/components/o-forms/src/scss/shared/_error-summary.scss
@@ -21,7 +21,18 @@ $_o-forms-alert-icon-right-padding: $_o-forms-spacing-two;
 /// @output styles for error summary
 @mixin _oFormsErrorSummary() {
 	.o-forms__error-summary {
-		@include oPrivateTypographySans($scale: 0);
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
 		background-color: $_o-forms-error-summary-background-color;
 		margin-bottom: $_o-forms-spacing-four;
 		padding: $_o-forms-spacing-three;
@@ -50,7 +61,18 @@ $_o-forms-alert-icon-right-padding: $_o-forms-spacing-two;
 			top: calc($_o-forms-spacing-three + 0.1rem);
 		}
 		.o-forms__error-summary__heading {
-			@include oPrivateTypographySans($weight: 'semibold');
+			font-family: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-family'
+			);
+			font-size: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-size'
+			);
+			line-height: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-line-height'
+			);
+			font-weight: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-weight'
+			);
 			color: $_o-forms-error-summary-foreground-color;
 			margin: 0 0 $_o-forms-spacing-one;
 		}
@@ -70,7 +92,18 @@ $_o-forms-alert-icon-right-padding: $_o-forms-spacing-two;
 			}
 
 			.o-forms__error-summary__item-overview {
-				@include oPrivateTypographySans($weight: 'semibold');
+				font-family: oPrivateFoundationGet(
+					'o3-typography-use-case-body-highlight-font-family'
+				);
+				font-size: oPrivateFoundationGet(
+					'o3-typography-use-case-body-highlight-font-size'
+				);
+				line-height: oPrivateFoundationGet(
+					'o3-typography-use-case-body-highlight-line-height'
+				);
+				font-weight: oPrivateFoundationGet(
+					'o3-typography-use-case-body-highlight-font-weight'
+				);
 			}
 		}
 	}

--- a/components/o-forms/src/scss/shared/_single-inputs.scss
+++ b/components/o-forms/src/scss/shared/_single-inputs.scss
@@ -10,7 +10,8 @@
 	border-radius: oPrivateFoundationGet('o3-border-radius-1');
 	box-sizing: border-box;
 	min-height: $_o-forms-spacing-eleven;
-	padding: oPrivateFoundationGet('o3-spacing-4xs') oPrivateFoundationGet('o3-spacing-2xs');
+	padding: oPrivateFoundationGet('o3-spacing-4xs')
+		oPrivateFoundationGet('o3-spacing-2xs');
 	width: 100%;
 
 	@if $disabled {
@@ -41,7 +42,18 @@
 @mixin _oFormsInputSmall($element) {
 	&.o-forms-input--small {
 		#{$element} {
-			@include oPrivateTypographySans($scale: -1);
+			font-family: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-family'
+			);
+			font-size: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-size'
+			);
+			line-height: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-line-height'
+			);
+			font-weight: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-weight'
+			);
 			line-height: 1.65;
 			min-height: $_o-forms-spacing-seven;
 			padding: 0 $_o-forms-spacing-two;

--- a/components/o-forms/src/scss/shared/_validity.scss
+++ b/components/o-forms/src/scss/shared/_validity.scss
@@ -20,11 +20,21 @@
 		}
 
 		.o-forms-input__error {
-			@include oPrivateTypographySans($scale: 1);
+			font-family: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-family'
+			);
+			font-size: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-size'
+			);
+			line-height: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-line-height'
+			);
+			font-weight: oPrivateFoundationGet(
+				'o3-typography-use-case-body-base-font-weight'
+			);
 			color: _oFormsGet('invalid-base');
 			display: block;
 			position: relative;
-			margin-top: oPrivateFoundationGet('o3-spacing-3xs');
 			margin-bottom: -$_o-forms-spacing-five;
 		}
 	}


### PR DESCRIPTION
Increase margin between form fields to accommodate larger error copy. Align colours to new o3-forms

<img width="1384" alt="Screenshot 2025-01-20 at 18 21 43" src="https://github.com/user-attachments/assets/1fb3c094-7376-4ffa-8e9e-47bc39f658ed" />
<img width="1384" alt="Screenshot 2025-01-20 at 18 22 52" src="https://github.com/user-attachments/assets/b0f23aab-5106-4065-afeb-7b0272865fe1" />
