### PR TITLE
chore: Apply type usecases to o-stepped-progress

### DIFF
--- a/components/o-stepped-progress/src/scss/_mixins.scss
+++ b/components/o-stepped-progress/src/scss/_mixins.scss
@@ -38,7 +38,17 @@
 /// @access private
 @mixin _oSteppedProgressBase() {
 	.o-stepped-progress {
-		@include oPrivateTypographySans(_oSteppedProgressGet('font-scale'));
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-detail-font-family'
+		);
+		font-size: oPrivateFoundationGet('o3-typography-use-case-detail-font-size');
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-detail-font-weight'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-detail-line-height'
+		);
+
 		display: block;
 		position: relative;
 
@@ -252,9 +262,9 @@
 	$variant: 'heavy';
 
 	.o-stepped-progress--heavy {
-		@include oPrivateTypographySans(
-			_oSteppedProgressGet('font-scale', $variant)
-		);
+		strong {
+			font-weight: oPrivateFoundationGet('o3-font-weight-semibold');
+		}
 
 		// Progress bars
 		&::before {


### PR DESCRIPTION
Apply a custom weight to the heavy varient. A redesign is required to fit the current type tokens, and this varient looks pretty borked in other ways (icon size).

Text becomes a little larger:
<img width="1279" alt="Screenshot 2025-01-22 at 14 13 13" src="https://github.com/user-attachments/assets/fbc9c5f5-29fa-44f9-8b31-717cee29d14a" />

The `strong` element of this "heavy" variant is a custom type style. I decided to stick with this as this variant is internal only, not our focus right now, and its icons are so small I wonder if it's used. This sets a stronger weight on the `detail` type token – stepping up in size to `body-base` and `body-highlight` is quite large, and may visually break longer copy. 
<img width="1280" alt="Screenshot 2025-01-22 at 14 14 07" src="https://github.com/user-attachments/assets/79867245-9865-43e0-8daf-90bd32b8ae7e" />
