### PR TITLE
feat: remove bold and italic o3-typography classes

### DIFF
--- a/components/o3-foundation/README.md
+++ b/components/o3-foundation/README.md
@@ -86,7 +86,7 @@ Then apply the brand data selector `data-o3-brand="[BRAND]"` on a container elem
 #### JSX
 
 ```jsx
-import { List } from '@financial-times/o3-foundation/cjs' // or esm;
+import { List } from '@financial-times/o3-foundation/cjs'; // or esm;
 
 <UnorderedList>
  <li>Item 1</li>
@@ -119,6 +119,16 @@ import {Wrapper} from '@financial-times/o3-foundation/cjs'; // or esm
 	<p>And so does this paragraphy of text.</p>
 	<h2>This gets styled also</h2>
 </Wrapper>;
+```
+
+### Highlight (Bold)
+
+Use typography use cases to style body content with bolder styles:
+
+```html
+<p class="o3-type-body-base">
+  This is <strong class="o3-type-body">really</strong> important.
+</p>
 ```
 
 ### Custom Properties

--- a/components/o3-foundation/src/css/components/typography/index.css
+++ b/components/o3-foundation/src/css/components/typography/index.css
@@ -7,14 +7,6 @@
 	--o3-typography-max-line-width: 60ch;
 }
 
-.o3-typography-bold {
-	font-weight: var(--o3-font-weight-bold);
-}
-
-.o3-typography-italic {
-	font-style: italic;
-}
-
 :where([class^='o3-typography']) {
 	font-family: var(--o3-font-family-metric);
 }


### PR DESCRIPTION
## Describe your changes

* Removes `o3-typography-bold` and `o3-typography-italic` classes.

Releasing as minor as there are no usages outside of Origami. Verified with github search.

Docs appear to be updated already. [Readme](https://github.com/Financial-Times/origami/tree/2025-release/components/o3-foundation), [Migration]()



## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
