### PR TITLE
fix: remove Sass interpolation #{} from font-family [OR-1350]

### DIFF
--- a/components/o-private-foundation/src/scss/o-typography/main.scss
+++ b/components/o-private-foundation/src/scss/o-typography/main.scss
@@ -57,7 +57,7 @@
 		@if ($scale < 0) {
 			$scale-item-key: 'negative#{$scale}';
 		}
-		font-family: #{oPrivateFoundationGet('o3-font-family-#{$font}')};
+		font-family: oPrivateFoundationGet('o3-font-family-#{$font}');
 		font-size: oPrivateFoundationGet(
 			'o3-font-size#{$scale-key}#{$scale-item-key}'
 		);


### PR DESCRIPTION
## Describe your changes

Sass was stripping the `" "` needed for the `font-family` property to have `"metric 2 VF"`. Removed the `#{}` from the Sass file affected so that it wouldn't strip the double quotes out when the Sass got compiled into CSS.

## Issue ticket number and link

[OR-1350](https://financialtimes.atlassian.net/browse/OR-1350)

## Link to Figma designs

N/A


[OR-1350]: https://financialtimes.atlassian.net/browse/OR-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ