### PR TITLE
2025 release forms design tweaks

### DIFF
--- a/apps/for-everyone-website/src/content/docs/components/Form/password-input.mdx
+++ b/apps/for-everyone-website/src/content/docs/components/Form/password-input.mdx
@@ -7,16 +7,16 @@ sidebar:
     variant: caution
 ---
 
-import {Aside} from '@astrojs/starlight/components';
-import {Form, TextInput} from '@financial-times/o3-form';
+import { Aside } from '@astrojs/starlight/components';
+import { Form, TextInput } from '@financial-times/o3-form';
 
 import Tip from '../../../../components/utils/Tip.astro';
 import Example from '../../../../components/Example.astro';
 
-import {default as TextInputAnatomy} from '../../../../components/form/anatomy/Password-input.astro';
+import { default as TextInputAnatomy } from '../../../../components/form/anatomy/Password-input.astro';
 
-import {default as PasswordExample} from '../../../../components/form/examples/Input-password.astro';
-import {default as PasswordValidation} from '../../../../components/form/examples/Input-password-validation.astro';
+import { default as PasswordExample } from '../../../../components/form/examples/Input-password.astro';
+import { default as PasswordValidation } from '../../../../components/form/examples/Input-password-validation.astro';
 
 import '@financial-times/o3-form/css/whitelabel.css';
 import '@financial-times/o3-form/css/internal.css';
@@ -71,7 +71,7 @@ Provide clear and specific error message if the password doesn't meet the requir
 			users to sign up.
 		</li>
 		<li>
-			Providing a "Show Password" toggle allows users to verify their input
+			Providing a "Show password" toggle allows users to verify their input
 			without retyping it
 		</li>
 	</ol>

--- a/components/o-forms/main.scss
+++ b/components/o-forms/main.scss
@@ -154,7 +154,9 @@
 
 	@if $white-theme {
 		.o-forms-field--white {
-			--o-forms-toggle-handle-color: #{oPrivateFoundationGet('o3-color-palette-white')};
+			--o-forms-toggle-handle-color: #{oPrivateFoundationGet(
+					'o3-color-palette-white'
+				)};
 		}
 	}
 

--- a/components/o-forms/src/scss/modifiers/_inverse.scss
+++ b/components/o-forms/src/scss/modifiers/_inverse.scss
@@ -5,7 +5,7 @@
 /// @output styles for inverse toggle based on a checkbox input
 @mixin _oFormsInverse($error-summary: null, $radio: null, $file: null) {
 	.o-forms-field--inverse {
-		color: _oFormsGet('toggle-inverse');
+		color: oPrivateFoundationGet('o3-color-use-case-body-inverse-text');
 
 		.o-forms-title {
 			.o-forms-title__main:after,
@@ -32,7 +32,7 @@
 		input {
 			@include oPrivateNormaliseFocusApply() {
 				@include oPrivateNormaliseFocusContentInverse();
-			};
+			}
 		}
 
 		input[type='checkbox'] {

--- a/components/o-forms/src/scss/shared/_base.scss
+++ b/components/o-forms/src/scss/shared/_base.scss
@@ -25,6 +25,7 @@
 		flex-direction: column;
 		margin-bottom: $_o-forms-spacing-eight;
 		position: relative;
+		color: oPrivateFoundationGet('o3-color-use-case-body-text');
 
 		label {
 			display: block;

--- a/components/o-forms/src/scss/shared/_brand.scss
+++ b/components/o-forms/src/scss/shared/_brand.scss
@@ -73,7 +73,7 @@ $_o-forms-shared-brand-config: (
 						error-summary-border-inverse:
 							oPrivateFoundationGet('o3-color-palette-claret-100'),
 						'professional': (
-							default-text: oPrivateFoundationGet('o3-color-palette-black-80'),
+							default-text: oPrivateFoundationGet('o3-color-use-case-body-text'),
 							controls-base: oPrivateFoundationGet('o3-color-palette-slate'),
 							controls-negative-checked-background:
 								oPrivateFoundationGet('o3-color-palette-slate'),
@@ -83,7 +83,8 @@ $_o-forms-shared-brand-config: (
 								oPrivateFoundationGet('o3-color-palette-white'),
 						),
 						'professional-inverse': (
-							default-text: oPrivateFoundationGet('o3-color-palette-white'),
+							default-text:
+								oPrivateFoundationGet('o3-color-use-case-body-inverse-text'),
 							controls-base: oPrivateFoundationGet('o3-color-palette-mint'),
 							default-border: oPrivateFoundationGet('o3-color-palette-mint'),
 							controls-checked-base:

--- a/components/o3-form/src/css/components/checkbox.css
+++ b/components/o3-form/src/css/components/checkbox.css
@@ -128,9 +128,9 @@
 .o3-form-input-checkbox__label {
 	display: flex;
 	align-items: center;
-	font-family: var(--o3-typography-use-case-body-lg-font-family);
-	font-size: var(--o3-typography-use-case-body-lg-font-size);
-	font-weight: var(--o3-typography-use-case-body-lg-font-weight);
-	line-height: var(--o3-typography-use-case-body-lg-line-height);
+	font-family: var(--o3-typography-use-case-body-base-font-family);
+	font-size: var(--o3-typography-use-case-body-base-font-size);
+	font-weight: var(--o3-typography-use-case-body-base-font-weight);
+	line-height: var(--o3-typography-use-case-body-base-line-height);
 	color: var(--o3-color-use-case-body-text);
 }

--- a/components/o3-form/src/css/components/radio-button.css
+++ b/components/o3-form/src/css/components/radio-button.css
@@ -76,7 +76,8 @@
 	}
 
 	&:focus + label::before {
-		box-shadow: var(--o3-focus-use-case-ring-inner), var(--03-focus-use-case-ring-outer);
+		box-shadow: var(--o3-focus-use-case-ring-inner),
+			var(--03-focus-use-case-ring-outer);
 		outline: 3px solid transparent; /* For Windows high contrast mode. */
 	}
 
@@ -85,7 +86,8 @@
 			box-shadow: unset;
 		}
 		&:focus-visible + label::before {
-			box-shadow: var(--o3-focus-use-case-ring-inner), var(--o3-focus-use-case-ring-outer);
+			box-shadow: var(--o3-focus-use-case-ring-inner),
+				var(--o3-focus-use-case-ring-outer);
 			outline: 3px solid transparent; /* For Windows high contrast mode. */
 		}
 	}
@@ -94,9 +96,9 @@
 .o3-form-input-radio-button__label {
 	display: flex;
 	align-items: center;
-	font-size: var(--o3-typography-use-case-body-lg-font-size);
-	font-weight: var(--o3-typography-use-case-body-lg-font-weight);
-	font-family: var(--o3-typography-use-case-body-lg-font-family);
-	line-height: var(--o3-typography-use-case-body-lg-line-height);
+	font-size: var(--o3-typography-use-case-body-base-font-size);
+	font-weight: var(--o3-typography-use-case-body-base-font-weight);
+	font-family: var(--o3-typography-use-case-body-base-font-family);
+	line-height: var(--o3-typography-use-case-body-base-line-height);
 	color: var(--o3-color-use-case-body-text);
 }

--- a/components/o3-form/src/tsx/PasswordInput.tsx
+++ b/components/o3-form/src/tsx/PasswordInput.tsx
@@ -43,9 +43,13 @@ export const PasswordInput = ({
 				<CheckBoxItem
 					attributes={{disabled}}
 					inputId={showPasswordId}
-					checkboxLabel="Show Password"
+					checkboxLabel="Show password"
 				/>
-				{!disabled && <a className='o3-typography-link' href="">Forgot password?</a>}
+				{!disabled && (
+					<a className="o3-typography-link" href="">
+						Forgot password?
+					</a>
+				)}
 			</div>
 		</>
 	);


### PR DESCRIPTION
- Reduce checkbox / radio label type size to body base. We've already done this by accident in o-forms. Leave text input, etc, at `body-lg` by design.
- Correct tense in show password field.