### PR TITLE
fix: revert changes to components not being upgraded

### DIFF
--- a/components/o-colors/demos/src/color-mixer/color-mixer.scss
+++ b/components/o-colors/demos/src/color-mixer/color-mixer.scss
@@ -48,7 +48,7 @@ body {
 	}
 }
 
-input[type='radio'] {
+input[type=radio] { // stylelint-disable-line selector-no-qualifying-type
 	appearance: none;
 	border: 1px solid var(--color);
 	display: inline-block;

--- a/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
+++ b/components/o-colors/demos/src/contrast-checker/contrast-checker.scss
@@ -11,7 +11,6 @@
 @include oButtons();
 @import '@financial-times/o-overlay/main';
 @include oOverlay();
-
 @mixin swatchStyle() {
 	appearance: none;
 	border: 1px solid lightgrey;
@@ -25,6 +24,7 @@
 }
 
 @if not oBrandIs(whitelabel) {
+
 	:root {
 		--background: white;
 		--foreground: black;
@@ -78,16 +78,16 @@
 		grid-area: 1 / 4 / span 3;
 		width: 320px;
 
-		.o-tabs--buttontabs[data-o-tabs--js][role='tablist'] {
+		.o-tabs--buttontabs[data-o-tabs--js][role="tablist"] {
 			border-color: black;
 
-			[role='tab'] {
+			[role=tab] {
 				color: black;
 				border-color: black;
 				background-color: oColorsByName('white');
 			}
 
-			[role='tab'][aria-selected='true'] {
+			[role=tab][aria-selected=true] {
 				background-color: oColorsByName('black-10');
 
 				a {
@@ -95,7 +95,7 @@
 				}
 			}
 
-			[role='tab'][aria-selected='false'] a {
+			[role=tab][aria-selected=false] a {
 				font-weight: 400;
 			}
 		}
@@ -110,11 +110,12 @@
 			}
 		}
 
-		input[type='radio'] {
+		input[type=radio] { // stylelint-disable-line selector-no-qualifying-type
 			@include swatchStyle();
 
+			// stylelint-disable-next-line selector-no-qualifying-type
 			&.o-overlay-trigger,
-			&.trigger-input {
+			&.trigger-input { // stylelint-disable-line selector-no-qualifying-type
 				background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Aplus?source=o-colors&width=24&height=24&tint=gray');
 			}
 		}
@@ -128,8 +129,7 @@
 			right: 20px;
 		}
 
-		// stylelint-disable selector-max-id
-		#add-mix {
+		#add-mix { //stylelint-disable-line selector-max-id
 			background-image: none;
 			font-size: inherit;
 			float: none;
@@ -141,10 +141,10 @@
 			padding: 0;
 		}
 
-		input[type='radio'] {
+		input[type=radio] { // stylelint-disable-line selector-no-qualifying-type
 			@include swatchStyle();
 
-			&[name='range'] {
+			&[name=range] { // stylelint-disable-line selector-no-qualifying-type
 				height: 48px;
 				width: 22px;
 			}
@@ -161,7 +161,7 @@
 	}
 
 	.contrast-info {
-		grid-area: 1 / 2 / auto / span 2;
+		grid-area: 1 / 2 / auto / span 2 ;
 		padding: 12px;
 		margin-top: 28px;
 		width: 320px;
@@ -189,7 +189,6 @@
 		}
 
 		.rating-result {
-
 			&--aaa,
 			&--aa {
 				color: oColorsMix('jade', 'black', 70);
@@ -228,4 +227,5 @@
 			color: inherit;
 		}
 	}
+
 }

--- a/components/o-colors/demos/src/demo.scss
+++ b/components/o-colors/demos/src/demo.scss
@@ -3,7 +3,7 @@
 @include oColors();
 @import '@financial-times/o-fonts/main';
 @include oFonts();
-@import "@financial-times/o-normalise/main";
+@import '@financial-times/o-normalise/main';
 @include oNormalise();
 
 

--- a/components/o-icons/stories/icons.scss
+++ b/components/o-icons/stories/icons.scss
@@ -1,6 +1,5 @@
 @import '@financial-times/o-fonts/main';
 @import '@financial-times/o-normalise/main';
-
 @include oFonts();
 @include oNormalise();
 

--- a/components/o-typography/demos/src/demo.scss
+++ b/components/o-typography/demos/src/demo.scss
@@ -9,66 +9,65 @@
 
 
 body {
-  background-color: oColorsByUsecase('page', 'background');
-  overflow-y: scroll;
+	background-color: oColorsByUsecase('page', 'background');
+	overflow-y: scroll;
 }
 
 .demo {
-  // prevent images and media from expanding its container
-  img {
-    max-width: 100%;
-    height: auto;
-    display: block;
-  }
-
-  figure {
-    margin: 0 0 28px;
-  }
+	// prevent images and media from expanding its container
+	img {
+		max-width: 100%;
+		height: auto;
+		display: block;
+	}
+	figure {
+		margin: 0 0 28px;
+	}
 }
 
 .demo-inverse body {
-  background-color: oColorsByUsecase('page-inverse', 'background');
+	background-color: oColorsByUsecase('page-inverse', 'background');
 }
 
 .type-scale {
-  white-space: nowrap;
-  overflow: hidden;
+	white-space: nowrap;
+	overflow: hidden;
 
-  .type-scale__label {
-    @include oTypographySans(1);
-    color: oColorsByName('black-60');
-    display: inline-block;
-    min-width: 1ch;
-    padding: 0 1em;
-  }
+	.type-scale__label {
+		@include oTypographySans(1);
+		color: oColorsByName('black-60');
+		display: inline-block;
+		min-width: 1ch;
+		padding: 0 1em;
+	}
 
-  .type-scale__example {
-    white-space: nowrap;
-    overflow: hidden;
-  }
+	.type-scale__example {
+		white-space: nowrap;
+		overflow: hidden;
+	}
 
-  @each $scale, $values in $_o-typography-font-scale {
-    .type-scale__example-#{$scale} {
-      @include oTypographyDisplay($scale);
-    }
-  }
+	@each $scale, $values in $_o-typography-font-scale {
+		.type-scale__example-#{$scale} {
+			@include oTypographyDisplay($scale);
+		}
+	}
 }
 
 .line-width-demo {
-  display: flex;
+	display: flex;
 
-  .line-width-demo__selection {
-    min-width: 100px;
-    margin: 20px;
-  }
+	.line-width-demo__selection {
+		min-width: 100px;
+		margin: 20px;
+	}
 
-  .line-width-demo__scale {
-    max-width: oTypographyMaxLineWidth();
-  }
+	.line-width-demo__scale {
+		max-width: oTypographyMaxLineWidth();
+	}
 
-  @each $scale, $values in $_o-typography-font-scale {
-    .line-width-demo__scale--#{$scale} {
-      @include oTypographySans($scale);
-    }
-  }
+	@each $scale, $values in $_o-typography-font-scale {
+		.line-width-demo__scale--#{$scale} {
+			@include oTypographySans($scale);
+		}
+	}
 }

--- a/components/o-typography/main.scss
+++ b/components/o-typography/main.scss
@@ -1,10 +1,11 @@
 @import '@financial-times/math';
 @import '@financial-times/o-spacing/main';
-@import '@financial-times/o-private-foundation/main';
-@import '@financial-times/o-colors/main';
+@import '@financial-times/o-grid/main';
 @import '@financial-times/o-fonts/main';
+@import '@financial-times/o-colors/main';
 @import '@financial-times/o-icons/main';
 @import '@financial-times/o-normalise/main';
+
 @import 'src/scss/brand';
 @import 'src/scss/variables';
 @import 'src/scss/functions';
@@ -25,28 +26,16 @@
 ///     ));
 ///
 /// @param {Map} $opts [('headings': (1, 2, 3, 4, 5, 6), 'wrapper': true, 'body': true, 'links': true, 'lists': ('ordered', 'unordered'), 'caption': true, 'footer': true, 'utilities': true)] - The features of o-typography to output classes for. See the [README](https://registry.origami.ft.com/components/o-typography/readme) for more details.
-@mixin oTypography(
-	$opts: (
-		'headings': (
-			1,
-			2,
-			3,
-			4,
-			5,
-			6,
-		),
-		'wrapper': true,
-		'body': true,
-		'links': true,
-		'lists': (
-			'ordered',
-			'unordered',
-		),
-		'caption': true,
-		'footer': true,
-		'utilities': true,
-	)
-) {
+@mixin oTypography($opts: (
+	'headings': (1, 2, 3, 4, 5, 6),
+	'wrapper': true,
+	'body': true,
+	'links': true,
+	'lists': ('ordered', 'unordered'),
+	'caption': true,
+	'footer': true,
+	'utilities': true,
+)) {
 	$wrapper-enabled: map-get($opts, 'wrapper');
 	$body-enabled: map-get($opts, 'body');
 	$links-enabled: map-get($opts, 'links');
@@ -55,18 +44,12 @@
 	$utilities-enabled: map-get($opts, 'utilities');
 	$headings: map-get($opts, 'headings');
 	$headings: if($headings, $headings, ());
-	@if (
-		$headings and
-			type-of($headings) !=
-			'list' and
-			type-of($headings) !=
-			'number'
-	) {
+	@if($headings and type-of($headings) != 'list' and type-of($headings) != 'number') {
 		@error ('The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5, 6)`.');
 	}
 	$lists: map-get($opts, 'lists');
 	$lists: if($lists, $lists, ());
-	@if ($lists and type-of($lists) != 'list') {
+	@if($lists and type-of($lists) != 'list') {
 		@error ('The "lists" option must be a list of list types to include e.g. `(\'ordered\', \'unordered\')`.');
 	}
 
@@ -87,7 +70,7 @@
 	// Body, Italic, Superscript, Subscript.
 	@if $utilities-enabled {
 		.o-typography-bold {
-			@include oTypographySans(
+			@include oTypographySans (
 				$weight: 'semibold',
 				$include-font-family: false
 			);
@@ -112,7 +95,7 @@
 			@include oTypographyBody;
 		}
 		.o-typography-inverse {
-			--_o-typography-body-color: #{_oTypographyGet('color', 'body-inverse')};
+			--_o-typography-body-color: #{_oTypographyGet('color', 'body-inverse')};;
 		}
 	}
 
@@ -124,75 +107,33 @@
 
 		.o-typography-inverse {
 			--_o-typography-link-color: #{_oTypographyGet('base', 'link-inverse')};
-			--_o-typography-link-decoration-color: #{_oTypographyGet(
-					'base-decoration',
-					'link-inverse'
-				)};
-			--_o-typography-link-color-hover: #{_oTypographyGet(
-					'hover',
-					'link-inverse'
-				)};
-			--_o-typography-link-decoration-color-hover: #{_oTypographyGet(
-					'hover-decoration',
-					'link-inverse'
-				)};
+			--_o-typography-link-decoration-color: #{_oTypographyGet('base-decoration', 'link-inverse')};
+			--_o-typography-link-color-hover: #{_oTypographyGet('hover', 'link-inverse')};
+			--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-inverse')};
 		}
 
 		@if _oTypographySupports('professional') {
 			.o-typography-professional {
-				--_o-typography-link-color: #{_oTypographyGet(
-						'base',
-						'link-professional'
-					)};
-				--_o-typography-link-decoration-color: #{_oTypographyGet(
-						'base-decoration',
-						'link-professional'
-					)};
-				--_o-typography-link-color-hover: #{_oTypographyGet(
-						'hover',
-						'link-professional'
-					)};
-				--_o-typography-link-decoration-color-hover: #{_oTypographyGet(
-						'hover-decoration',
-						'link-professional'
-					)};
+				--_o-typography-link-color: #{_oTypographyGet('base', 'link-professional')};
+				--_o-typography-link-decoration-color: #{_oTypographyGet('base-decoration', 'link-professional')};
+				--_o-typography-link-color-hover: #{_oTypographyGet('hover', 'link-professional')};
+				--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-professional')};
 			}
 
 			.o-typography-professional.o-typography-inverse {
-				--_o-typography-link-color: #{_oTypographyGet(
-						'base',
-						'link-professional-inverse'
-					)};
-				--_o-typography-link-decoration-color: #{_oTypographyGet(
-						'base-decoration',
-						'link-professional-inverse'
-					)};
-				--_o-typography-link-color-hover: #{_oTypographyGet(
-						'hover',
-						'link-professional-inverse'
-					)};
-				--_o-typography-link-decoration-color-hover: #{_oTypographyGet(
-						'hover-decoration',
-						'link-professional-inverse'
-					)};
+				--_o-typography-link-color: #{_oTypographyGet('base', 'link-professional-inverse')};
+				--_o-typography-link-decoration-color: #{_oTypographyGet('base-decoration', 'link-professional-inverse')};
+				--_o-typography-link-color-hover: #{_oTypographyGet('hover', 'link-professional-inverse')};
+				--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-professional-inverse')};
 			}
 		}
 
 		@if _oTypographySupports('ft-live') {
 			.o-typography-ft-live {
 				--_o-typography-link-color: #{_oTypographyGet('base', 'link-ft-live')};
-				--_o-typography-link-decoration-color: #{_oTypographyGet(
-						'base-decoration',
-						'link-ft-live'
-					)};
-				--_o-typography-link-color-hover: #{_oTypographyGet(
-						'hover',
-						'link-ft-live'
-					)};
-				--_o-typography-link-decoration-color-hover: #{_oTypographyGet(
-						'hover-decoration',
-						'link-ft-live'
-					)};
+				--_o-typography-link-decoration-color: #{_oTypographyGet('base-decoration', 'link-ft-live')};
+				--_o-typography-link-color-hover: #{_oTypographyGet('hover', 'link-ft-live')};
+				--_o-typography-link-decoration-color-hover: #{_oTypographyGet('hover-decoration', 'link-ft-live')};
 			}
 		}
 	}

--- a/components/o-typography/package.json
+++ b/components/o-typography/package.json
@@ -37,10 +37,11 @@
   },
   "peerDependencies": {
     "@financial-times/math": "^1.0.0",
+    "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-fonts": "^5.0.0",
+    "@financial-times/o-grid": "^6.1.1",
     "@financial-times/o-icons": "^7.0.0",
     "@financial-times/o-normalise": "^3.3.0",
-    "@financial-times/o-private-foundation": "^0.0.0",
     "@financial-times/o-spacing": "^3.0.0"
   },
   "devDependencies": {

--- a/components/o-typography/src/scss/_brand.scss
+++ b/components/o-typography/src/scss/_brand.scss
@@ -112,17 +112,17 @@ $_o-typography-font-scale: (
 
 	@include oBrandDefine('o-typography', 'core', (
 		'variables': (
-			'author-color': oPrivateFoundationGet('o3-color-use-case-body-text'),
+			'author-color': oColorsByUsecase('body', 'text'),
 			'author-hover-color': oColorsByName('claret'),
 			'body': (
 				'color': oColorsByUsecase('body', 'text', $fallback: null),
 			),
 			'body-inverse': (
-				'color':  oColorsByUsecase('body-inverse', 'text', $fallback: null),
+				'color': oColorsByUsecase('body-inverse', 'text', $fallback: null),
 			),
 			'link': (
-				'base': oPrivateFoundationGet('o3-color-use-case-link-text'),
-				'hover': oPrivateFoundationGet('o3-color-use-case-link-text-hover'),
+				'base': oColorsByUsecase('link', 'text'),
+				'hover': oColorsByUsecase('link-hover', 'text'),
 			),
 			'link-inverse': (
 				'base': oColorsByName('white'),
@@ -188,8 +188,8 @@ $_o-typography-font-scale: (
 	@include oBrandDefine('o-typography', 'internal', (
 		'variables': (
 			'link': (
-				'base': oPrivateFoundationGet('o3-color-use-case-link-text'),
-				'hover': oPrivateFoundationGet('o3-color-use-case-link-text-hover'),
+				'base': oColorsByUsecase('link', 'text'),
+				'hover': oColorsByUsecase('link-hover', 'text'),
 			),
 			'heading-level-one': (
 				'scale': 5,

--- a/components/o-typography/src/scss/_mixins.scss
+++ b/components/o-typography/src/scss/_mixins.scss
@@ -290,7 +290,7 @@
 			}
 
 			@if $breakpoint != 'default' and $current-scale {
-				@include oPrivateGridRespondTo($breakpoint) {
+				@include oGridRespondTo($breakpoint) {
 					font-size: _oTypographyFontSizeFromScale($current-scale, 1, $font);
 					line-height: _oTypographyLineHeightFromScale($current-scale, $current-line-height, $font);
 				}
@@ -368,7 +368,7 @@
 					font-size: _oTypographyFontSizeFromScale($number, $progressive-font-adjust, $font);
 				}
 			} @else if($number) {
-				@include oPrivateGridRespondTo($breakpoint) {
+				@include oGridRespondTo($breakpoint) {
 					@if type-of($number) == list {
 						font-size: _oTypographyFontSizeFromScale(nth($number, 1), $progressive-font-adjust, $font);
 					} @else {

--- a/components/o-typography/src/scss/use-cases/_general.scss
+++ b/components/o-typography/src/scss/use-cases/_general.scss
@@ -1,4 +1,3 @@
-
 /// Output styles for page headings.
 /// @example Output heading level 1 styles.
 ///     h1 {
@@ -39,7 +38,7 @@
 		),
 		$weight: $weight
 	);
-	color:  oColorsByUsecase('body', 'text', $fallback: null);
+	color: oColorsByUsecase('body', 'text', $fallback: null);
 	margin: 0 0 oSpacingByName('s4');
 }
 

--- a/components/o-typography/stories/typography.scss
+++ b/components/o-typography/stories/typography.scss
@@ -1,8 +1,7 @@
-@import '@financial-times/o-fonts/main';
-@import '@financial-times/o-normalise/main';
+@import "@financial-times/o-fonts/main";
+@import "@financial-times/o-normalise/main";
 @include oFonts();
 @include oNormalise();
 
-@import '@financial-times/o-quote/main';
-@import '@financial-times/o-typography/main';
+@import "@financial-times/o-quote/main";
 @include oTypography();

--- a/components/o-visual-effects/stories/visual-effects.scss
+++ b/components/o-visual-effects/stories/visual-effects.scss
@@ -1,22 +1,20 @@
-@import '@financial-times/o-private-foundation/main';
-@import '@financial-times/o-visual-effects/main';
-@import '@financial-times/o-normalise/main';
-@import '@financial-times/o-spacing/main';
-@import '@financial-times/o-typography/main';
-@import '@financial-times/o-fonts/main';
-@import '@financial-times/o-colors/main';
+@import "@financial-times/o-visual-effects/main";
+@import "@financial-times/o-normalise/main";
+@import "@financial-times/o-buttons/main";
+@import "@financial-times/o-spacing/main";
+@import "@financial-times/o-typography/main";
+@import "@financial-times/o-fonts/main";
+@import "@financial-times/o-colors/main";
 
 @include oNormalise();
 @include oFonts();
 @include oVisualEffects();
 
 .demo-button {
-	@include oPrivateButtonsContent(
-		(
-			'size': 'big',
-			'type': 'primary',
-		)
-	);
+	@include oButtonsContent((
+		'size': 'big',
+		'type': 'primary',
+	));
 	margin-right: oSpacingByName('s8');
 	float: left;
 }
@@ -32,8 +30,7 @@
 	}
 	width: var(--demo-size);
 	height: var(--demo-size);
-	transition: all var(--demo-transition-duration)
-		var(--demo-transition-timing-function);
+	transition: all var(--demo-transition-duration) var(--demo-transition-timing-function);
 	display: inline-block;
 }
 
@@ -63,7 +60,7 @@
 }
 
 .shadow-demo {
-	@include oPrivateTypographySans($scale: 1);
+	@include oTypographySans($scale: 1);
 	display: inline-flex;
 	background: white;
 	width: 10rem;


### PR DESCRIPTION
## Describe your changes
Reverts changes in deprecated components:
* o-typography
* o-visual-effects

Reverts linting changes by components unaffected by migration, this is to save releasing them as a big release:
* o-colors
* o-icons
* o-spacing

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
