### PR TITLE
fix: o-footer arrow position

### DIFF
--- a/components/o-footer/src/scss/_mixins.scss
+++ b/components/o-footer/src/scss/_mixins.scss
@@ -5,12 +5,17 @@
 @mixin _oFooterBrandImage($logo-name, $fallback-width) {
 	// Error if the global $system-code variable is not set.
 	// This is required for image service requests.
-	@if(global-variable-exists('system-code') == false or type-of($system-code) != 'string') {
+	@if (
+		global-variable-exists('system-code') ==
+			false or
+			type-of($system-code) !=
+			'string'
+	) {
 		@error 'A global "$system-code" Sass variable must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).';
 	}
 
-	$base-url: "https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:";
-	background-image: url($base-url + $logo-name + "?source=#{$system-code}&format=svg");
+	$base-url: 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:';
+	background-image: url($base-url + $logo-name + '?source=#{$system-code}&format=svg');
 }
 
 /// Styles for the dark theme
@@ -112,17 +117,21 @@
 				content: ' ';
 				position: absolute;
 				right: 0;
-				top: div(($line-size - $_o-footer-icon-size), 2);
+				top: calc((#{$line-size} - #{$_o-footer-icon-size}) / 2);
 
 				@each $theme in $themes {
 					.o-footer--theme-#{$theme} & {
-						@include oIconsContent('arrow-down', _oFooterGet('title', $theme), $size: $_o-footer-icon-size);
+						@include oIconsContent(
+							'arrow-down',
+							_oFooterGet('title', $theme),
+							$size: $_o-footer-icon-size
+						);
 					}
 				}
 			}
 		}
 
-		&[aria-expanded="true"] {
+		&[aria-expanded='true'] {
 			&:after {
 				// don't download another icon...
 				transform: rotate(180deg);
@@ -144,7 +153,7 @@
 	}
 
 	.o-footer__matrix-content {
-		&[aria-hidden="true"] {
+		&[aria-hidden='true'] {
 			display: none;
 		}
 	}
@@ -180,7 +189,7 @@
 			content: '';
 			// Undo in-built icon whitespace.
 			position: relative;
-			margin: calc(#{$_o-footer-icon-size}px / -4);
+			margin: calc(#{$_o-footer-icon-size} / -4);
 			vertical-align: baseline;
 		}
 	}

--- a/components/o-footer/src/scss/_variables.scss
+++ b/components/o-footer/src/scss/_variables.scss
@@ -9,21 +9,45 @@ $_o-footer-spacing-unit: oSpacingByIncrement(5);
 /// @type Map
 $_o-footer-matrix: (
 	1: (
-		group: (default: 12, M: 4, L: 2),
-		columns: (default: 12)
+		group: (
+			default: 12,
+			M: 4,
+			L: 2,
+		),
+		columns: (
+			default: 12,
+		),
 	),
 	2: (
-		group: (default: 12, M: 6, L: 4),
-		columns: (default: 6)
+		group: (
+			default: 12,
+			M: 6,
+			L: 4,
+		),
+		columns: (
+			default: 6,
+		),
 	),
 	4: (
-		group: (default: 12, L: 8),
-		columns: (default: 6, M: 3)
+		group: (
+			default: 12,
+			L: 8,
+		),
+		columns: (
+			default: 6,
+			M: 3,
+		),
 	),
 	6: (
-		group: (default: 12),
-		columns: (default: 6, M: 3, L: 2)
-	)
+		group: (
+			default: 12,
+		),
+		columns: (
+			default: 6,
+			M: 3,
+			L: 2,
+		),
+	),
 );
 
-$_o-footer-icon-size: 20;
+$_o-footer-icon-size: 20px;


### PR DESCRIPTION
When `$o-spacing-relative-units` is true, arrows were misaligned, due to borked calculations involving mixed px and rem values.
![Screenshot 2025-01-31 at 09 17 30](https://github.com/user-attachments/assets/95301b40-d39b-4632-b897-7e636406da16)

