### PR TITLE
Apply type usecases to tooltip components [OR-1191]

### DIFF
--- a/components/o-tooltip/main.scss
+++ b/components/o-tooltip/main.scss
@@ -62,13 +62,26 @@
 	}
 
 	.o-tooltip-content {
-		font-family: '#{oPrivateFoundationGet('o3-font-family-metric')}', sans-serif;
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
 		position: relative;
 		box-sizing: border-box;
 		overflow: auto;
-		padding: 15px 35px 15px 20px;
+		padding: oPrivateFoundationGet('o3-spacing-3xs')
+			oPrivateFoundationGet('o3-spacing-m')
+			oPrivateFoundationGet('o3-spacing-3xs')
+			oPrivateFoundationGet('o3-spacing-xs');
 		float: left;
-		line-height: 1;
 		hyphens: auto; // Breaks long words to fit into smaller screen sizes
 
 		> *:first-child {
@@ -212,8 +225,6 @@
 		margin: 5px 5px 15px 15px;
 		padding: 0;
 		cursor: pointer;
-		font-size: 8px;
-		line-height: 1;
 		user-select: none;
 		top: 0;
 		right: 0;

--- a/components/o3-tooltip/main.css
+++ b/components/o3-tooltip/main.css
@@ -21,10 +21,10 @@ o3-tooltip-toggle.o3-tooltip {
 		5px 5px 24px 0px rgba(26, 26, 26, 0.17);
 	background: var(--_o3-tooltip-background-color);
 	color: var(--_o3-tooltip-text-color);
-	font-weight: var(--o3-font-weight-regular);
-	font-family: var(--o3-font-family-metric), sans-serif;
-	font-size: var(--o3-font-size-metric2-negative-1);
-	line-height: var(--o3-font-lineheight-metric2-negative-1);
+	font-family: var(--o3-typography-use-case-body-base-font-family);
+	font-weight: var(--o3-typography-use-case-body-base-font-weight);
+	font-size: var(--o3-typography-use-case-body-base-font-size);
+	line-height: var(--o3-typography-use-case-body-base-line-height);
 }
 
 .o3-tooltip-content {
@@ -49,8 +49,10 @@ o3-tooltip-toggle[no-title] .o3-tooltip-content-title {
 }
 
 .o3-tooltip-content-title {
-	font-weight: var(--o3-font-weight-semibold);
-	font-size: var(--o3-font-size-0);
+	font-family: var(--o3-typography-use-case-body-highlight-font-family);
+	font-weight: var(--o3-typography-use-case-body-highlight-font-weight);
+	font-size: var(--o3-typography-use-case-body-highlight-font-size);
+	line-height: var(--o3-typography-use-case-body-highlight-line-height);
 	color: inherit;
 	margin-bottom: var(--o3-spacing-4xs);
 	padding-right: calc(


### PR DESCRIPTION
Before / after. Within o-tooltip font size was previously inherited, and line height set very low:
<img width="1277" alt="Screenshot 2025-01-22 at 13 44 07" src="https://github.com/user-attachments/assets/de9ddd51-a44b-4af6-a00d-12153b5e1bc0" />
