### PR TITLE
feat: use o-private-foundation/o-colors in o-subs-card

### DIFF
--- a/components/o-subs-card/demos/src/demo.scss
+++ b/components/o-subs-card/demos/src/demo.scss
@@ -14,7 +14,7 @@ body {
   // sass-lint:disable no-vendor-prefixes
   -webkit-font-smoothing: antialiased;
   // sass-lint:enable no-vendor-prefixes
-  background-color: oColorsByName(paper);
+  background-color: oPrivateFoundationGet("o3-color-palette-paper");
 }
 
 .o-subs-card__container {

--- a/components/o-subs-card/src/scss/_mixins.scss
+++ b/components/o-subs-card/src/scss/_mixins.scss
@@ -15,9 +15,9 @@
 	}
 
 	.o-subs-card__top {
-		color: oColorsByName("black");
-		background-color: oColorsByName("white");
-		box-shadow: 0 5px 5px oColorsByName("black-5");
+		color: oPrivateFoundationGet("o3-color-palette-black");
+		background-color: oPrivateFoundationGet("o3-color-palette-white");
+		box-shadow: 0 5px 5px oPrivateFoundationGet("o3-color-palette-black-5");
 		padding-bottom: 0;
 		padding-right: $o-subs-card-horizontal-padding;
 		padding-left: $o-subs-card-horizontal-padding;
@@ -66,9 +66,9 @@
 	}
 
 	.o-subs-card__expander {
-		color: oColorsByName("black");
-		background-color: oColorsByName("white");
-		box-shadow: 0 5px 5px oColorsByName("black-5");
+		color: oPrivateFoundationGet("o3-color-palette-black");
+		background-color: oPrivateFoundationGet("o3-color-palette-white");
+		box-shadow: 0 5px 5px oPrivateFoundationGet("o3-color-palette-black-5");
 
 		&--collapsed {
 			display: none;
@@ -99,9 +99,9 @@
 	.o-subs-card__read-more {
 		@include oPrivateTypographySans($scale: -1, $weight: "semibold");
 
-		background-color: oColorsByName("wheat");
+		background-color: oPrivateFoundationGet("o3-color-palette-wheat");
 		border-width: 0;
-		color: oColorsByName("teal-50");
+		color: oPrivateFoundationGet("o3-color-palette-teal-50");
 		cursor: pointer;
 		display: block;
 		padding-bottom: oPrivateSpacingByName("s2");
@@ -114,7 +114,7 @@
 
 		//doesn't use oExpanderToggle mixin, because that mixin has a fixed font-size/icon size
 		&:after {
-			@include oPrivateIconsContent("arrow-down", oColorsByName("teal-50"), $size: 16);
+			@include oPrivateIconsContent("arrow-down", oPrivateFoundationGet("o3-color-palette-teal-50"), $size: 16);
 			content: "";
 			position: relative;
 			vertical-align: middle;
@@ -132,7 +132,7 @@
 	.o-subs-card__swg {
 		background: white;
 		padding: 0 16px 16px;
-		box-shadow: 0 5px 5px oColorsByName("black-5");
+		box-shadow: 0 5px 5px oPrivateFoundationGet("o3-color-palette-black-5");
 	}
 
 	.o-subs-card__separator {

--- a/components/o-subs-card/src/scss/_themes.scss
+++ b/components/o-subs-card/src/scss/_themes.scss
@@ -1,12 +1,12 @@
 @mixin oSubsCardB2B {
 	.o-subs-card__top {
-		background: oColorsByName("slate");
-		color: oColorsByName("white");
+		background: oPrivateFoundationGet("o3-color-palette-slate");
+		color: oPrivateFoundationGet("o3-color-palette-white");
 	}
 
 	.o-subs-card__copy-benefits {
-		background: oColorsByName("slate");
-		color: oColorsByName("white");
+		background: oPrivateFoundationGet("o3-color-palette-slate");
+		color: oPrivateFoundationGet("o3-color-palette-white");
 	}
 
 	.o-subs-card__copy-title:first-child {
@@ -33,19 +33,19 @@
 		@include oPrivateTypographySans(3);
 		padding-top: oPrivateSpacingByIncrement(5);
 		line-height: 1;
-		color: oColorsByName("claret-80");
+		color: oPrivateFoundationGet("o3-color-palette-claret-80");
 	}
 
 	.o-subs-card__select-button {
 		@include oPrivateButtonsContentWithThemeOverride($opts: ("type": "primary",
 				"size": "big",
 			),
-			$theme-override: (color: oColorsByName("claret-80"),
-				context: oColorsByName("white"),
+			$theme-override: (color: oPrivateFoundationGet("o3-color-palette-claret-80"),
+				context: oPrivateFoundationGet("o3-color-palette-white"),
 			));
 	}
 
 	.o-subs-card__charge__value {
-		color: oColorsByName("claret-80");
+		color: oPrivateFoundationGet("o3-color-palette-claret-80");
 	}
 }

--- a/components/o-subs-card/src/scss/_themes.scss
+++ b/components/o-subs-card/src/scss/_themes.scss
@@ -17,7 +17,7 @@
 	}
 
 	.o-subs-card__select-button {
-		@include oPrivateButtonsContent($opts: ("type": "primary",
+		@include oPrivateButtonsContent($opts: ("type": "secondary",
 				"size": "big",
 				"theme": "inverse",
 			));


### PR DESCRIPTION
## Describe your changes
* uses o-private-foundation/o-colors
* fixes a styling issue where primary button was used instead of secondary

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
