### PR TITLE
chore: correct o2 focus ring [OR-1206]

### DIFF
--- a/components/o-private-foundation/src/scss/o-normalise/_variables.scss
+++ b/components/o-private-foundation/src/scss/o-normalise/_variables.scss
@@ -1,3 +1,10 @@
 /// @access private
-$_o-private-normalise-focus-ring: oPrivateFoundationGet('o3-focus-use-case-ring-inverse-outer'), oPrivateFoundationGet('o3-focus-use-case-ring-inverse-inner');
-$_o-private-normalise-reverse-focus-ring: oPrivateFoundationGet('o3-focus-use-case-ring-inverse-inner'), oPrivateFoundationGet('o3-focus-use-case-ring-inverse-outer');
+$_o-private-normalise-focus-ring: oPrivateFoundationGet(
+		'o3-focus-use-case-ring-inner'
+	),
+	oPrivateFoundationGet('o3-focus-use-case-ring-outer');
+
+$_o-private-normalise-reverse-focus-ring: oPrivateFoundationGet(
+		'o3-focus-use-case-ring-inverse-inner'
+	),
+	oPrivateFoundationGet('o3-focus-use-case-ring-inverse-outer');


### PR DESCRIPTION
The inverse token was used for non-inverse focus state.