### PR TITLE
banner type

### DIFF
--- a/components/o-banner/src/scss/_mixins.scss
+++ b/components/o-banner/src/scss/_mixins.scss
@@ -48,7 +48,16 @@
 }
 
 @mixin _oBannerInner {
-	@include oPrivateTypographySans($scale: 2);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-family'
+	);
+	font-size: oPrivateFoundationGet('o3-typography-use-case-body-lg-font-size');
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-weight'
+	);
 	-webkit-font-smoothing: antialiased;
 	position: relative;
 	display: flex;
@@ -61,7 +70,18 @@
 	box-sizing: border-box;
 
 	@include oPrivateGridRespondTo($until: S) {
-		@include oPrivateTypographySans($scale: 0);
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-base-font-weight'
+		);
 		display: block;
 		padding: $_o-banner-spacing;
 		padding-bottom: $_o-banner-spacing - $_o-banner-brand-border;
@@ -84,7 +104,18 @@
 	h4,
 	h5,
 	h6 {
-		@include oPrivateTypographySans($scale: 3, $weight: 'semibold');
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-weight'
+		);
 		margin-top: 0;
 		margin-bottom: oPrivateSpacingByName('s1');
 	}
@@ -101,10 +132,6 @@
 		margin-top: oPrivateSpacingByName('s3');
 		margin-bottom: 0;
 
-		li {
-			@include oPrivateTypographySans($scale: 2);
-			line-height: oPrivateSpacingByIncrement(7);
-		}
 		li:before {
 			color: inherit;
 		}
@@ -147,13 +174,22 @@
 		margin-bottom: oPrivateSpacingByName('s4');
 
 		// Color is set separately for easier overriding later
-		border-bottom: oPrivateSpacingByIncrement(2) solid;
+		border-bottom: 0.6ex solid;
 		border-color: _oBannerGet('heading-rule-color');
 	}
 }
 
 @mixin _oBannerActions {
-	@include oPrivateTypographySans($scale: 2);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-family'
+	);
+	font-size: oPrivateFoundationGet('o3-typography-use-case-body-lg-font-size');
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-weight'
+	);
 	display: flex;
 	align-items: center;
 
@@ -194,7 +230,18 @@
 
 @mixin _oBannerLink {
 	@include oPrivateTypographyLink();
-	@include oPrivateTypographySans($scale: 0);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-family'
+	);
+	font-size: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-size'
+	);
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-weight'
+	);
 	white-space: nowrap;
 	&:focus,
 	&:focus-visible {

--- a/components/o-banner/src/scss/layouts/_compact.scss
+++ b/components/o-banner/src/scss/layouts/_compact.scss
@@ -30,7 +30,18 @@
 
 @mixin _oBannerCompactInner {
 	@include oPrivateVisualEffectsShadowContent('high');
-	@include oPrivateTypographySans($scale: 0);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-family'
+	);
+	font-size: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-size'
+	);
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-weight'
+	);
 	background: _oBannerGet('background-color');
 	display: block;
 	padding: $_o-banner-spacing;
@@ -39,6 +50,18 @@
 }
 
 @mixin _oBannerCompactContent {
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-family'
+	);
+	font-size: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-size'
+	);
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-weight'
+	);
 	padding: 0;
 
 	h1,
@@ -48,24 +71,32 @@
 	h5,
 	h6,
 	ul li {
-		@include oPrivateTypographySans($scale: 0);
-	}
-	@include oPrivateGridRespondTo($until: M) {
-		&,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6,
-		ul li {
-			@include oPrivateTypographySans($scale: 0);
-		}
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-highlight-font-weight'
+		);
 	}
 }
 
 @mixin _oBannerCompactHeading {
-	@include oPrivateTypographySans($scale: 3);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-font-family'
+	);
+	font-size: oPrivateFoundationGet('o3-typography-use-case-title-md-font-size');
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-font-weight'
+	);
 	padding-right: $_o-banner-spacing;
 
 	h1,
@@ -74,19 +105,20 @@
 	h4,
 	h5,
 	h6 {
-		@include oPrivateTypographySans($scale: 3, $weight: 'semibold');
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-weight'
+		);
 	}
-	@include oPrivateGridRespondTo($until: M) {
-		&,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			@include oPrivateTypographySans($scale: 2);
-		}
-	}
+
 	&:after {
 		margin-top: oPrivateSpacingByName('s2');
 		margin-bottom: oPrivateSpacingByName('s3');

--- a/components/o-banner/src/scss/layouts/_small.scss
+++ b/components/o-banner/src/scss/layouts/_small.scss
@@ -30,7 +30,16 @@
 
 @mixin _oBannerSmallInner {
 	@include oPrivateVisualEffectsShadowContent('high');
-	@include oPrivateTypographySans($scale: 2);
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-family'
+	);
+	font-size: oPrivateFoundationGet('o3-typography-use-case-body-lg-font-size');
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-lg-font-weight'
+	);
 	background: _oBannerGet('background-color');
 	display: block;
 	padding: $_o-banner-spacing;
@@ -40,6 +49,18 @@
 
 @mixin _oBannerSmallContent {
 	padding: 0;
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-family'
+	);
+	font-size: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-size'
+	);
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-body-base-font-weight'
+	);
 
 	h1,
 	h2,
@@ -48,10 +69,20 @@
 	h5,
 	h6,
 	ul li {
-		@include oPrivateTypographySans($scale: 2);
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-body-lg-font-weight'
+		);
 	}
 	@include oPrivateGridRespondTo($until: M) {
-		&,
 		h1,
 		h2,
 		h3,
@@ -59,14 +90,34 @@
 		h5,
 		h6,
 		ul li {
-			@include oPrivateTypographySans($scale: 0);
+			font-family: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-family'
+			);
+			font-size: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-size'
+			);
+			line-height: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-line-height'
+			);
+			font-weight: oPrivateFoundationGet(
+				'o3-typography-use-case-body-highlight-font-weight'
+			);
 		}
 	}
 }
 
 @mixin _oBannerSmallHeading {
-	@include oPrivateTypographySans($scale: 4);
 	padding-right: $_o-banner-spacing;
+	font-family: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-font-family'
+	);
+	font-size: oPrivateFoundationGet('o3-typography-use-case-title-md-font-size');
+	line-height: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-line-height'
+	);
+	font-weight: oPrivateFoundationGet(
+		'o3-typography-use-case-title-md-font-weight'
+	);
 
 	h1,
 	h2,
@@ -74,18 +125,18 @@
 	h4,
 	h5,
 	h6 {
-		@include oPrivateTypographySans($scale: 4, $weight: 'semibold');
-	}
-	@include oPrivateGridRespondTo($until: M) {
-		&,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			@include oPrivateTypographySans($scale: 3);
-		}
+		font-family: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-family'
+		);
+		font-size: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-size'
+		);
+		line-height: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-line-height'
+		);
+		font-weight: oPrivateFoundationGet(
+			'o3-typography-use-case-title-lg-font-weight'
+		);
 	}
 }
 


### PR DESCRIPTION
There are a 1,000 variations of this one. Many are outmoded and it's often overridden with marketing customisations. That is to say, along with other on site messaging components in need of an audit and redesign! I'd love for them to come after forms this year.

In the meantime my approach to applying the new type use-cases has been to go up in size for headings.
This is a bit shouty but seems to keep the hierarchy better than using a lower weight title or body-lg. The "compact" variant becomes pretty redundant as we're normalising on a larger font size, so definitely a candidate for deprecation with a future audit. 

Screenshots / conversation:
https://financialtimes.slack.com/archives/C07GJU8UK7G/p1738152211384239