### PR TITLE
fix: revert o3 o normalise changes

### DIFF
--- a/components/o-normalise/src/scss/_mixins.scss
+++ b/components/o-normalise/src/scss/_mixins.scss
@@ -106,8 +106,8 @@
 ///
 /// @param {String|Color} $color - The background colour of the focused element.
 @mixin oNormaliseFocusContentForElementColour($color) {
-	$black-contrast: oPrivateColorsGetContrastRatio($color, 'o3-color-palette-black');
-	$white-contrast: oPrivateColorsGetContrastRatio($color, 'o3-color-palette-white');
+	$black-contrast: oColorsGetContrastRatio($color, 'black');
+	$white-contrast: oColorsGetContrastRatio($color, 'white');
 	$shadow: if(
 		$black-contrast <= $white-contrast,
 		$_o-normalise-focus-ring,


### PR DESCRIPTION
## Describe your changes

Reverts usage of o3 colour tokens in o-normalise. To fix build issues on `2025-release`.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
