### PR TITLE
o-tracking add IntersectionObserver.threshold as opt

### DIFF
--- a/libraries/o-tracking/README.md
+++ b/libraries/o-tracking/README.md
@@ -182,6 +182,7 @@ To track when an element has come into view of the user, add the attribute `data
 - To track different elements, set the `selector` option property to a CSS selector.
 - Like click events, view events will also track the path from the root of the DOM tree to the element which triggered the tracking event into a property called `domPathTokens`.
 - To categorise the view events, set the `category` option property.
+- To customise the how much of this element needs to be in the viewport to trigger the event, use the `intersectionObserverThreshold` option. This value will be set as the threshold for the IntersectionObserver (it defaults to `1.0`).
 - To collect extra data to send with the tracking event, add a function named `getContextData` to the options. The function receives as it's single argument the element which triggered the tracking event and needs to return an object with any of these optional properties set:
 	- `componentContentId`
 	- `type`

--- a/libraries/o-tracking/src/javascript/events/component-view.js
+++ b/libraries/o-tracking/src/javascript/events/component-view.js
@@ -42,7 +42,7 @@ const decorateEventData = (eventData, viewedEl, opts) => {
  * Listen for view events.
  *
  * @alias view#init
- * @param {object} opts - To set custom category[String], selector[String], getContextData[Function]
+ * @param {object} opts - To set custom category[String], selector[String], getContextData[Function], intersectionObserverThreshold[Any]
  * @returns {undefined}
  */
 const init = (opts = {}) => {
@@ -75,7 +75,7 @@ const init = (opts = {}) => {
 		});
 	}
 
-	const observer = new IntersectionObserver(onChange, { threshold: [ 1.0 ] });
+	const observer = new IntersectionObserver(onChange, { threshold: opts.intersectionObserverThreshold || [ 1.0 ] });
 
 	elementsToTrack.forEach(el => observer.observe(el));
 };


### PR DESCRIPTION
## Description

I'm configuring the App Homepage `scrolldepth` tracking event using `oTracking.view.init()` in [this PR](https://github.com/Financial-Times/ft-app/pull/2878) by setting a selector that will trigger this event every time a `<section />` comes into the viewport. In the beginning, it was working as expected, but after some days I retested it and the `scrolldepth` events were not being sent as expected.

After some investigation, I realized that the problem was located in the **1.0** IntersectionObserver threshold defined [here](https://github.com/Financial-Times/origami/blob/4d2111699890b9cce57da3150401fbd722001773/libraries/o-tracking/src/javascript/events/component-view.js#L78). Looking [at the docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold), this means that "A value of 1.0 means that the threshold isn't considered passed until every pixel is visible". This is not a problem in medium / big screens, since they can fit a whole `<section />` in the viewport (that's why it worked in the beginning), but for small screens, is rather difficult to fit the whole `<section />` in it.

I've considered changing the selector provided to this function by selecting only the first teaser of each `<section />`, but the payload sent to Spoor changes drastically.

So, to fix this, we can modify the threshold to a lover value so the event triggers with smaller portions of the `<section />`.

## Issue ticket number and link

Relates to [this ticket](https://financialtimes.atlassian.net/browse/HETD-56)

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
