### PR TITLE
Make 2025-release with design language changes and o3 migration path

### DIFF
--- a/components/ft-concept-button/MIGRATION.md
+++ b/components/ft-concept-button/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migration Guide
+## Migration Guide
 
-## Migrating from v2 to v3
+### Migrating from v1 to v2
 
 This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
 
@@ -16,11 +16,3 @@ To upgrade, replace the following "o2" components with their "o3" equivalent:
 - [o-big-number](../o-big-number/MIGRATION.md)
 - [o-quote](../o-quote/MIGRATION.md)
 - [o-fonts](../o-fonts/MIGRATION.md)
-
-### Migrating from v1 to v2
-
-Support for Bower and version 2 of the Origami Build Service have been removed.
-
-CSS is also now wrapped into a `gAudio` mixin.
-
-Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).

--- a/components/ft-concept-button/README.md
+++ b/components/ft-concept-button/README.md
@@ -60,7 +60,7 @@ This one has a little plus or a tick icon. You'd be advised to include the `data
 ## JavaScript
 
 ```js
-import ConceptButton from "@financial-times/ft-concept-button";
+import ConceptButton from '@financial-times/ft-concept-button';
 ```
 
 ### Options
@@ -105,7 +105,12 @@ export interface ConceptButtonProps {
 	// descriptive label for button
 	ariaLabel?: string;
 	// button theme
-	theme?: 'standard' | 'inverse' | 'opinion' | 'monochrome' | 'inverse-monochrome';
+	theme?:
+		| 'standard'
+		| 'inverse'
+		| 'opinion'
+		| 'monochrome'
+		| 'inverse-monochrome';
 	// button type (the follow type has an icon)
 	type?: 'concept' | 'follow';
 	// whether the button is currently pressed
@@ -114,3 +119,10 @@ export interface ConceptButtonProps {
 	extraButtonProps: any;
 }
 ```
+
+## Migration
+
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       2       |        N/A         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.3         |                          N/A                          |

--- a/components/g-audio/README.md
+++ b/components/g-audio/README.md
@@ -38,10 +38,10 @@ To create an audio player inline with text:
 
 ```html
 <span class="g-audio">
-  Bring to the table win-win survival
-  <audio controls>
-    <source src="demo.mp3" type="audio/mpeg">
-  </audio>
+	Bring to the table win-win survival
+	<audio controls>
+		<source src="demo.mp3" type="audio/mpeg" />
+	</audio>
 </span>
 ```
 
@@ -49,19 +49,20 @@ To create an audio player between paragraphs of text (in development):
 
 ```html
 <span class="g-audio g-audio--block">
-  Podcasting operational change management
-  <audio controls>
-    <source src="demo2.mp3" type="audio/mpeg">
-  </audio>
+	Podcasting operational change management
+	<audio controls>
+		<source src="demo2.mp3" type="audio/mpeg" />
+	</audio>
 </span>
 ```
 
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-⚠ maintained | 1 | 1.0.7 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |       1.0.7        |                          N/A                          |
 
 ## Licence
 

--- a/components/n-notification/MIGRATION.md
+++ b/components/n-notification/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v8 to v9
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v7 to v8
 
 Support for Bower and version 2 of the Origami Build Service have been removed.

--- a/components/o-autocomplete/MIGRATION.md
+++ b/components/o-autocomplete/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migration Guide
+## Migration Guide
 
-## Migrating from v2 to v3
+### Migrating from v1 to v2
 
 This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
 
@@ -16,11 +16,3 @@ To upgrade, replace the following "o2" components with their "o3" equivalent:
 - [o-big-number](../o-big-number/MIGRATION.md)
 - [o-quote](../o-quote/MIGRATION.md)
 - [o-fonts](../o-fonts/MIGRATION.md)
-
-### Migrating from v1 to v2
-
-Support for Bower and version 2 of the Origami Build Service have been removed.
-
-CSS is also now wrapped into a `gAudio` mixin.
-
-Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).

--- a/components/o-autocomplete/README.md
+++ b/components/o-autocomplete/README.md
@@ -4,18 +4,18 @@ An Origami component for autocomplete inputs. This is built on top of the excell
 
 - [Usage](#usage)
 - [Markup](#markup)
-    - [For a static set of suggestions](#for-a-static-set-of-suggestions)
-    - [For a dynamic set of suggestions](#for-a-dynamic-set-of-suggestions)
-    - [Use with o-forms](#use-with-o-forms)
+  - [For a static set of suggestions](#for-a-static-set-of-suggestions)
+  - [For a dynamic set of suggestions](#for-a-dynamic-set-of-suggestions)
+  - [Use with o-forms](#use-with-o-forms)
 - [Sass](#sass)
 - [JavaScript](#javascript)
-    - [dynamic suggestions function](#dynamic-suggestions-function)
-    - [mapOptionToSuggestedValue](#mapoptiontosuggestedvalue)
-    - [onConfirm](#onconfirm)
+  - [dynamic suggestions function](#dynamic-suggestions-function)
+  - [mapOptionToSuggestedValue](#mapoptiontosuggestedvalue)
+  - [onConfirm](#onconfirm)
 - [Keyboard Support](#keyboard-support)
-    - [When focus is within the text input](#when-focus-is-within-the-text-input)
-    - [When focus is within the suggestions menu](#when-focus-is-within-the-suggestions-menu)
-    - [When focus is within the clear button](#when-focus-is-within-the-clear-button)
+  - [When focus is within the text input](#when-focus-is-within-the-text-input)
+  - [When focus is within the suggestions menu](#when-focus-is-within-the-suggestions-menu)
+  - [When focus is within the clear button](#when-focus-is-within-the-clear-button)
 - [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -33,11 +33,11 @@ To provide a static set of suggestions, we recommend using a `select` element. o
 ```html
 <label for="my-autocomplete">Select your country</label>
 <span data-o-component="o-autocomplete" class="o-autocomplete">
-    <select id="my-autocomplete">
-        <option value="fr">France</option>
-        <option value="de">Germany</option>
-        <option value="gb">United Kingdom</option>
-    </select>
+	<select id="my-autocomplete">
+		<option value="fr">France</option>
+		<option value="de">Germany</option>
+		<option value="gb">United Kingdom</option>
+	</select>
 </span>
 ```
 
@@ -46,9 +46,10 @@ To provide a static set of suggestions, we recommend using a `select` element. o
 To provide a dynamic set of suggestions, provide a javascript function or name of a javascript function on the window object which follows the [dynamic-suggestions-function](#dynamic-suggestions-function) <abbr title="application programming interface">API</abbr>.
 
 The input element requires an `id` attribute, this is used within the component to implement the accessibility features.
+
 ```html
 <span data-o-component="o-autocomplete" class="o-autocomplete">
-    <input id="my-autocomplete" type="text" >
+	<input id="my-autocomplete" type="text" />
 </span>
 ```
 
@@ -57,27 +58,29 @@ The input element requires an `id` attribute, this is used within the component 
 To have styling for labels, you will need to use [o-forms](https://registry.origami.ft.com/components/o-forms) as part of the autocomplete implementation.
 
 Below is an example of how to combine o-forms and o-autocomplete components together. Note the `label` and `select` element are connected using `for` and `id` attributes.
+
 ```html
-<span class="o-forms-field" >
-    <label for="my-autocomplete" class="o-forms-title">
-        <span class="o-forms-title__main">Select your country</span>
-    </label>
-    <span class="o-forms-input o-forms-input--select">
-        <span data-o-component="o-autocomplete" class="o-autocomplete">
-            <select id="my-autocomplete">
-                <option value=""></option>
-                <option>Afghanistan</option>
-            </select>
-        </span>
-    </span>
+<span class="o-forms-field">
+	<label for="my-autocomplete" class="o-forms-title">
+		<span class="o-forms-title__main">Select your country</span>
+	</label>
+	<span class="o-forms-input o-forms-input--select">
+		<span data-o-component="o-autocomplete" class="o-autocomplete">
+			<select id="my-autocomplete">
+				<option value=""></option>
+				<option>Afghanistan</option>
+			</select>
+		</span>
+	</span>
 </span>
 ```
+
 ## Sass
 
 Use `@include oAutocomplete()` to include styles for all `o-autocomplete` features.
 
 ```scss
-@import "@financial-times/o-autocomplete/main";
+@import '@financial-times/o-autocomplete/main';
 
 @include oAutocomplete();
 ```
@@ -86,7 +89,7 @@ Use `@include oAutocomplete()` to include styles for all `o-autocomplete` featur
 
 JavaScript is initialised automatically for [Origami Build Service](https://www.ft.com/__origami/service/build/v3/) users.
 
-If your project is using a manual build process, initialise  `o-autocomplete` manually.
+If your project is using a manual build process, initialise `o-autocomplete` manually.
 For example call the `init` method to initialise all `o-autocomplete` instances in the document:
 
 ```js
@@ -98,9 +101,12 @@ Or pass an element to initialise a specific `o-autocomplete` instance:
 
 ```js
 import oAutocomplete from 'o-autocomplete';
-const oAutocompleteElement = document.getElementById('my-o-autocomplete-element');
+const oAutocompleteElement = document.getElementById(
+	'my-o-autocomplete-element'
+);
 new oAutocomplete(oAutocompleteElement);
 ```
+
 ### dynamic suggestions function
 
 #### Example
@@ -117,15 +123,17 @@ import oAutocomplete from 'o-autocomplete';
  * @param {string} query - Text which was typed into the autocomplete by the user
  * @param {PopulateOptions} populateOptions - Function to call when ready to update the suggestions dropdown
  * @returns {void}
-*/
+ */
 async function customSuggestions(query, populateOptions) {
 	const suggestions = await getSuggestions(query);
 	populateOptions(suggestions);
 }
 
-const oAutocompleteElement = document.getElementById('my-o-autocomplete-element');
+const oAutocompleteElement = document.getElementById(
+	'my-o-autocomplete-element'
+);
 new oAutocomplete(oAutocompleteElement, {
-    source: customSuggestions
+	source: customSuggestions,
 });
 ```
 
@@ -135,20 +143,20 @@ If wanting to supply dynamic suggestions, you will need to provide a function wh
 
 #### (query, suggestionsCallback) ⇒ <code>void</code>
 
-| Param | Type | Description |
-| --- | --- | --- |
-| query | <code>string</code> | Text which was typed into the text input |
+| Param               | Type                                                     | Description                                                |
+| ------------------- | -------------------------------------------------------- | ---------------------------------------------------------- |
+| query               | <code>string</code>                                      | Text which was typed into the text input                   |
 | suggestionsCallback | [<code>suggestionsCallback</code>](#suggestionsCallback) | Function to call when ready to update the suggestions menu |
 
 <a name="suggestionsCallback"></a>
 
 #### suggestionsCallback : <code>function</code>
+
 **Properties**
 
-| Name | Type | Description |
-| --- | --- | --- |
-| options | <code>Array.&lt;*&gt;</code> | The options which match the entered query |
-
+| Name    | Type                          | Description                               |
+| ------- | ----------------------------- | ----------------------------------------- |
+| options | <code>Array.&lt;\*&gt;</code> | The options which match the entered query |
 
 ### mapOptionToSuggestedValue
 
@@ -156,7 +164,6 @@ This function is used to convert the options returned from the `source` function
 If the `source` function is returning an array of strings which are already suitable to be displayed in within the suggestions menu, then there is no need to define a `mapOptionToSuggestedValue` function.
 
 The most common scenario which requires having to define a `mapOptionToSuggestedValue` function is when the `source` function is returning an array of objects, where one of the properties in the object should be used as the suggestion.
-
 
 #### Example
 
@@ -171,25 +178,28 @@ async function customSuggestions(query, populateOptions) {
 /**
  * @param {{"suggestionText": string}} option - The option to transform into a suggestion string
  * @returns {string} The string to display as the suggestions for this option
-*/
+ */
 function mapOptionToSuggestedValue(option) {
 	return option.suggestionText;
 }
 
-const oAutocompleteElement = document.getElementById('my-o-autocomplete-element');
+const oAutocompleteElement = document.getElementById(
+	'my-o-autocomplete-element'
+);
 new oAutocomplete(oAutocompleteElement, {
-    mapOptionToSuggestedValue,
-    source: customSuggestions,
+	mapOptionToSuggestedValue,
+	source: customSuggestions,
 });
 ```
 
 <a name="MapOptionToSuggestedValue"></a>
 
 #### MapOptionToSuggestedValue ⇒ <code>string</code>
+
 **Returns**: <code>string</code> - The string to display as the suggestions for this option
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param  | Type            | Description                                      |
+| ------ | --------------- | ------------------------------------------------ |
 | option | <code>\*</code> | The option to transform into a suggestion string |
 
 ### onConfirm
@@ -229,7 +239,6 @@ new oAutocomplete(oAutocompleteElement, {
 });
 ```
 
-
 ### suggestionTemplate
 
 This function is used to override the default rendering of suggestion items, with a function that returns a custom HTML string for the given option.
@@ -265,10 +274,12 @@ function suggestionTemplate(option) {
 	`;
 }
 
-const oAutocompleteElement = document.getElementById('my-o-autocomplete-element');
+const oAutocompleteElement = document.getElementById(
+	'my-o-autocomplete-element'
+);
 new oAutocomplete(oAutocompleteElement, {
-    suggestionTemplate,
-    source: customSuggestions,
+	suggestionTemplate,
+	source: customSuggestions,
 });
 ```
 
@@ -278,23 +289,26 @@ Using the `query` value to apply highlighting to one of the `option` properties:
 import oAutocomplete from 'o-autocomplete';
 
 async function customSuggestions(query, populateOptions) {
-    const suggestions = await getSuggestions(query);
-    populateOptions(suggestions);
+	const suggestions = await getSuggestions(query);
+	populateOptions(suggestions);
 }
 
 function highlightSuggestion(suggestion, query) {
-    const result = suggestion.split('');
+	const result = suggestion.split('');
 
-    const matchIndex = suggestion.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
-    return result.map(function(character, index) {
-        let shouldHighlight = true;
-        const hasMatched = matchIndex > -1;
-        const characterIsWithinMatch = index >= matchIndex && index <= matchIndex + query.length - 1;
-        if (hasMatched && characterIsWithinMatch) {
-            shouldHighlight = false;
-        }
-        return [character, shouldHighlight];
-    });
+	const matchIndex = suggestion
+		.toLocaleLowerCase()
+		.indexOf(query.toLocaleLowerCase());
+	return result.map(function (character, index) {
+		let shouldHighlight = true;
+		const hasMatched = matchIndex > -1;
+		const characterIsWithinMatch =
+			index >= matchIndex && index <= matchIndex + query.length - 1;
+		if (hasMatched && characterIsWithinMatch) {
+			shouldHighlight = false;
+		}
+		return [character, shouldHighlight];
+	});
 }
 
 /**
@@ -302,39 +316,42 @@ function highlightSuggestion(suggestion, query) {
  * @param {string} [query] - Text which was typed into the autocomplete text input field by the user
  * @returns {string} The HTML to render in the suggestion list*/
 function suggestionTemplate(option, query) {
-    const characters = highlightSuggestion(option.name, query || option.name);
+	const characters = highlightSuggestion(option.name, query || option.name);
 
-    let output = '';
-    for (const [character, shoudHighlight] of characters) {
-        if (shoudHighlight) {
-            output += `<span class="o-autocomplete__option--highlight">${character}</span>`;
-        } else {
-            output += `${character}`;
-        }
-    }
-    output += ` (${option.role})`;
-    const span = document.createElement('span');
-    span.setAttribute('aria-label', option.name);
-    span.innerHTML = output;
-    return span.outerHTML;
+	let output = '';
+	for (const [character, shoudHighlight] of characters) {
+		if (shoudHighlight) {
+			output += `<span class="o-autocomplete__option--highlight">${character}</span>`;
+		} else {
+			output += `${character}`;
+		}
+	}
+	output += ` (${option.role})`;
+	const span = document.createElement('span');
+	span.setAttribute('aria-label', option.name);
+	span.innerHTML = output;
+	return span.outerHTML;
 }
 
-const oAutocompleteElement = document.getElementById('my-o-autocomplete-element');
+const oAutocompleteElement = document.getElementById(
+	'my-o-autocomplete-element'
+);
 new oAutocomplete(oAutocompleteElement, {
-    suggestionTemplate,
-    source: customSuggestions,
+	suggestionTemplate,
+	source: customSuggestions,
 });
 ```
 
 <a name="SuggestionTemplate"></a>
 
 #### SuggestionTemplate ⇒ <code>string</code>
+
 **Returns**: <code>string</code> - The HTML string to render as the suggestion for this option
 
-| Param | Type | Description |
-| --- | --- | --- |
-| option | <code>\*</code> | The option to transform into a suggestion  |
-| query | <code>string</code> | Text which was typed into the autocomplete text input field by the user  |
+| Param  | Type                | Description                                                             |
+| ------ | ------------------- | ----------------------------------------------------------------------- |
+| option | <code>\*</code>     | The option to transform into a suggestion                               |
+| query  | <code>string</code> | Text which was typed into the autocomplete text input field by the user |
 
 ### onConfirm
 
@@ -377,8 +394,8 @@ new oAutocomplete(oAutocompleteElement, {
 
 #### onConfirm ⇒ <code>void</code>
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param  | Type            | Description                  |
+| ------ | --------------- | ---------------------------- |
 | option | <code>\*</code> | The option the user selected |
 
 #### `defaultValue` (default: `''`)
@@ -393,40 +410,42 @@ _When progressively enhancing a [static set of suggestions](#for-a-static-set-of
 
 ### When focus is within the text input
 
-Key|Function
----|---
-Down Arrow | If the suggestions menu is displayed, moves focus to the first suggested value in the suggestions menu.
-Enter | If the suggestions menu is displayed, does nothing.
-Escape | If the suggestions menu is displayed, closes it.
+| Key        | Function                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| Down Arrow | If the suggestions menu is displayed, moves focus to the first suggested value in the suggestions menu. |
+| Enter      | If the suggestions menu is displayed, does nothing.                                                     |
+| Escape     | If the suggestions menu is displayed, closes it.                                                        |
 
 ### When focus is within the suggestions menu
 
-Key|Function
----|---
-Enter | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the text input.</li></ul>
-Tab | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the clear button.</li></ul>
-Space | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the text input.</li></ul>
-Up Arrow | If focus is on the first option, returns focus to the text input. Otherwise, moves focus to and selects the previous option in the suggestions menu.
-Down Arrow | If focus is on the last option, does nothing. Otherwise, moves focus to and selects the next option in the suggestions menu.
-Backspace | Returns focus to the text input and deletes the character prior to the cursor
-Printable Characters | <ul><li>Moves focus to the text input.</li><li>Types the characters into the text input.</li></ul>
+| Key                  | Function                                                                                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Enter                | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the text input.</li></ul>   |
+| Tab                  | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the clear button.</li></ul> |
+| Space                | <ul><li>Sets the text input value to the content of the focused option in the suggestions menu.</li><li>Closes the suggestions menu.</li><li>Sets focus on the text input.</li></ul>   |
+| Up Arrow             | If focus is on the first option, returns focus to the text input. Otherwise, moves focus to and selects the previous option in the suggestions menu.                                   |
+| Down Arrow           | If focus is on the last option, does nothing. Otherwise, moves focus to and selects the next option in the suggestions menu.                                                           |
+| Backspace            | Returns focus to the text input and deletes the character prior to the cursor                                                                                                          |
+| Printable Characters | <ul><li>Moves focus to the text input.</li><li>Types the characters into the text input.</li></ul>                                                                                     |
 
 ### When focus is within the clear button
 
-Key|Function
----|---
-Enter | <ul><li>Moves focus to the text input.</li><li>Removes all the characters within the text input.</li></ul>
-Space | <ul><li>Moves focus to the text input.</li><li>Removes all the characters within the text input.</li></ul>
-
+| Key   | Function                                                                                                   |
+| ----- | ---------------------------------------------------------------------------------------------------------- |
+| Enter | <ul><li>Moves focus to the text input.</li><li>Removes all the characters within the text input.</li></ul> |
+| Space | <ul><li>Moves focus to the text input.</li><li>Removes all the characters within the text input.</li></ul> |
 
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 1 | 1.0 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       3       |        n/a         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ⚠ maintained |       1       |        1.10        |                          N/A                          |
 
 ## Contact
+
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-autocomplete/issues), visit [##origami-support](https://financialtimes.slack.com/messages/#origami-support/) or email [origami.support@ft.com](mailto:origami.support@ft.com).
 
 ## Licence
+
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/components/o-banner/MIGRATION.md
+++ b/components/o-banner/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v3 to v4
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -51,16 +68,22 @@ In addition `theme` no longer accepts an array. Instead pass a single `theme` ('
 The main sass mixin, `oBanner`, no longer takes a custom class as an argument. Themes have been split into layouts ('small', 'compact') and themes ('marketing', 'product'). These are passed as part of the `$opts` map, as so:
 
 ```scss
-@include oBanner($opts: (
-	'themes': ('small'),
-	'layouts': ('compact'),
-))
+@include oBanner(
+	$opts: (
+		'themes': (
+			'small',
+		),
+		'layouts': (
+			'compact',
+		),
+	)
+);
 ```
 
 The `themes` option used to take a map or the word 'all', but as 'all' is the default, one can get that effect by not specifying anything.
 
 ```scss
-@include oBanner()
+@include oBanner();
 ```
 
 All other mixins have been removed, you'll need to update your code to use the documented `o-banner` classes.
@@ -68,6 +91,7 @@ All other mixins have been removed, you'll need to update your code to use the d
 #### Colour Usecases
 
 The following colour usecases have been removed. Please contact the Origami team if your project relied on these:
+
 - o-banner
 - o-banner-button
 - o-banner-button-active
@@ -86,7 +110,6 @@ The following colour usecases have been removed. Please contact the Origami team
 - o-banner-product-link
 - o-banner-product-close
 - o-banner-product-heading-rule
-
 
 ## Migrating from v1 to v2
 

--- a/components/o-banner/README.md
+++ b/components/o-banner/README.md
@@ -31,10 +31,12 @@ This HTML demonstrates the declarative way to instantiate o-banner. If you are u
 <div class="o-banner" data-o-component="o-banner">
 	<div class="o-banner__outer">
 		<div class="o-banner__inner" data-o-banner-inner="">
-
 			<!-- Content to display on larger screens -->
 			<div class="o-banner__content o-banner__content--long">
-				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+				<p>
+					Try the new compact homepage. A list view of today's homepage with
+					fewer images.
+				</p>
 			</div>
 
 			<!-- Content to display on smaller screens -->
@@ -51,7 +53,6 @@ This HTML demonstrates the declarative way to instantiate o-banner. If you are u
 					<a href="#" class="o-banner__link">Give feedback</a>
 				</div>
 			</div>
-
 		</div>
 	</div>
 </div>
@@ -64,7 +65,10 @@ Variable content based on screen size as well as the link after the button are o
 	<div class="o-banner__outer">
 		<div class="o-banner__inner" data-o-banner-inner="">
 			<div class="o-banner__content">
-				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+				<p>
+					Try the new compact homepage. A list view of today's homepage with
+					fewer images.
+				</p>
 			</div>
 			<div class="o-banner__actions">
 				<div class="o-banner__action">
@@ -149,12 +153,13 @@ If you wish to create a banner from scratch with no existing DOM elements, you c
 ```js
 import Banner from '@financial-times/o-banner';
 const myBanner = new Banner(null, {
-	contentLong: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+	contentLong:
+		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	contentShort: 'Try the new compact homepage.',
 	buttonLabel: 'Try it now',
 	buttonUrl: '#try-button',
 	linkLabel: 'Give feedback',
-	linkUrl: '#feedback-link'
+	linkUrl: '#feedback-link',
 });
 ```
 
@@ -192,7 +197,7 @@ There are several options used to change the appearance or behaviour of o-banner
 
 Include the "primary mixin"`oBanner` to output all `o-banner` styles for all banner variants.
 
-```scss
+````scss
 @import 'o-banner/main';
 
 @include oBanner();```
@@ -204,7 +209,7 @@ To output styles only for the variants of `o-banner` your project uses, the "pri
 	'layouts': ('small', 'compact'),
 	'themes': ('marketing', 'product', 'professional-inverse')
 ));
-```
+````
 
 If you call the mixin without arguments you will get all the built-in themes:
 
@@ -222,16 +227,14 @@ o-banner supports different layouts:
 In the markup, these can be applied as classes alongside the `o-banner` class. They are exposed as modifiers:
 
 ```html
-<div class="o-banner o-banner--small">
-	...
-</div>
+<div class="o-banner o-banner--small">...</div>
 ```
 
 In the JavaScript, use the `layout` [option](#options):
 
 ```js
 const myBanner = new oBanner({
-	layout: 'small'
+	layout: 'small',
 });
 ```
 
@@ -246,16 +249,14 @@ o-banner is themeable which may be used in combination with a [layout](#layouts)
 In the markup, these can be applied as classes alongside the `o-banner` class. They are exposed as modifiers:
 
 ```html
-<div class="o-banner o-banner--marketing">
-	...
-</div>
+<div class="o-banner o-banner--marketing">...</div>
 ```
 
 In the JavaScript, use the `theme` [option](#options):
 
 ```js
 const myBanner = new oBanner({
-	theme: 'marketing'
+	theme: 'marketing',
 });
 ```
 
@@ -264,10 +265,13 @@ const myBanner = new oBanner({
 The `oBannerAddTheme` mixin can be used to create and output styles for a custom banner theme. This allows you to alter colours and backgrounds completely:
 
 ```scss
-@include oBannerAddTheme('bubblegum', (
-	background-color: oColorsMix('candy', 'white', 75),
-	text-color: oColorsByName('oxford-90')
-));
+@include oBannerAddTheme(
+	'bubblegum',
+	(
+		background-color: oColorsMix('candy', 'white', 75),
+		text-color: oColorsByName('oxford-90'),
+	)
+);
 ```
 
 The above Sass will output CSS like this:
@@ -281,9 +285,7 @@ The above Sass will output CSS like this:
 You can add this new class to your banner element, either in the HTML:
 
 ```html
-<div class="o-banner o-banner--bubblegum">
-	...
-</div>
+<div class="o-banner o-banner--bubblegum">...</div>
 ```
 
 or via the `theme` option in JavaScript:
@@ -300,34 +302,34 @@ const myBanner = new Banner(null, {
 You can change a lot of aspects of a banner's visual appearance. When using the `oBannerAddTheme` mixin, you can specify the following properties:
 
 | Property                  | Required? | Type      | Description                                                                                                                                                                                |
-|---------------------------|-----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `background-color`        | Yes       | Colour*   | Sets the banner background colour                                                                                                                                                          |
-| `text-color`              | Yes       | Colour*   | Sets the banner's text colour                                                                                                                                                              |
+| ------------------------- | --------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `background-color`        | Yes       | Colour\*  | Sets the banner background colour                                                                                                                                                          |
+| `text-color`              | Yes       | Colour\*  | Sets the banner's text colour                                                                                                                                                              |
 | `background-image`        | No        | String    | Sets the banner background image, this should be a URL. Defaults to no background                                                                                                          |
 | `background-position`     | No        | CSS value | Sets the banner background position, this can be any valid [`background-position` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position). Defaults to `bottom right` |
 | `background-repeat`       | No        | CSS Value | Sets the banner background repeat, this can be any valid [`background-repeat` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat). Defaults to `no-repeat`          |
-| `button-background-color` | No        | Colour*   | Sets the banner's primary action button colour. Defaults to the value of the `text-color` property                                                                                         |
-| `button-type`             | No        | String        | Sets the banner's button type, this can be either `primary` or `secondary`. Defaults to `primary`                                                                                      |
-| `heading-rule-color`      | No        | Colour*   | Sets the banner's heading rule colour, the line that appears below the heading. Defaults to the value of the `text-color` property                                                         |
-| `link-text-color`         | No        | Colour*   | Sets the banner's link text colour, both in the banner content and the secondary action. Defaults to the value of the `text-color` property                                                |
+| `button-background-color` | No        | Colour\*  | Sets the banner's primary action button colour. Defaults to the value of the `text-color` property                                                                                         |
+| `button-type`             | No        | String    | Sets the banner's button type, this can be either `primary` or `secondary`. Defaults to `primary`                                                                                          |
+| `heading-rule-color`      | No        | Colour\*  | Sets the banner's heading rule colour, the line that appears below the heading. Defaults to the value of the `text-color` property                                                         |
+| `link-text-color`         | No        | Colour\*  | Sets the banner's link text colour, both in the banner content and the secondary action. Defaults to the value of the `text-color` property                                                |
 
 \* When a type of Colour is required, please specify a colour value and not an o-colors name. If you with to use an o-colors colour, then you can pass in `oColorsByName('<NAME>')`, replacing `<NAME>` with your desired color.
 
-
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.4 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.3 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.7 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.5         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.4         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.7         |                          N/A                          |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-banner/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-comments/MIGRATION.md
+++ b/components/o-comments/MIGRATION.md
@@ -1,9 +1,28 @@
 ## Migration
 
+### Migrating from v11 to v12
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v10 to v11
+
 To migrate you need to have a page that will display the illegal comments report form, existing on an available path e.g. https://github.com/Financial-Times/next-article/commit/3dca12c19ee223f654d11cf74ad8d545e1bad0b7. This defaults to switching `/content/` to `/article/comment-report/` but you can specify your own paths.
 
 ### Migrating from v9 to v10
+
 To migrate you need to have the coral API in version 7 and change the urls to fetch fonts and styles on coral API admin to fetch styles from this version . See more in (documentation)[https://docs.coralproject.net/migrating-6-to-7#after-coral-has-been-updated-to-v7]
 
 ### Migrating from v8 to v9
@@ -29,31 +48,29 @@ Dependencies have all been updated to the latest major versions. If you have any
 
 In version 6 the commenting provider has been updated from Livefyre to [Coral Talk](https://coralproject.net/talk/) and as a result version 6 is a complete rewrite.
 
-
 #### Event naming
 
 In v6 the naming of events has changed and all events use a dot notation.
 
 The table below shows the mapping of old events to new.
 
-| Old event              | New event                   |
-| ---------------------- | --------------------------- |
-| error.init             | Not mapped yet              |
-| error.widget           | Not mapped yet              |
-| error.livefyreJs       | Deprecated                  |
-| data.init              | Not mapped yet              |
-| data.auth              | Not mapped yet              |
-| widget.timeout         | Not mapped yet              |
-| widget.ready           | Deprecation candidate       |
-| widget.load            | Deprecation candidate       |
-| widget.renderComplete  | oComments.ready             |
-| tracking.postComment   | oComments.postComment       |
-| tracking.likeComment   | ocomments.likeComment       |
-| tracking.shareComment  | Deprecation candidate       |
-| tracking.socialMention | Deprecated                  |
-| auth.login             | Not mapped yet              |
-| auth.loginRequired     | Not mapped yet              |
-
+| Old event              | New event             |
+| ---------------------- | --------------------- |
+| error.init             | Not mapped yet        |
+| error.widget           | Not mapped yet        |
+| error.livefyreJs       | Deprecated            |
+| data.init              | Not mapped yet        |
+| data.auth              | Not mapped yet        |
+| widget.timeout         | Not mapped yet        |
+| widget.ready           | Deprecation candidate |
+| widget.load            | Deprecation candidate |
+| widget.renderComplete  | oComments.ready       |
+| tracking.postComment   | oComments.postComment |
+| tracking.likeComment   | ocomments.likeComment |
+| tracking.shareComment  | Deprecation candidate |
+| tracking.socialMention | Deprecated            |
+| auth.login             | Not mapped yet        |
+| auth.loginRequired     | Not mapped yet        |
 
 ### Migrating from v4 to v5
 

--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -5,15 +5,15 @@ A component, integrated with FT authentication and [Coral Talk](https://coralpro
 - [Usage](#usage)
 - [Additional dependencies](#additional-dependencies)
 - [Markup](#markup)
-	- [Stream](#stream)
-	- [Count](#count)
-	- [Use staging environment](#use-staging-environment)
-	- [Pass a display name into Coral Talk](#pass-a-display-name-into-coral-talk)
+  - [Stream](#stream)
+  - [Count](#count)
+  - [Use staging environment](#use-staging-environment)
+  - [Pass a display name into Coral Talk](#pass-a-display-name-into-coral-talk)
 - [JavaScript](#javascript)
-	- [Constructing an o-comments](#constructing-an-o-comments)
-	- [Firing an oDomContentLoaded event](#firing-an-odomcontentloaded-event)
-	- [Events](#events)
-	- [Tracking](#tracking)
+  - [Constructing an o-comments](#constructing-an-o-comments)
+  - [Firing an oDomContentLoaded event](#firing-an-odomcontentloaded-event)
+  - [Events](#events)
+  - [Tracking](#tracking)
 - [Sass](#sass)
 - [Migration](#migration)
 - [Contact](#contact)
@@ -38,13 +38,15 @@ These elements will be initialized automatically on the `o.DOMContentReady` even
 Use the following markup to enable a comment stream:
 
 ```html
-<div class="o-comments"
+<div
+	class="o-comments"
 	id="{element-id}"
 	data-o-component="o-comments"
 	data-o-comments-article-id="{article-id}"
-	data-o-comments-article-url="{optional-article-url}">
-</div>
+	data-o-comments-article-url="{optional-article-url}"
+></div>
 ```
+
 Coral needs a parent element id when initialising the comment stream embed script.
 
 ### Redirection for illegal comment reporting
@@ -53,7 +55,7 @@ Within Coral, when a user clicks on the link to report an illegal comment, Coral
 
 The paywall report path defaults to `/content/`, the redirect report path defaults to `/article/comment-report/`. If you need either of these to be different paths, you can add either or both of the following attributes to change them to your paths.
 
-```diff
+````diff
 <div class="o-comments"
 	id="{element-id}"
 	data-o-component="o-comments"
@@ -74,7 +76,7 @@ Add the following attribute to the markup to enable a comment count:
 	data-o-comments-article-id="{article-id}"
 +	data-o-comments-count="true">
 </div>
-```
+````
 
 The comment count is rendered when the `data-o-comments-count` attribute value is `true`.
 
@@ -83,8 +85,7 @@ The comment count is rendered when the `data-o-comments-count` attribute value i
 If you need the count as a value, use the `getCount` method which returns an integer.
 
 ```js
-Comments.getCount('article-id')
-	.then(count => console.log(count));
+Comments.getCount("article-id").then(count => console.log(count));
 ```
 
 ### Use staging environment
@@ -92,6 +93,7 @@ Comments.getCount('article-id')
 Add the following attribute to the markup to use Coral staging environment:
 
 For stream:
+
 ```diff
 <div class="o-comments"
 	id="o-comments-stream"
@@ -103,6 +105,7 @@ For stream:
 ```
 
 For count:
+
 ```diff
 <div class="o-comments"
 	data-o-component="o-comments"
@@ -135,12 +138,12 @@ No code will run automatically unless you are using the [Build Service](https://
 Assuming you have an HTML element on the page to represent your comment stream or count:
 
 ```js
-import oComments from '@financial-times/o-comments';
-const commentsElement = document.querySelector('#element');
+import oComments from "@financial-times/o-comments";
+const commentsElement = document.querySelector("#element");
 const Comments = new oComments(commentsElement, {
-	articleId: 'article-id',
-	articleUrl: 'optional-article-url'
-})
+	articleId: "article-id",
+	articleUrl: "optional-article-url",
+});
 ```
 
 Add `useStagingEnvironment: true` to the options if you want to use Coral staging environment.
@@ -148,12 +151,15 @@ Add `useStagingEnvironment: true` to the options if you want to use Coral stagin
 If you want to initialise every comment stream or count element on the page (based on the presence of the attribute: `data-o-component="o-comments"`):
 
 ```js
-import oComments from '@financial-times/o-comments';
+import oComments from "@financial-times/o-comments";
 oComments.init();
 ```
+
 ### Options
+
 These are the available options we can pass to oComments:
-- articleId 
+
+- articleId
 - articleUrl
 - displayName
 - commentsAuthUrl
@@ -167,10 +173,10 @@ These are the available options we can pass to oComments:
 ### Firing an oDomContentLoaded event
 
 ```js
-import '@financial-times/o-comments';
+import "@financial-times/o-comments";
 
-document.addEventListener('DOMContentLoaded', function() {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+document.addEventListener("DOMContentLoaded", function () {
+	document.dispatchEvent(new CustomEvent("o.DOMContentLoaded"));
 });
 ```
 
@@ -179,8 +185,8 @@ document.addEventListener('DOMContentLoaded', function() {
 Events are emitted during key events or interactions and can be listened to by listening for events on the document.
 
 ```js
-document.addEventListener('oComments.ready', (event) => {
-	console.log('This comments have rendered');
+document.addEventListener("oComments.ready", event => {
+	console.log("This comments have rendered");
 });
 ```
 
@@ -211,11 +217,12 @@ To keep tracking consistent across applications o-comments will emit [o-tracking
 If you want to disable the o-tracking events and manage tracking / analytics yourself this can be done by passing the `disableOTracking` option to the o-comments instance.
 
 **Imperatively**
+
 ```js
-import oComments from '@financial-times/o-comments';
-const commentsElement = document.querySelector('#element');
+import oComments from "@financial-times/o-comments";
+const commentsElement = document.querySelector("#element");
 const comments = new Comments(commentsElement, {
-	disableOTracking: true
+	disableOTracking: true,
 });
 ```
 
@@ -231,14 +238,16 @@ const comments = new Comments(commentsElement, {
 </div>
 ```
 
-
-
 ## Sass
 
 Include all styles for o-comments with the mixin `oComments`. Set the `coral-talk-iframe` option to `false`:
 
 ```scss
-@include oComments($opts: ('coral-talk-iframe': false));
+@include oComments(
+	$opts: (
+		"coral-talk-iframe": false,
+	)
+);
 ```
 
 The `coral-talk-iframe` option is set to false as these styles are included in the Coral Talk iframe, via the [Origami Build Service](https://www.ft.com/__origami/service/build/), and do not need to be included directly within projects themselves.
@@ -247,22 +256,22 @@ The `coral-talk-iframe` option is set to false as these styles are included in t
 
 This component contains a sass file (/src/scss/coral-talk-iframe/main.scss) that provides custom styling for Coral Talk components inside their own iframe. That file is included in the Coral Talk admin panel by including o-comments using an [Origami Build Service](https://www.ft.com/__origami/service/build/) request.
 
-
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 11 | N/A | [migrate to v11](MIGRATION.md#migrating-from-v10-to-v11) |
-⚠ maintained | 10 | N/A | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
-⚠ maintained | 9 | N/A | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-╳ deprecated | 8 | 8.3.3 | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
-╳ deprecated | 7 | 7.7 | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-╳ deprecated | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-╳ deprecated | 5 | 5.0.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated | 4 | 4.2.0 | - |
-╳ deprecated | 3 | 3.5.0 | - |
-╳ deprecated | 2 | 2.5.0 | - |
-╳ deprecated | 1 | 1.0.10 | - |
+|    State     | Major Version | Last Minor Release |                     Migration guide                      |
+| :----------: | :-----------: | :----------------: | :------------------------------------------------------: |
+| ⚠ maintained |      12       |        N/A         | [migrate to v12](MIGRATION.md#migrating-from-v11-to-v12) |
+| ╳ deprecated |      11       |        11.2        | [migrate to v11](MIGRATION.md#migrating-from-v10-to-v11) |
+| ╳ deprecated |      10       |        N/A         | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10)  |
+| ╳ deprecated |       9       |        N/A         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)   |
+| ╳ deprecated |       8       |       8.3.3        |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)   |
+| ╳ deprecated |       7       |        7.7         |  [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7)   |
+| ╳ deprecated |       6       |        N/A         |  [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6)   |
+| ╳ deprecated |       5       |       5.0.1        |  [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5)   |
+| ╳ deprecated |       4       |       4.2.0        |                            -                             |
+| ╳ deprecated |       3       |       3.5.0        |                            -                             |
+| ╳ deprecated |       2       |       2.5.0        |                            -                             |
+| ╳ deprecated |       1       |       1.0.10       |                            -                             |
 
 ## Contact
 

--- a/components/o-cookie-message/MIGRATION.md
+++ b/components/o-cookie-message/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v5 to v6
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -42,13 +59,14 @@ To get both themes:
 The privacy policy cookie message was a temporary feature whose time is up. It
 has been completely removed in this version. If you still needed that, [contact origami](mailto:origami.support@ft.com)
 
-
 ## Migrating from v3 to v4
+
 The 4.0.0 release changes the way cookies are set for FT products. It relies on an [internal consent API](https://github.com/Financial-Times/next-consent-proxy/), and `o-cookie-message` will make a call to an endpoint within the API when consent is given.
 
 It no longer has a direct dependency on any component other than `o-banner`, which is now responsible for the construction of the cookie message.
 
 The markup has changed for the banner. When using o-cookie-message imperatively, the correct markup is:
+
 ```diff
 -<div data-o-component="o-cookie-message" class='o-cookie-message o-cookie-message--banner-centric'>
 +<div data-o-component="o-cookie-message">
@@ -56,6 +74,7 @@ The markup has changed for the banner. When using o-cookie-message imperatively,
 ```
 
 o-cookie-message events have changed to:
+
 ```diff
 -oCookieMessage.ready
 +oCookieMessage.view
@@ -63,9 +82,11 @@ o-cookie-message events have changed to:
 +oCookieMessage.act
 +oCookieMessage.close
 ```
+
 When using custom HTML, declaring `data-o-cookie-message-use-custom-html="true"` is no longer necessary.
 
 ## Migrating from v2 to v3
+
 The 3.0.0 introduces the new majors of o-colors and o-typography and a new dependency on o-normalise. Updating to this new version will mean updating any other components that you have which are using o-colors or o-typography.
 There are some design tweaks but no other breaking changes in this release.
 
@@ -89,8 +110,10 @@ The 2.0.0 release changes the default behaviour of o-cookie-message. Instead of 
 What you need now is:
 
 ```html
-<div data-o-component="o-cookie-message" class='o-cookie-message o-cookie-message--banner-centric'>
-</div>
+<div
+	data-o-component="o-cookie-message"
+	class="o-cookie-message o-cookie-message--banner-centric"
+></div>
 ```
 
 If you do not want to use the FT legal team approved cookie message (for example if you aren't running an FT site), you can opt out of it by setting the `data-o-cookie-message-use-custom-html` attribute to `"true"`. All FT sites **must** use this cookie message unless otherwise cleared by the FT's legal team.

--- a/components/o-cookie-message/README.md
+++ b/components/o-cookie-message/README.md
@@ -196,8 +196,9 @@ Include the [`alternative` cookie message theme](https://registry.origami.ft.com
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ⚠ maintained |       5       |        5.1         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.7         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.1         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 | ╳ deprecated |       4       |        4.7         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 | ╳ deprecated |       3       |        3.3         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 | ╳ deprecated |       2       |        2.2         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |

--- a/components/o-date/MIGRATION.md
+++ b/components/o-date/MIGRATION.md
@@ -1,14 +1,14 @@
 # Migration Guide
 
-### Migrating from v5 to v6
+## Migrating from v5 to v6
 
-We have introduced a `t` format symbol that renders a full ft-style time 10:43pm for the time. 
+We have introduced a `t` format symbol that renders a full ft-style time 10:43pm for the time.
 
-Custom formats which use the string 't' will no longer render as a string literal "t". 
+Custom formats which use the string 't' will no longer render as a string literal "t".
 
-To add the literal 't' update the custom date format string from `t` to `\t`. 
+To add the literal 't' update the custom date format string from `t` to `\t`.
 
-**Before** 
+**Before**
 
 ```
 <time data-o-component="o-date" class="o-date" datetime="Tue Mar 21 2023 10:38:05 GMT+0000 (Greenwich Mean Time)" data-o-date-format="d MMM yyyy, t" title="March 21 2023 10:38 am" data-o-date-js="">21 Mar 2023, t</time>

--- a/components/o-editorial-layout/MIGRATION.md
+++ b/components/o-editorial-layout/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v2 to v3
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v2 to v3
 

--- a/components/o-editorial-layout/README.md
+++ b/components/o-editorial-layout/README.md
@@ -113,7 +113,7 @@ See the [o-editorial-layout Sassdoc](https://registry.origami.ft.com/components/
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ⚠ maintained |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 | ╳ deprecated |       2       |        2.4         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 | ╳ deprecated |       1       |        1.4         |                          N/A                          |
 

--- a/components/o-expander/MIGRATION.md
+++ b/components/o-expander/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v5 to v6
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -31,6 +48,7 @@ The Sass mixins `oExpanderToggle` and `oExpanderContent` have been removed. Inst
 ### JavaScript
 
 The following functions are removed or now private, ensure your project doesn't call them:
+
 - `toggleExpander` and `displayState`: use `toggle`, `collapse`, or `expand` methods instead.
 - `ariaToggles`
 - `configure`

--- a/components/o-expander/README.md
+++ b/components/o-expander/README.md
@@ -6,9 +6,9 @@ Accessible, content-aware component for expanding and collapsing content.
 - [Markup](#markup)
 - [Sass](#sass)
 - [JavaScript](#javascript)
-	- [Construction](#construction)
-	- [Custom expander](#custom-expander)
-	- [Events](#events)
+  - [Construction](#construction)
+  - [Custom expander](#custom-expander)
+  - [Events](#events)
 - [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -19,7 +19,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 
 ## Markup
 
-The  `o-expander` component has a content element `o-expander__content` (the DOM to expand and collapse) and toggle elements `o-expander__toggle` (the triggers to toggle the expander).
+The `o-expander` component has a content element `o-expander__content` (the DOM to expand and collapse) and toggle elements `o-expander__toggle` (the triggers to toggle the expander).
 
 - `o-expander__toggle` and `o-expander__content` can be put anywhere within `o-expander` as long as `o-expander__toggle` is not contained within `o-expander__content`.
 - `o-expander__toggle` should be placed on a button or anchor element for keyboard accessibility.
@@ -32,7 +32,9 @@ The  `o-expander` component has a content element `o-expander__content` (the DOM
 	</div>
 	<button class="o-expander__toggle">
 		Toggle
-		<span class="o-expander__visually-hidden">(content will be added above button)</span>
+		<span class="o-expander__visually-hidden"
+			>(content will be added above button)</span
+		>
 	</button>
 </div>
 ```
@@ -196,16 +198,15 @@ Set `data-o-expander-toggle-state="aria"` to update the toggle aria attributes b
 
 ## Sass
 
-
 Default expander styles hide the toggle until the expander is initialised successfully, so no content is obscured if JavaScript fails. When toggled the expander hides and shows content immediately. To include all `o-expander` CSS use the `oExpander` mixin.
 
 ```scss
-	@include oExpander();
+@include oExpander();
 ```
+
 If using the height expander, also set your `max-height`. See [Height Expander](#height-expander) for an example.
 
 _For animation and other more complex styles don't include opinionated o-expander CSS. Instead create a [custom expander](#custom-expander) with totally custom styles._
-
 
 ## JavaScript
 
@@ -214,12 +215,14 @@ No JavaScript will run automatically unless you are using the Build Service. You
 ### Construction
 
 If you have set up your expander declaratively, use the following to initialise all expanders on the page with the `data-o-component="o-expander"` attribute:
+
 ```js
 import Expander from '@financial-times/o-expander';
 Expander.init();
 ```
 
 Or initialise a specific declarative expander:
+
 ```js
 import Expander from '@financial-times/o-expander';
 const myExpanderElement = document.querySelector('my-expander');
@@ -227,12 +230,13 @@ const myExpander = new Expander(myExpanderElement);
 ```
 
 All declarative options set via [Markup](#markup) may also be passed as an `opts` object. See the [options section](#options) for a full list. e.g:
+
 ```js
 import Expander from '@financial-times/o-expander';
 const myExpanderElement = document.querySelector('my-expander');
 const myExpander = new Expander(myExpanderElement, {
 	shrinkTo: 4,
-	itemSelecor: 'p'
+	itemSelecor: 'p',
 });
 ```
 
@@ -241,7 +245,7 @@ const myExpander = new Expander(myExpanderElement, {
 All the following can be passed to JavaScript or may be set declaratively via [Markup](#markup) as data-attributes (hyphenated and prefixed by `o-expander` e.g. `data-o-expander-shrink-to="height"`):
 
 - `shrinkTo` `[height]`: The expander collapse method, "height", "hidden", or a number of items.
-- `itemSelector` `[li]`: A selector for items to count when  `shrinkTo` is set to a number, relative to `.o-expander__content`.
+- `itemSelector` `[li]`: A selector for items to count when `shrinkTo` is set to a number, relative to `.o-expander__content`.
 - `expandedToggleText` `[less|fewer]`: Toggle text for when the expander is collapsed. Defaults to "fewer", or "less" when `shrinkTo` is "height", or "hidden" when `shrinkTo` is "hidden".
 - `collapsedToggleText` `[more]`: Toggle text for when the expander is collapsed. Defaults to "more", or "show" when `shrinkTo` is "hidden".
 - `toggleState` `[all|aria|none]`: How to update the expander toggles: "all" to update text and aria-expanded attributes, "aria" to update only aria-expanded attributes, "none" to avoid updating toggles on click.
@@ -267,8 +271,8 @@ const myCustomExpander = Expander.createCustom(myExpanderElement, {
 		inactive: 'my-expander--inactive', // Added to the expander element if the expander doesn't need to contract/expand.
 		expanded: 'my-expander__content--expanded', // Added to the content element when expanded.
 		collapsed: 'my-expander__content--collapsed', // Added to the content element when collapsed.
-		collapsibleItem: 'my-expander__collapsible-item' // Added to item elements which are hidden when collapsed.
-	}
+		collapsibleItem: 'my-expander__collapsible-item', // Added to item elements which are hidden when collapsed.
+	},
 });
 ```
 
@@ -284,20 +288,21 @@ o-expander fires the following events, which always fire before any repainting/l
 
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 6 | N/A  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-⚠ maintained | 5 | 5.0.11  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated | 4 | 4.7  | - |
-╳ deprecated | 3 | 3.0  | - |
-╳ deprecated | 2 | 2.0 | - |
-╳ deprecated | 1 | 1.4 | - |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.3         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.0         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.7         |                           -                           |
+| ╳ deprecated |       3       |        3.0         |                           -                           |
+| ╳ deprecated |       2       |        2.0         |                           -                           |
+| ╳ deprecated |       1       |        1.4         |                           -                           |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-expander/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-footer-services/MIGRATION.md
+++ b/components/o-footer-services/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ### Migrating from v3 to v4
 
@@ -23,6 +40,7 @@ All mixins have been replaced with `oFooterServices`, except `oFooterServicesLin
 Multiple `o-footer-services` mixin calls should be replaced with one call to `oFooterServices` with the options required by your project.
 
 - `oFooterServicesBase` may be replaced by setting the `oFooterServices` `$opts` argument with the icons your footer uses as links:
+
 ```diff
 - @include oFooterServicesBase();
 + @include oFooterServices($opts: (
@@ -31,6 +49,7 @@ Multiple `o-footer-services` mixin calls should be replaced with one call to `oF
 ```
 
 - `oFooterServicesWithLogo` has been removed. Instead pass a `logo` option to `oFooterServices`, which includes the image set `ftlogo-v1` to get the logo from (also specify the icons your footer uses as links):
+
 ```diff
 - @include oFooterServicesWithLogo($logo: 'origami');
 + @include oFooterServices($opts: (
@@ -40,6 +59,7 @@ Multiple `o-footer-services` mixin calls should be replaced with one call to `oF
 ```
 
 - `oFooterServicesIcons` has been removed. Instead add to the `oFooterServices` `icons` option and update your markup to use the `o-footer-services` class (`o-footer-services__icon-link--[icon-name]`):
+
 ```diff
 - .my-custom-share-icon-link {
 -     @include oFooterServicesIcons('share');
@@ -49,6 +69,7 @@ Multiple `o-footer-services` mixin calls should be replaced with one call to `oF
 + 	'icons': ('slack', 'github','share')
 + ));
 ```
+
 ```diff
 - <a class="o-footer-services__icon-link my-custom-share-icon-link" href="#">share</a>
 + <a class="o-footer-services__icon-link o-footer-services__icon-link--share" href="#">share</a>

--- a/components/o-footer-services/README.md
+++ b/components/o-footer-services/README.md
@@ -63,40 +63,55 @@ To output all `o-footer-services` CSS call `oFooterServices()`.
 @include oFooterServices();
 ```
 
-To keep your CSS bundle size small, include  `o-footer-services` features granularly using the `opts` argument.
+To keep your CSS bundle size small, include `o-footer-services` features granularly using the `opts` argument.
 E.g. to output styles for the dark theme with a project logo, but without the default icon link to Github:
 
 ```scss
-@include oFooterServices($opts: (
-	'logo': 'ftlogo-v1:origami',
-	'icons': ('slack'),
-	'themes': ('dark'),
-));
+@include oFooterServices(
+	$opts: (
+		'logo': 'ftlogo-v1:origami',
+		'icons': (
+			'slack',
+		),
+		'themes': (
+			'dark',
+		),
+	)
+);
 ```
+
 All options include:
 
-| Option      | Description                                                                                                                                               | Brand support                |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
-| logo        | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).           | core, internal, whitelabel |
-| icons       | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`.         | core, internal, whitelabel |
-| brand-strip | Whether to include styles for the brand strip at the bottom of the footer, "a Nikkei company".                                                            | core, internal, whitelabel |
-| themes      | A list of themes to include. Currently the only theme is `dark`, which is only supported by the core brand.                                             | core                       |
-
+| Option      | Description                                                                                                                                       | Brand support              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| logo        | A logo from the [image service](https://github.com/Financial-Times/origami-image-service.) to include in the footer (e.g. `ftlogo-v1:origami`).   | core, internal, whitelabel |
+| icons       | A list of [social share](https://registry.origami.ft.com/components/social-images) icons to include links for, defaults to '('slack', 'github')`. | core, internal, whitelabel |
+| brand-strip | Whether to include styles for the brand strip at the bottom of the footer, "a Nikkei company".                                                    | core, internal, whitelabel |
+| themes      | A list of themes to include. Currently the only theme is `dark`, which is only supported by the core brand.                                       | core                       |
 
 Your project should call `oFooterServices` once, and add to the `opts` argument when new features are needed. However, if `oFooterServices` is called multiple times, for example for code splitting across multiple bundles, the `$include-base-styles` argument may be set to `false` to omit fundamental base styles required by all options.
+
 ```scss
 // Output o-footer-services with no icons.
-@include oFooterServices($opts: (
-	'logo': 'ftlogo-v1:origami',
-	'icons': ()
-));
+@include oFooterServices(
+	$opts: (
+		'logo': 'ftlogo-v1:origami',
+		'icons': (),
+	)
+);
 
 // Include o-footer-services icons separately,
 // without repeating base styles output above.
 // This is *not* recommended.
-@include oFooterServices($opts: (
-	'icons': ('slack', 'github')
-), $include-base-styles: false);
+@include oFooterServices(
+	$opts: (
+		'icons': (
+			'slack',
+			'github',
+		),
+	),
+	$include-base-styles: false
+);
 ```
 
 ### Customisation
@@ -108,25 +123,30 @@ $o-brand: whitelabel;
 @import '@financial-times/o-footer-services/main';
 
 // Customise o-footer-services colours
-@include oFooterServicesCustomize((
-	'text-color': rgb(73, 0, 39),
-	'background-color': rgb(251, 238, 240),
-	'border-color': hotpink,
-	'link-color': rgb(156, 4, 85),
-	'link-hover-color': rgb(156, 4, 85),
-	'legal-text-color': rgb(214, 73, 148),
-	'brand-background-color': oColorsByName('black'),
-	'brand-foreground-color': oColorsByName('white'),
-));
+@include oFooterServicesCustomize(
+	(
+		'text-color': rgb(73, 0, 39),
+		'background-color': rgb(251, 238, 240),
+		'border-color': hotpink,
+		'link-color': rgb(156, 4, 85),
+		'link-hover-color': rgb(156, 4, 85),
+		'legal-text-color': rgb(214, 73, 148),
+		'brand-background-color': oColorsByName('black'),
+		'brand-foreground-color': oColorsByName('white'),
+	)
+);
 
 // Output o-footer-services css
-@include oFooterServices($opts: (
-	'logo': 'ftlogo-v1:origami',
-	'icons': ()
-));
+@include oFooterServices(
+	$opts: (
+		'logo': 'ftlogo-v1:origami',
+		'icons': (),
+	)
+);
 ```
 
 Available brand variables include:
+
 - `text-color`: The default text colour.
 - `background-color`: The background colour.
 - `border-color`: The border colour used around and within the footer.
@@ -136,23 +156,23 @@ Available brand variables include:
 - `brand-background-color`: The background colour of the brand strip, at the bottom of the footer, "a Nikkei company".
 - `brand-foreground-color`: The foreground colour for the logo in the brand strip, at the bottom of the footer, "a Nikkei company".
 
-
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.0.2 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |         -          | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |       2.2.0        | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |       1.0.2        |                           -                           |
 
-***
+---
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-footer-services/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-footer/MIGRATION.md
+++ b/components/o-footer/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v9 to v10
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v8 to v9
 
 Markup has been updated to support 2 extra columns of links, one for Community Events and another for "More from the FT Group". All nav items are now behind a dropdown on mobile devices.
@@ -7,13 +24,16 @@ Markup has been updated to support 2 extra columns of links, one for Community E
 Update `o-footer` markup in your project according to the README and component demos. The changes are as follows:
 
 1. Each `o-footer__matrix-link` element must now include a child element `o-footer__matrix-link__copy`.
+
 ```diff
 <a class="o-footer__matrix-link" href="#">
 +        <span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
 -        <!-- link 1 -->
 </a>
 ```
-2. The markup for the "More from the FT Group" link has changed. It has been moved inside the `nav` element alongside other links, within  it's matrix group. Unlike other matrix title elements there is an extra class `o-footer__matrix-title--link`, to indicate the title contains a link. The link itself also has an extra class `o-footer__matrix-link--more`, which applies the right arrow, etc. Note in the diff below some classes such as `o-footer__more-from-ft` are deleted.
+
+2. The markup for the "More from the FT Group" link has changed. It has been moved inside the `nav` element alongside other links, within it's matrix group. Unlike other matrix title elements there is an extra class `o-footer__matrix-title--link`, to indicate the title contains a link. The link itself also has an extra class `o-footer__matrix-link--more`, which applies the right arrow, etc. Note in the diff below some classes such as `o-footer__more-from-ft` are deleted.
+
 ```diff
 <!-- ... more o-footer markup ...  -->
 <nav>
@@ -58,6 +78,7 @@ Origami components now require a `$system-code` variable is set by the project, 
 The mixin `oFooter` has been updated. By default it now outputs all o-footer styles. To upgrade explicitly include the styles your project needs using the options `$opts` map:
 
 `oFooter` previously included the complex "matrix" navigation structure with dark theme by default:
+
 ```diff
 -@include oFooter;
 +@include oFooter($opts: (
@@ -67,6 +88,7 @@ The mixin `oFooter` has been updated. By default it now outputs all o-footer sty
 ```
 
 Instead of setting `$theme` update the `theme` key in the options map:
+
 ```diff
 -@include oFooter($theme: 'light');
 +@include oFooter($opts: (
@@ -76,6 +98,7 @@ Instead of setting `$theme` update the `theme` key in the options map:
 ```
 
 Instead of turning off output for the matrix of links by setting `$simple: true`, do not set the `matrix` option:
+
 ```diff
 - @include oFooter($simple: true);
 +@include oFooter($opts: (
@@ -84,6 +107,7 @@ Instead of turning off output for the matrix of links by setting `$simple: true`
 ```
 
 To remove the default margin set the `margin` option to false (alternatively set the top margin value):
+
 ```diff
 - @include oFooter($margin: false);
 +@include oFooter($opts: (
@@ -91,17 +115,9 @@ To remove the default margin set the `margin` option to false (alternatively set
 +));
 ```
 
-The following Sass mixins have been removed and must not be used. Instead use the `oFooter` mixin with related options:
-    - `oFooterBrandImage`
-    - `oFooterMatrix`
-    - `oFooterThemeDark`
-    - `oFooterThemeLight`
+The following Sass mixins have been removed and must not be used. Instead use the `oFooter` mixin with related options: - `oFooterBrandImage` - `oFooterMatrix` - `oFooterThemeDark` - `oFooterThemeLight`
 
-The following Sass variables have been removed without a direct replacement. Please contact the Origami team if your project relies on these:
-    - `$o-footer-image-base-url`
-    - `$o-footer-image-service-version`
-    - `$o-footer-matrix`
-    - `$o-footer-spacing-unit`
+The following Sass variables have been removed without a direct replacement. Please contact the Origami team if your project relies on these: - `$o-footer-image-base-url` - `$o-footer-image-service-version` - `$o-footer-matrix` - `$o-footer-spacing-unit`
 
 All custom o-footer [colours and colour usecases](https://github.com/Financial-Times/o-footer/blob/v6.1.4/src/scss/_colors.scss) have also been removed. Please contact Origami if your project requires these colours.
 
@@ -110,12 +126,11 @@ All custom o-footer [colours and colour usecases](https://github.com/Financial-T
 V5 -> V6 introduces the new majors of o-colors and o-typography. Updating to this new version will mean updating any other components that you have which are using o-colors and o-typography. There are no other breaking changes in this release.
 
 ## Migrating from v4 to v5
+
 Version 5 has significant markup changes compared to version 4. If you want to upgrade, the best option is to look at the demos: [footer](https://github.com/Financial-Times/o-footer/blob/master/demos/src/footer.mustache) and [simple footer](https://github.com/Financial-Times/o-footer/blob/master/demos/src/simple-footer.mustache).
 If you don't want to upgrade, some superficial visual changes have been back-ported to a minor version on 4.x.x.
 
-
 ## Migrating from v3 to v4
-
 
 Note that o-footer v4 relies on o-grid v4.
 

--- a/components/o-footer/README.md
+++ b/components/o-footer/README.md
@@ -21,13 +21,23 @@ _See [o-footer-services](https://registry.origami.ft.com/components/o-footer-ser
 The basic structure of a simple footer has a theme and includes legal links, a copyright notice, and a logo. The demo on the component page does not use real navigation data as it may become out of date. See the [Origami Navigation Service](https://www.ft.com/__origami/service/navigation) to populate `o-footer` markup with real navigation data. The Origami Navigation Service is a JSON API which provides navigation structures for use across FT websites.
 
 ```html
-<footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">
+<footer
+	class="o-footer o-footer--theme-dark"
+	data-o-component="o-footer"
+	data-o-footer--no-js=""
+>
 	<div class="o-footer__container">
 		<div>
 			<ul class="o-footer__legal-links">
-				<li><a href="#"><!-- legal link 1--></a></li>
-				<li><a href="#"><!-- legal link 2--></a></li>
-				<li><a href="#"><!-- legal link 3--></a></li>
+				<li>
+					<a href="#"><!-- legal link 1--></a>
+				</li>
+				<li>
+					<a href="#"><!-- legal link 2--></a>
+				</li>
+				<li>
+					<a href="#"><!-- legal link 3--></a>
+				</li>
 			</ul>
 		</div>
 		<div class="o-footer__copyright">
@@ -62,9 +72,12 @@ A more complex footer with a matrix of links is also supported. Add a row `o-foo
 The width of the columns and the way they collapse on smaller viewports may be controlled by adding a modifier class to each group `o-footer__matrix-group--[NUMBER]`. Where `NUMBER` is the number of columns in a row on desktop (1, 2, 4, or 6).
 
 ```html
-<footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">
+<footer
+	class="o-footer o-footer--theme-dark"
+	data-o-component="o-footer"
+	data-o-footer--no-js=""
+>
 	<div class="o-footer__container">
-
 		<div class="o-footer__row">
 			<nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
@@ -73,12 +86,12 @@ The width of the columns and the way they collapse on smaller viewports may be c
 					</h3>
 					<div class="o-footer__matrix-content" id="o-footer-section-0">
 						<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
-								</a>
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
-								</a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+							</a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
+							</a>
 						</div>
 					</div>
 				</div>
@@ -104,27 +117,31 @@ The width of the columns and the way they collapse on smaller viewports may be c
 						Services
 					</h3>
 					<div class="o-footer__matrix-content" id="o-footer-section-2">
-							<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
-								</a>
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
-								</a>
-							</div>
-							<div class="o-footer__matrix-column">
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 3 --></span>
-								</a>
-								<a class="o-footer__matrix-link" href="#">
-									<span class="o-footer__matrix-link__copy"><!-- link 4 --></span>
-								</a>
-							</div>
+						<div class="o-footer__matrix-column">
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 1 --></span>
+							</a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 2 --></span>
+							</a>
+						</div>
+						<div class="o-footer__matrix-column">
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 3 --></span>
+							</a>
+							<a class="o-footer__matrix-link" href="#">
+								<span class="o-footer__matrix-link__copy"><!-- link 4 --></span>
+							</a>
+						</div>
 					</div>
 				</div>
 				<div class="o-footer__matrix-group o-footer__matrix-group--1">
 					<h3 class="o-footer__matrix-title o-footer__matrix-title--link">
-						<a class ='o-footer__matrix-link o-footer__matrix-link--more' id="o-footer-section-5" href="#">
+						<a
+							class="o-footer__matrix-link o-footer__matrix-link--more"
+							id="o-footer-section-5"
+							href="#"
+						>
 							<span class="o-footer__matrix-link__copy"><!-- link  --></span>
 						</a>
 					</h3>
@@ -164,18 +181,28 @@ To output just the footer styles you need pass an options `$opts` map. The map a
 - `margin`: A [length](https://developer.mozilla.org/en-US/docs/Web/CSS/length) to set a custom top margin for o-footer.
 
 E.g. include only the dark theme for a simple footer of legal links:
+
 ```scss
-@include oFooter($opts: (
-	'themes': ('dark')
-));
+@include oFooter(
+	$opts: (
+		'themes': (
+			'dark',
+		),
+	)
+);
 ```
 
 E.g. include only the dark theme for a complex footer with a matrix of site links:
+
 ```scss
-@include oFooter($opts: (
-	'themes': ('dark'),
-	'matrix': true
-));
+@include oFooter(
+	$opts: (
+		'themes': (
+			'dark',
+		),
+		'matrix': true,
+	)
+);
 ```
 
 ## JavaScript
@@ -194,30 +221,31 @@ const ofooter = new oFooter();
 ### Firing an oDomContentLoaded event
 
 ```js
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
 ```
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 9 | N/A | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-⚠ maintained | 8 | N/A | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
-⚠ maintained | 7 | 7.0.12 | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-╳ deprecated | 6 | 6.1 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-╳ deprecated | 5 | 5.4 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated | 4 | 4.1 | - |
-╳ deprecated | 3 | 3.2 | - |
-╳ deprecated | 2 | 2.0 | - |
-╳ deprecated | 1 | 1.16 | - |
+|    State     | Major Version | Last Minor Release |                     Migration guide                     |
+| :----------: | :-----------: | :----------------: | :-----------------------------------------------------: |
+| ⚠ maintained |      10       |        N/A         | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
+| ╳ deprecated |       9       |        9.2         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)  |
+| ╳ deprecated |       8       |        N/A         |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)  |
+| ╳ deprecated |       7       |       7.0.12       |  [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7)  |
+| ╳ deprecated |       6       |        6.1         |  [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6)  |
+| ╳ deprecated |       5       |        5.4         |  [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5)  |
+| ╳ deprecated |       4       |        4.1         |                            -                            |
+| ╳ deprecated |       3       |        3.2         |                            -                            |
+| ╳ deprecated |       2       |        2.0         |                            -                            |
+| ╳ deprecated |       1       |        1.16        |                            -                            |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-footer/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-forms/MIGRATION.md
+++ b/components/o-forms/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration Guide
 
+### Migrating from v9 to v10
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v8 to v9
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -25,12 +42,12 @@ The dependencies for this component have all been updated to the latest major ve
 If you have any conflicts while installing this version, you'll need to first update
 its dependencies. See [the Bower config for these](./bower.json).
 
-
 ### Migrating from v6 to v7
 
 Version 7 introduces a complete redesign to the `o-forms` markup, Sass and JavaScript API, and makes small design changes and additions.
 
 All Sass mixins have been removed, and have been replaced with two public mixins:
+
 - `oForms()`
 - `oFormsAddCustom()`
 
@@ -55,6 +72,7 @@ The following example would output small text inputs and regular checkboxes:
 ```
 
 The customisation mixin outputs a custom modifier, and can be applied as follows:
+
 ```diff
 -.o-forms__radio-button.o-forms__radio-button--my-theme {
 -	@include oFormsRadioButtonsStyledTheme($theme: $my-theme);
@@ -70,6 +88,7 @@ The customisation mixin outputs a custom modifier, and can be applied as follows
 ```
 
 The markup has been changed entirely to accommodate the following structure:
+
 ```
 ┌— field container (.o-forms-field) —————┐
 |      (one of div or label)             |
@@ -87,38 +106,41 @@ The markup has been changed entirely to accommodate the following structure:
 ```
 
 The root `o-forms` class is no longer used. Instead, there are modifiers for each type of container (field, title, input) illustrated above, and some modifiers that only work for specific inputs:
+
 - Field container modifiers:
-	- `.o-forms-field--optional`
-	- `.o-forms-field--inline`
-	- `.o-forms-field--inverse`
+  - `.o-forms-field--optional`
+  - `.o-forms-field--inline`
+  - `.o-forms-field--inverse`
 - Title container modifiers:
-	- `.o-forms-title`
-	- `.o-forms-title--shrink`
-	- `.o-forms-title--vertical-center`
+  - `.o-forms-title`
+  - `.o-forms-title--shrink`
+  - `.o-forms-title--vertical-center`
 - Input container modifiers:
-	- `.o-forms-input--pseudo-radio-box`
-	- `.o-forms-input--checkbox`
-	- `.o-forms-input--date`
-	- `.o-forms-input--inline`
-	- `.o-forms-input--invalid`
-	- `.o-forms-input--radio-box`
-	- `.o-forms-input--radio-round`
-	- `.o-forms-input--select`
-	- `.o-forms-input--text-area`
-	- `.o-forms-input--password`
-	- `.o-forms-input--text`
-	- `.o-forms-input--toggle`
-	- `.o-forms-input--valid`
+  - `.o-forms-input--pseudo-radio-box`
+  - `.o-forms-input--checkbox`
+  - `.o-forms-input--date`
+  - `.o-forms-input--inline`
+  - `.o-forms-input--invalid`
+  - `.o-forms-input--radio-box`
+  - `.o-forms-input--radio-round`
+  - `.o-forms-input--select`
+  - `.o-forms-input--text-area`
+  - `.o-forms-input--password`
+  - `.o-forms-input--text`
+  - `.o-forms-input--toggle`
+  - `.o-forms-input--valid`
 
 Unlike with the previous `o-forms` class no `max-width` is set, as this was often overridden by projects based on context. Place your form field elements within a containing element or set your own `max-width`.
 
 Note that in some cases the above modifiers must be used to recreate previously default behaviour. The inline input titles now require the `o-forms-title--vertical-center` class to vertically with the input, where the label is short and prompt text has not been provided.
 
 The JavaScript for `o-forms` now accepts two options:
+
 - `useBrowserValidation`: whether to use the browsers validtion and error messages. Defaults to `false`
 - `errorSummary`: whether to display a summary of invalid fields on form submit. Defaults to `true`
 
 ### Migrating from v5 to v6
+
 Version 6 uses a new major version of o-loading. Make sure your project is compatible with o-loading@3.0.0
 
 ### Migrating from v4 to v5
@@ -126,42 +148,48 @@ Version 6 uses a new major version of o-loading. Make sure your project is compa
 Version 5 makes some design improvements including tightening up the spacing around checkboxes and radio buttons. It also provides many [new mixins](#sass) to make it easier to output `o-forms` features granularly.
 
 #### Checkboxes & Radios
+
 - Wrap groups of checkboxes and radios in `.o-forms__group` for correct vertical spacing.
 - `oFormsRadioCheckbox` no longer outputs all styles for checkboxes and radios, only what is shared between them. Use `oFormsRadioCheckboxFeatures` instead.
 - It is no longer possible to modify the complete selector of radios, checkboxes, or their labels. The base `.o-forms` class may still be updated using the `$class` argument.
 
 #### Prefix, Suffix
+
 - Prefixes have been removed entirely. We recommend using additional label information and feedback in form validation instead.
 - Suffix buttons now use standard `o-buttons` styling.
 - Check your uses of suffixs still display correctly. In the case of button suffixes it may be necessary to apply the extra `o-buttons` classes `.o-buttons--secondary` and `.o-buttons--big`.
 - The mixins `oFormsAffixButton`, `oFormsAffixCheckbox`, `oFormsPrefixSuffix` have been removed. Use `oFormsSuffixFeature` for suffix classes including the affix wrapper (as documented above).
 
 #### Toggles
+
 - `.o-forms__checkbox-toggle` has been renamed `.o-forms__toggle`.
 - The `oFormsCheckboxToggleSize` mixin has been removed due to lack of use.
 
 #### Wrappers and Messages
+
 - Wrappers have been renamed to sections. Their class names have also been updated to conform to the BEM naming convention (as optional containers their name should not contain `__` as they are not elements of a block).
-	- `.o-forms__wrapper` becomes `.o-forms-section`.
-	- `.o-forms__wrapper--highlight` becomes `.o-forms-section--highlight`.
-	- `.o-forms__wrapper--error` which becomes `.o-forms-section--error`.
-	- The `oFormsMessage` mixin now only outputs minimal message styles, uses should be replaced with `oFormsSectionFeature`.
+  - `.o-forms__wrapper` becomes `.o-forms-section`.
+  - `.o-forms__wrapper--highlight` becomes `.o-forms-section--highlight`.
+  - `.o-forms__wrapper--error` which becomes `.o-forms-section--error`.
+  - The `oFormsMessage` mixin now only outputs minimal message styles, uses should be replaced with `oFormsSectionFeature`.
 - Messages are now child elements of a section and must not be used independently.
-	- Wrap messages within a form section `.o-forms-section` if they are not already. They should be the first child of the section.
-	- Remove the class `.o-forms__message--error`. A message now infers that it is an error message based on its parent section `.o-forms-section--error`.
+  - Wrap messages within a form section `.o-forms-section` if they are not already. They should be the first child of the section.
+  - Remove the class `.o-forms__message--error`. A message now infers that it is an error message based on its parent section `.o-forms-section--error`.
 
 #### Other changes
+
 - `oFormsFullWidth` has been removed. Use `oFormsWideFeature` for classes to remove form max width restrictions.
 - There is a new dependancy on `o-icons`. Build your project to confirm that it is compatible.
 
 Please [contact us](#contact) if you have any queries.
 
 ### Migrating from v3 to v4
-- A dependency on [o-typography](http://github.com/financial-times/o-typography) v5 has been introduced. This will break any builds that use o-typography <v5. __Resolution__: Update to o-typography v5.
+
+- A dependency on [o-typography](http://github.com/financial-times/o-typography) v5 has been introduced. This will break any builds that use o-typography <v5. **Resolution**: Update to o-typography v5.
 - The o-colors dependency has been updated to `^4`. This could create bower conflicts which should be resolved by updating to the newest release of o-colors.
 - The design for o-forms has changed in v4. This could create issues on your pages which make use of o-forms. Ensure that the updated design does not break the layout on your webpage.
 
-----
+---
 
 ### Migrating from v2 to v3
 
@@ -192,7 +220,6 @@ An example of the changes should be:
 ```
 
 Any modifier classes like `o-forms--error` have remained the same.
-
 
 ### Migrating to v1
 

--- a/components/o-forms/README.md
+++ b/components/o-forms/README.md
@@ -1010,18 +1010,19 @@ myForm.setState('saving', 'my-radio-box', {
 
 ## Migration guide
 
-|    State     | Major Version | Last Minor Release |                    Migration guide                    |
-| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       9       |        N/A         | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-| ⚠ maintained |       8       |        8.5         | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
-| ╳ deprecated |       7       |        7.1         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-| ╳ deprecated |       6       |        6.0         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ╳ deprecated |       5       |        5.11        | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ╳ deprecated |       4       |        4.1         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated |       3       |        3.5         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-| ╳ deprecated |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ╳ deprecated |       1       |        1.0         |     [migrate to v1](MIGRATION.md#migrating-to-v1)     |
-| ╳ deprecated |       0       |        0.13        |                          N/A                          |
+|    State     | Major Version | Last Minor Release |                     Migration guide                     |
+| :----------: | :-----------: | :----------------: | :-----------------------------------------------------: |
+| ⚠ maintained |      10       |        9.12        | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
+| ╳ deprecated |       9       |        N/A         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)  |
+| ╳ deprecated |       8       |        8.5         |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)  |
+| ╳ deprecated |       7       |        7.1         |  [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7)  |
+| ╳ deprecated |       6       |        6.0         |  [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6)  |
+| ╳ deprecated |       5       |        5.11        |  [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5)  |
+| ╳ deprecated |       4       |        4.1         |  [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4)  |
+| ╳ deprecated |       3       |        3.5         |  [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3)  |
+| ╳ deprecated |       2       |        2.0         |  [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2)  |
+| ╳ deprecated |       1       |        1.0         |      [migrate to v1](MIGRATION.md#migrating-to-v1)      |
+| ╳ deprecated |       0       |        0.13        |                           N/A                           |
 
 ## Contact
 

--- a/components/o-ft-affiliate-ribbon/MIGRATION.md
+++ b/components/o-ft-affiliate-ribbon/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration guide
 
+### Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v4 to v5
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -13,10 +30,12 @@ Origami components now require a `$system-code` Sass variable is set by the proj
 v4 removes the mixin `oFtAffiliateRibbonVisuallyHidden`. Replace with the o-normalise mixin [oNormaliseVisuallyHidden](https://registry.origami.ft.com/components/o-normalise/sassdoc). The mixin `oFtAffiliateRibbonBrandImage` has also been removed, there is no replacement, please contact the Origami team if your project has a usecase for this mixin.
 
 Custom colours and colour usecases have also been removed from the palette and should not be used. Please contact Origami if your project does have a usecase for these however:
+
 - removed colour: affiliate-ribbon-text
 - removed usecases: ribbon-background, ribbon-text, ribbon-logo
 
 The following Sass variables were unused and removed. Do not set these in your project:
+
 - o-ft-affiliate-ribbon-image-base-url
 - o-ft-affiliate-ribbon-image-service-version
 

--- a/components/o-ft-affiliate-ribbon/README.md
+++ b/components/o-ft-affiliate-ribbon/README.md
@@ -21,8 +21,15 @@ Use the following HTML to get a full-width FT affiliation ribbon. This should be
 <div class="o-ft-affiliate-ribbon">
 	<div class="o-ft-affiliate-ribbon__container">
 		<div class="o-ft-affiliate-ribbon__row">
-			<a class="o-ft-affiliate-ribbon__logo" href="https://www.ft.com/" title="The Financial Times" target="_blank">
-				<span class="o-ft-affiliate-ribbon__visually-hidden">A service from the Financial Times</span>
+			<a
+				class="o-ft-affiliate-ribbon__logo"
+				href="https://www.ft.com/"
+				title="The Financial Times"
+				target="_blank"
+			>
+				<span class="o-ft-affiliate-ribbon__visually-hidden"
+					>A service from the Financial Times</span
+				>
 			</a>
 		</div>
 	</div>
@@ -34,25 +41,26 @@ Use the following HTML to get a full-width FT affiliation ribbon. This should be
 Call the primary mixin `oFtAffiliateRibbon` to include all CSS for the o-ft-affiliate-ribbon component:
 
 ```scss
-	@import '@financial-times/o-ft-affiliate-ribbon/main';
-	@include oFtAffiliateRibbon();
+@import '@financial-times/o-ft-affiliate-ribbon/main';
+@include oFtAffiliateRibbon();
 ```
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-⚠ maintained | 4 | 4.0.4 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.0 | - |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.2         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                           -                           |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-ft-affiliate-ribbon/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-header-services/MIGRATION.md
+++ b/components/o-header-services/MIGRATION.md
@@ -1,11 +1,27 @@
 # Migration guide
 
+## Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v4 to v5
 
 V7 drops support for Bower and version 2 of Origami Build Service.
 
 Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).
-
 
 ## Migrating from v3 to v4
 
@@ -23,6 +39,7 @@ its dependencies. See [the Bower config for these](./bower.json).
 ## Migrating from v2 to v3
 
 V3 introduces many new changes to o-header-services; It now transforms the primary nav into a drawer menu on smaller viewports. It introduces the option to have dropdown menus on primary navigation items. It removes a large dependency on o-header, and changes multiple class names and markup, and no longer allows custom class names. This major also removes most public mixins and makes `oHeaderServices` publicly available instead;
+
 ```diff
 -oHeaderServicesContainer
 -oHeaderServicesPrimaryNav
@@ -33,6 +50,7 @@ V3 introduces many new changes to o-header-services; It now transforms the prima
 ```
 
 The markup for a full header (**not** including dropdown menus) has changed in the following way:
+
 ```diff
 -<header class="o-header-services" data-o-component="o-header">
 +<header class='o-header-services' data-o-component='o-header-services'>

--- a/components/o-header-services/README.md
+++ b/components/o-header-services/README.md
@@ -4,15 +4,15 @@ This header is for tools and services built by the Financial Times.
 
 - [Usage](#usage)
 - [Markup](#markup)
-	- [Title Section](#title-section)
-	- [Primary navigation](#primary-navigation)
-	- [Core experience of the drawer](#core-experience-of-the-drawer)
-	- [Primary navigation with drop down](#primary-navigation-with-drop-down)
-	- [Secondary navigation](#secondary-navigation)
-	- [Themes](#themes)
-	- [Bleed header](#bleed-header)
+  - [Title Section](#title-section)
+  - [Primary navigation](#primary-navigation)
+  - [Core experience of the drawer](#core-experience-of-the-drawer)
+  - [Primary navigation with drop down](#primary-navigation-with-drop-down)
+  - [Secondary navigation](#secondary-navigation)
+  - [Themes](#themes)
+  - [Bleed header](#bleed-header)
 - [Sass](#sass)
-	- [Customisation](#customisation)
+  - [Customisation](#customisation)
 - [JavaScript](#javascript)
 - [Migration guide](#migration-guide)
 - [Contact](#contact)
@@ -27,7 +27,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 An `o-header-services` header is divided into three main parts: title section **(required)**, primary navigation **(optional)**, and secondary navigation **(optional)**. Each section is placed within a `header` element:
 
 ```html
-<header class='o-header-services' data-o-component='o-header-services'>
+<header class="o-header-services" data-o-component="o-header-services">
 	<!-- Markup specific to the needs of your product. Options detailed below. -->
 </header>
 ```
@@ -66,32 +66,37 @@ Drop down menus also get pulled into the drawer on smaller viewports.
 For an example and markup, see the [primary navigation with drop downs in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-header-with-primary-navigation-and-drop-down-menus).
 
 If copying markup from the above example, update the following attributes of dropdown navigation items:
+
 - `aria-label`: include the title of your navigation item in the label for your dropdown button.
 - `aria-controls`: link your dropdown button to the `id` of the `ul` navigation list which it controls
 
 The following example shows the correct markup for a "Documentation" dropdown:
+
 ```html
 <li data-o-header-services-level="1">
-	<a href>Documentation</a><!--
+	<a href>Documentation</a
+	><!--
 	--><button
 		class="o-header-services__drop-down-button"
 		aria-controls="documentation-dropdown"
-		aria-label="Toggle documentation dropdown menu">
-	</button>
+		aria-label="Toggle documentation dropdown menu"
+	></button>
 	<ul
 		id="documentation-dropdown"
 		data-o-header-services-level="2"
-		aria-hidden="true">
+		aria-hidden="true"
+	>
 		<!-- dropdown navigation list items -->
 	</ul>
 </li>
 ```
+
 ### Secondary Navigation
 
 The secondary navigation is also an **optional** addition to the header, but it makes more sense alongside the primary navigation, as it serves more complicated products.
 
 It includes two sections of navigation: 'ancestors' and 'children'.
-The 'ancestor' section  works in the form of a breadcrumb, and the children are relative to the ancestor.
+The 'ancestor' section works in the form of a breadcrumb, and the children are relative to the ancestor.
 
 At smaller viewports, it does _not_ collapse into the drawer, but becomes scrollable instead.
 
@@ -113,7 +118,9 @@ To add a theme to the header, add the appropriate class to the header element. F
 For an example and markup, see the [B2B and B2C headers in the Origami Registry](https://registry.origami.ft.com/components/o-header-services@3.2.10#demo-product-theme-b2c).
 
 ### Bleed Header
+
 If your application requires a bleed header, you'll need to add the `o-header-services--bleed` variant to your header.
+
 ```diff
 +<header class='o-header-services o-header-services--bleed' data-o-component='o-header'>
 -<header class='o-header-services' data-o-component='o-header'>
@@ -124,15 +131,17 @@ If your application requires a bleed header, you'll need to add the `o-header-se
 ## Sass
 
 In order to output every type of `o-header-services` style, you'll need to include the following:
-```scss
-	@import '@financial-times/o-header-services/main';
 
-	@include oHeaderServices();
+```scss
+@import '@financial-times/o-header-services/main';
+
+@include oHeaderServices();
 ```
 
 You can be more selective about which types you would like to output, by using an `$opts` map. It accepts the following options:
 
 **types**
+
 - `'primary-nav'`
 - `'secondary-nav'`
 - `'bleed'`
@@ -140,13 +149,15 @@ You can be more selective about which types you would like to output, by using a
 - `'b2c'`
 
 **logo**
+
 - The logo image to show in the header. The image must come from an Origami [image set](https://registry.origami.ft.com/components?imageset=true&active=true&maintained=true). Specify the image set and image name as a string `[imageset]:[image]` e.g `ftlogo-v1:origami`. Defaults to the FT logo.
 
 **drawer-breakpoint**
+
 - The breakpoint to move the primary navigation into a drawer. We recommend a `rem` value or a layout size from [o-grid](https://github.com/Financial-Times/o-grid/#layout-sizes) e.g. 'M'. Defaults to the medium grid size 'M'.
 
-
 To use a logo that is **not** the FT logo, the logo can be modified in one of two ways:
+
 - By using a logo name from the logo image set (e.g. 'origami')
 - By passing in a full url or data url that points at the SVG you want to use as a logo (e.g. `'https://www.example.com/logo.svg'`). Bear in mind that you can also run your chosen SVG through the [Image Service's URL Builder](https://www.ft.com/__origami/service/image/v2/docs/url-builder), which will optimise the image and provide a URL for it.
 
@@ -162,6 +173,7 @@ In this example we include only the styles for a [primary navigation](#primary-n
 
 	// Will output styles for a bleed header with a primary navigation and the Origami logo
 ```
+
 ### Customisation
 
 `o-header-services` provides the option to customise the `whitelabel` brand. If you are using this brand, you can modify brand-specific variables by overriding them in a map in `oHeaderServicesCustomize`.
@@ -170,14 +182,21 @@ In this example we include only the styles for a [primary navigation](#primary-n
 $o-brand: whitelabel;
 @import '@financial-times/o-header-services/main';
 
-@include oHeaderServicesCustomize((
-	'nav-hover-background': hotpink // will apply to background colors on hover, where appropriate
-))
-
-@include oHeaderServices($opts: (
-	'types': ('primary-nav'),
-	'features': ('drop-down')
-));
+@include oHeaderServicesCustomize(
+		(
+			'nav-hover-background': hotpink
+				// will apply to background colors on hover, where appropriate,,,,
+		)
+	) @include oHeaderServices(
+		$opts: (
+			'types': (
+				'primary-nav',
+			),
+			'features': (
+				'drop-down',
+			),
+		)
+	);
 ```
 
 We recommend customising the following brand variables:
@@ -218,13 +237,14 @@ oHeaderServices.init();
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-⚠ maintained | 4 | 4.0 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.3 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.3 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.2 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.5         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.3         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.2         |                          N/A                          |
 
 ## Contact
 

--- a/components/o-header/MIGRATION.md
+++ b/components/o-header/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration Guide
 
+## Migrating from v14 to v15
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v13 to v14
 
 ### Search bar
@@ -92,9 +109,10 @@
 ### Ask FT button
 
 `o-header v14` adds optional Ask FT button markup in the following places:
-  - top left menu of the header (o-header/src/tsx/drawer.tsx)
-  - top left menu of the sticky (o-header/src/tsx/sticky.tsx)
-  - as the top, under the search in the drawer menu (o-header/src/tsx/drawer.tsx)
+
+- top left menu of the header (o-header/src/tsx/drawer.tsx)
+- top left menu of the sticky (o-header/src/tsx/sticky.tsx)
+- as the top, under the search in the drawer menu (o-header/src/tsx/drawer.tsx)
 
 Update your markup according to the [Storybook demo](https://o2-core.origami.ft.com/?path=/story/components-o-header--header-primary&globals=backgrounds:!undefined) or [use o-header's tsx template](https://github.com/Financial-Times/origami/tree/main/components/o-header/src/tsx) with `showAskButton=true` if you need to include Ask FT button.
 

--- a/components/o-header/README.md
+++ b/components/o-header/README.md
@@ -103,9 +103,10 @@ To use `o-header` setup a [core and enhanced experience](https://origami.ft.com/
 
 |    State     | Major Version | Last Minor Release |                     Migration guide                      |
 | :----------: | :-----------: | :----------------: | :------------------------------------------------------: |
-|  ✨ active   |      13       |        N/A         | [migrate to v13](MIGRATION.md#migrating-from-v12-to-v13) |
-| ⚠ maintained |      12       |        N/A         | [migrate to v12](MIGRATION.md#migrating-from-v11-to-v12) |
-| ⚠ maintained |      11       |        N/A         | [migrate to v11](MIGRATION.md#migrating-from-v10-to-v11) |
+| ⚠ maintained |      14       |        N/A         | [migrate to v14](MIGRATION.md#migrating-from-v13-to-v14) |
+| ╳ deprecated |      13       |        13.1        | [migrate to v13](MIGRATION.md#migrating-from-v12-to-v13) |
+| ╳ deprecated |      12       |        N/A         | [migrate to v12](MIGRATION.md#migrating-from-v11-to-v12) |
+| ╳ deprecated |      11       |        N/A         | [migrate to v11](MIGRATION.md#migrating-from-v10-to-v11) |
 | ╳ deprecated |      10       |        N/A         | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10)  |
 | ╳ deprecated |       9       |        N/A         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)   |
 | ╳ deprecated |       8       |        8.6         |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)   |

--- a/components/o-labels/MIGRATION.md
+++ b/components/o-labels/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v5 to v6
 
@@ -16,7 +33,7 @@ its dependencies. See [the Bower config for these](./bower.json).
 
 ## Migrating from v3 to v4
 
-- The `oLabels` mixin parameters have been changed, and all of the  mixins have changed significantly. See the [Sass documentation](README.md#sass) for how to use the new and updated mixins
+- The `oLabels` mixin parameters have been changed, and all of the mixins have changed significantly. See the [Sass documentation](README.md#sass) for how to use the new and updated mixins
   - The following states have been removed. The decision to remove was based on a search of the various codebases using o-labels, if you need one of the removed states then please contact us and we'll add it back:
     - `active`: This state has been removed entirely
     - `brand`: This state has been removed entirely

--- a/components/o-labels/README.md
+++ b/components/o-labels/README.md
@@ -17,6 +17,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 ## Label Types
 
 There are three types of label:
+
 - [A standard label](#standard-label), the default.
 - [An indicator label](#indicator-label).
 - [A timestamp label](#timestamp-label).
@@ -29,8 +30,8 @@ The standard label is used for content classification or to emphasise a value. F
 
 This table outlines the possible standard label sizes.
 
-| Size  | Description                                 | Brand support                |
-|-------|---------------------------------------------|------------------------------|
+| Size  | Description                                 | Brand support              |
+| ----- | ------------------------------------------- | -------------------------- |
 | big   | Label with increased font size and padding. | core, internal, whitelabel |
 | small | Label with decreased font size and padding. | core, internal, whitelabel |
 
@@ -39,10 +40,10 @@ This table outlines the possible standard label sizes.
 This table outlines the possible standard label states. Custom states may also be created.
 
 | State                | Description                                                   | Brand support |
-|----------------------|---------------------------------------------------------------|---------------|
-| content-commercial   | Used to identify paid posts or promoted content.              | core        |
-| content-premium      | Used to identify premium content.                             | core        |
-| lifecycle-beta       | Used to identify a feature that's in beta.                    | core        |
+| -------------------- | ------------------------------------------------------------- | ------------- |
+| content-commercial   | Used to identify paid posts or promoted content.              | core          |
+| content-premium      | Used to identify premium content.                             | core          |
+| lifecycle-beta       | Used to identify a feature that's in beta.                    | core          |
 | support-active       | Used to indicate that a component is actively maintained.     | internal      |
 | support-maintained   | Used to indicate that a component is maintained.              | internal      |
 | support-experimental | Used to indicate that a component is an experimental feature. | internal      |
@@ -63,33 +64,36 @@ This table outlines the possible standard label states. Custom states may also b
 ### Indicator Label
 
 The indicator label is used to show story status with new, updated, and live variants. The indicator label only supports the core brand but [internal brand support is under consideration](https://github.com/Financial-Times/o-labels/issues/58).
+
 #### Indicator Label Status
 
 This table outlines the possible indicator label statuses:
 
-| Indicator            | Description                                                   | Brand support |
-|----------------------|---------------------------------------------------------------|---------------|
-| live                 | Indicate a story is live.                                     | core        |
-| closed               | Indicate a live story is no longer live.                      | core        |
-| new                  | Indicate a story is new.                                      | core        |
-| updated              | Indicate a story has been updated.                            | core        |
+| Indicator | Description                              | Brand support |
+| --------- | ---------------------------------------- | ------------- |
+| live      | Indicate a story is live.                | core          |
+| closed    | Indicate a live story is no longer live. | core          |
+| new       | Indicate a story is new.                 | core          |
+| updated   | Indicate a story has been updated.       | core          |
 
 E.g. for a live label:
 
 ```html
 <span class="o-labels-indicator o-labels-indicator--live">
-  <span class="o-labels-indicator__status">live</span>
+	<span class="o-labels-indicator__status">live</span>
 </span>
 ```
 
 The live and closed labels also support a more prominent badge variant:
+
 ```html
 <span
-  class="o-labels-indicator o-labels-indicator--live o-labels-indicator--inverse o-labels-indicator--badge"
+	class="o-labels-indicator o-labels-indicator--live o-labels-indicator--inverse o-labels-indicator--badge"
 >
-  <span class="o-labels-indicator__status">live</span>
+	<span class="o-labels-indicator__status">live</span>
 </span>
 ```
+
 ### Timestamp Label
 
 The timestamp label is used to show article status in place of an indicator label when the article is not new, updated, or live. The timestamp label only supports the core brand.
@@ -118,8 +122,10 @@ Labels can also have one of several states. The available states depend on which
 The following core brand states are used to categorise content, mostly on FT.com:
 
 ```html
-<span class="o-labels o-labels--content-commercial">Paid Post</span> (used for paid post and promoted content)
-<span class="o-labels o-labels--content-premium">Premium</span> (used for premium-only content)
+<span class="o-labels o-labels--content-commercial">Paid Post</span> (used for
+paid post and promoted content)
+<span class="o-labels o-labels--content-premium">Premium</span> (used for
+premium-only content)
 ```
 
 The following state is used to indicate that a feature is in a beta state:
@@ -162,43 +168,44 @@ The internal brand may also use colour palette based states, these do not specif
 ### Indicator Label Markup
 
 Indicator labels have one of three statuses:
+
 - `live`
 - `closed`
 - `updated`
 - `new`
 
 Use the following markup for a live label:
+
 ```html
 <span class="o-labels-indicator o-labels-indicator--live">
-    <span class="o-labels-indicator__status">
-		live
-    </span>
+	<span class="o-labels-indicator__status"> live </span>
 </span>
 ```
 
 Use the modifier class `o-labels-indicator--closed` for a closed label:
+
 ```html
 <span class="o-labels-indicator o-labels-indicator--closed">
-    <span class="o-labels-indicator__status">
-		closed
-    </span>
+	<span class="o-labels-indicator__status"> closed </span>
 </span>
 ```
 
 For an updated or new label use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
+
 ```html
 <span class="o-labels-indicator o-labels-indicator--new">
-    <span class="o-labels-indicator__status">
-        new
-    </span>
-    <span class="o-labels-indicator__timestamp">
-        <!-- demo `time` element only (the datetime is not 1 hour ago) -->
-        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm">1 hour ago</time>
-    </span>
+	<span class="o-labels-indicator__status"> new </span>
+	<span class="o-labels-indicator__timestamp">
+		<!-- demo `time` element only (the datetime is not 1 hour ago) -->
+		<time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm"
+			>1 hour ago</time
+		>
+	</span>
 </span>
 ```
 
 Indicator labels also support an inverse theme for use on dark backgrounds. To use an inverse theme add the `o-labels-indicator--inverse` class to your markup.
+
 ```diff
 -<span class="o-labels-indicator o-labels-indicator--live">
 +<span class="o-labels-indicator o-labels-indicator--live o-labels-indicator--inverse">
@@ -214,8 +221,10 @@ To include a timestamp label use the following markup. Note the timestamp label 
 
 ```html
 <span class="o-labels-timestamp o-labels-timestamp--inverse">
-    <!-- demo `time` element only -->
-    <time datetime="2016-02-29T12:35:48Z" title="February 29 2016 12:35 pm">February 29 2016</time>
+	<!-- demo `time` element only -->
+	<time datetime="2016-02-29T12:35:48Z" title="February 29 2016 12:35 pm"
+		>February 29 2016</time
+	>
 </span>
 ```
 
@@ -234,40 +243,41 @@ Or pass an options map `$opts` argument to output just the label styles you need
 - sizes: a list of standard label sizes to output (see [available sizes](#standard-label-sizes))
 - states: a list of standard label states to output (see [available states](#standard-label-states)))
 - indicators
-	- status: a list of indicator label statuses to output (see [available statuses](#indicator-label-status))
-	- inverse
+  - status: a list of indicator label statuses to output (see [available statuses](#indicator-label-status))
+  - inverse
 - timestamp
-	- inverse
+  - inverse
 
 ```scss
-@include oLabels($opts: (
-	// standard label sizes to output
-	// e.g. .o-labels--big
-	'sizes': ('big'),
-	// standard label states to output
-	// e.g. .o-labels--content-commercial
-	'states': (
-		'content-commercial',
-		'content-premium'
-	),
-	// indicator label labels to output
-	// .o-labels-indicator
-	'indicators': (
-		// indicator label statuses to output
-		// .o-labels-indicator--live
-		'status': ('live'),
-		// whether to output the indicator label inverse style
-		// .o-labels-indicator--inverse
-		'inverse': true,
-	),
-	// output the timestamp label label
-	// .o-labels-timestamp
-	'timestamp': (
-		// whether to output the timestamp label inverse style
-		// .o-labels-timestamp--inverse
-		'inverse': true
+@include oLabels(
+	$opts: (
+		// standard label sizes to output
+		// e.g. .o-labels--big
+		'sizes': ('big'),
+		// standard label states to output
+		// e.g. .o-labels--content-commercial
+		'states': ('content-commercial', 'content-premium'),
+		// indicator label labels to output
+		// .o-labels-indicator
+		'indicators':
+			(
+				// indicator label statuses to output
+				// .o-labels-indicator--live
+				'status': ('live'),
+				// whether to output the indicator label inverse style
+				// .o-labels-indicator--inverse
+				'inverse': true
+			),
+		// output the timestamp label label
+		// .o-labels-timestamp
+		'timestamp':
+			(
+				// whether to output the timestamp label inverse style
+				// .o-labels-timestamp--inverse
+				'inverse': true
+			),
 	)
-));
+);
 ```
 
 ### Custom Standard Label State
@@ -276,14 +286,18 @@ Use `oLabelsAddState` mixin to add a custom label state for the standard label. 
 
 ```scss
 // outputs a class .o-labels--citrus-fruit
-@include oLabelsAddState('citrus-fruit', (
-	background-color: oColorsByName('lemon')
-));
+@include oLabelsAddState(
+	'citrus-fruit',
+	(
+		background-color: oColorsByName('lemon'),
+	)
+);
 ```
 
 ### Custom Markup
 
 When it's not possible to use an `o-labels` CSS class, for example within another Origami component, use:
+
 - `oLabelsContent` to output a standard label with a custom class.
 - `oLabelsIndicatorContent` to output an indicator label with a custom class.
 - `oLabelsTimestampContent` to output a timestamp label with a custom class.
@@ -295,26 +309,32 @@ If it is possible to use `o-labels` classes we recommend [oLabels](#sass) and [o
 `oLabelsContent` accepts an `$opts` argument which is a map of options. To output styles required by all labels set "base" to "true". Then set the labels "[sizes](#size)" and its "[state](#states)". Any of these options may be output independently.
 
 To output an existing label:
+
 ```scss
 .o-example-my-label {
-	@include oLabelsContent($opts: (
-		'base': true,
-		'size': 'big',
-		'state': 'tier-gold'
-	));
+	@include oLabelsContent(
+		$opts: (
+			'base': true,
+			'size': 'big',
+			'state': 'tier-gold',
+		)
+	);
 }
 ```
 
 To output a custom label:
+
 ```scss
 .o-example-my-custom-label {
-	@include oLabelsContent($opts: (
-		'base': true,
-		'size': 'big',
-		'state': (
-			'background-color': oColorsByName('lemon')
+	@include oLabelsContent(
+		$opts: (
+			'base': true,
+			'size': 'big',
+			'state': (
+				'background-color': oColorsByName('lemon'),
+			),
 		)
-	));
+	);
 }
 ```
 
@@ -325,38 +345,54 @@ As styles for the indicator label apply to multiple html elements, the `oLabelsI
 ```scss
 // equivalent to .o-labels-indicator
 .my-indicator-label {
-	@include oLabelsIndicatorContent($opts: ('block': true));
+	@include oLabelsIndicatorContent(
+		$opts: (
+			'block': true,
+		)
+	);
 }
 // equivalent to .o-labels-indicator--live
 .my-indicator-label--live {
-	@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
+	@include oLabelsIndicatorContent(
+		$opts: (
+			'block': true,
+			'modifier': 'live',
+		)
+	);
 }
 // equivalent to .o-labels-indicator__status
 .my-indicator-label__status {
-	@include oLabelsIndicatorContent($opts: ('element': 'status'));
+	@include oLabelsIndicatorContent(
+		$opts: (
+			'element': 'status',
+		)
+	);
 }
 // equivalent to .o-labels-indicator__timestamp
 .my-indicator-label__timestamp {
-	@include oLabelsIndicatorContent($opts: ('element': 'timestamp'));
+	@include oLabelsIndicatorContent(
+		$opts: (
+			'element': 'timestamp',
+		)
+	);
 }
 ```
 
 ## Migration guide
 
-|     State     | Major Version | Last Minor Release | Migration guide |
-|:-------------:| :---: | :---: | :---:|
-|   ✨ active    | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-|   ✨ active    | 5 | 5.2 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠ maintained  | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated  | 3 | 3.1.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-| ╳ deprecated  | 2 | 2.1.0 | N/A |
-|  ╳ deprecated | 1 | 1.0.6 | N/A |
-
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.5         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.2         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        N/A         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |       3.1.1        | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |       2.1.0        |                          N/A                          |
+| ╳ deprecated |       1       |       1.0.6        |                          N/A                          |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-labels/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
-
 
 ## Licence
 

--- a/components/o-layout/MIGRATION.md
+++ b/components/o-layout/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v4 to v5
 
@@ -17,8 +34,8 @@ its dependencies. See [the Bower config for these](./bower.json).
 ## Migrating from v2 to v3
 
 - `o-layout` supports the internal brand only, so your project must set its brand to the internal brand:
-	- If using SASS, set the variable `$o-brand: 'internal';` before importing any Origami component.
-	- If using the Origami Build Service, add the brand parameter to your CSS URL `?o-layout@^3.0.0&brand=internal`.
+  - If using SASS, set the variable `$o-brand: 'internal';` before importing any Origami component.
+  - If using the Origami Build Service, add the brand parameter to your CSS URL `?o-layout@^3.0.0&brand=internal`.
 
 ### Markup Changes
 

--- a/components/o-layout/README.md
+++ b/components/o-layout/README.md
@@ -784,11 +784,12 @@ oLayout.init(null, {linkHeadings: true});
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠ maintained |       4       |        N/A         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ⚠ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.4         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |         -          | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 | ╳ deprecated |       3       |        3.3         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 | ╳ deprecated |       2       |       2.2.5        | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ╳ deprecated |       1       |       1.3.4        |                          N/A                          |
+| ╳ deprecated |       1       |       1.3.4        |                           -                           |
 
 ## Troubleshooting
 

--- a/components/o-loading/MIGRATION.md
+++ b/components/o-loading/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration Guide
 
+### Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v4 to v5
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -11,12 +28,21 @@ Follow [the migration guide on the Origami website](https://origami.ft.com/docum
 The `$o-loading-themes` variable is now private. If you are a whitelabel brand user and would like to customise the colours of `o-loading`, use the `oLoadingCustomize` mixin instead. See [o-loading Sassdoc](https://registry.origami.ft.com/components/o-loading/sassdoc?brand=whitelabel) for more details.
 
 The `$o-loading-sizes` is also now private. If your project uses this to configure which sizes of `o-loading` to output, use the `oLoading` mixin instead, e.g.
+
 ```scss
-@include oLoading($opts: (
-	'themes': ('light'),
-	'sizes': ('medium', 'large')
-));
+@include oLoading(
+	$opts: (
+		'themes': (
+			'light',
+		),
+		'sizes': (
+			'medium',
+			'large',
+		),
+	)
+);
 ```
+
 If your project uses `$o-loading-sizes` for any other reason, e.g. to customise the dimensions of `o-loading`, please contact the Origami team.
 
 Finally the `$o-loading-animation-keyframes` variable is now private and should not be used.
@@ -32,6 +58,7 @@ its dependencies. See [the Bower config for these](./bower.json).
 V3 changes the internal structure of `o-loading`.
 
 These mixins have been privatised and are no longer meant to be used within a product.
+
 ```diff
 - oLoadingColor
 + _oLoadingTheme
@@ -40,20 +67,34 @@ These mixins have been privatised and are no longer meant to be used within a pr
 ```
 
 In order to output styles, the available mixin is now:
+
 ```scss
-@include oLoading($opts: (
-	'themes': ('dark'),
-	'sizes': ('small')
-))
+@include oLoading(
+	$opts: (
+		'themes': (
+			'dark',
+		),
+		'sizes': (
+			'small',
+		),
+	)
+);
 ```
 
 If you can't use `o-loading` classes, you can add styles to a specific element by using `oLoadingContent`:
+
 ```scss
 .my-small-dark-loading-spinner {
-	@include oLoadingContent($opts: (
-		'theme': ('dark'),
-		'size': ('small')
-	));
+	@include oLoadingContent(
+		$opts: (
+			'theme': (
+				'dark',
+			),
+			'size': (
+				'small',
+			),
+		)
+	);
 }
 ```
 

--- a/components/o-loading/README.md
+++ b/components/o-loading/README.md
@@ -83,11 +83,12 @@ If you need to build a loading spinner into a component, for example, you can us
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠ maintained |       4       |       4.0.4        | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ⚠ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.2         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |       4.0.4        | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 | ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 | ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ╳ deprecated |       1       |        1.0         |                          N/A                          |
+| ╳ deprecated |       1       |        1.0         |                           -                           |
 
 ## Contact
 

--- a/components/o-message/MIGRATION.md
+++ b/components/o-message/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration Guide
 
+### Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v4 to v5
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -26,6 +43,7 @@ It removes layout modifiers. State modifiers stay the same.
 ```
 
 All oMessage mixins have been made private. The option to add custom classnames has been removed. And the main Sass mixin has been changed to accept only one argument, namely `$opts`:
+
 ```diff
 -@include oMessage($class: 'my message', $types: ('alert-inner'), $status: ('error'))
 +@include oMessage($opts: (
@@ -36,6 +54,7 @@ All oMessage mixins have been made private. The option to add custom classnames 
 ```
 
 All colour use cases have been removed from the palette in favour of branding-specific colours.
+
 ```diff
 -black-crimson-12.5
 -paper-crimson-90
@@ -50,6 +69,7 @@ The JS for `o-message` now requires the `type` and `state` to be supplied in the
 
 This major includes a change in markup and a new type of message, namely the 'notice' message.
 The following changes have been made to the markup:
+
 ```diff
 <div class="o-message o-message--alert o-message--error" data-o-component="o-message">
 	<div class="o-message__container">

--- a/components/o-message/README.md
+++ b/components/o-message/README.md
@@ -343,9 +343,10 @@ To create a new message with a unique look call `oMessageAddSate`. The mixin acc
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠ maintained |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ⚠ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.4         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |         -          | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 | ╳ deprecated |       2       |        2.4         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 | ╳ deprecated |       1       |        1.0         |                          N/A                          |
 

--- a/components/o-meter/MIGRATION.md
+++ b/components/o-meter/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v3 to v4
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v2 to v3
 
@@ -9,5 +26,6 @@ Follow [the migration guide on the Origami website](https://origami.ft.com/docum
 ## Migrating from v1 to v2
 
 If your project uses a meter of a custom colour, rename the CSS variables:
+
 - `--o-meter-high-color` to `--o-meter-sub-optimum-color`
 - `--o-meter-low-color` to `--o-meter-less-than-sub-optimum-color`

--- a/components/o-meter/README.md
+++ b/components/o-meter/README.md
@@ -1,6 +1,5 @@
 # o-meter [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-
 Use the meter element to measure data within a given range. The `<meter>` tag defines a scalar measurement within a known range, or a fractional value. This is also known as a gauge.
 
 - [Usage](#usage)
@@ -20,79 +19,118 @@ Check out [how to include Origami components in your project](https://origami.ft
 This HTML demonstrates a way to use a basic o-meter
 
 ```html
-<meter class="o-meter" aria-label="a meter component" data-o-component="o-meter" min="0" max="100" value="25">
+<meter
+	class="o-meter"
+	aria-label="a meter component"
+	data-o-component="o-meter"
+	min="0"
+	max="100"
+	value="25"
+>
 	25
 </meter>
 ```
 
 This HTML demonstrates a way to use an extended o-meter with an additional value indicator
+
 ```html
 <div class="o-meter-container">
-	<meter class="o-meter" aria-label="a meter component" data-o-component="o-meter" min="0" max="100" value="75">
-	75
-	</meter>
-	<span class="o-meter-value" style="left: 75%">
+	<meter
+		class="o-meter"
+		aria-label="a meter component"
+		data-o-component="o-meter"
+		min="0"
+		max="100"
+		value="75"
+	>
 		75
-	</span>
+	</meter>
+	<span class="o-meter-value" style="left: 75%"> 75 </span>
 </div>
 ```
 
 This HTML demonstrates a way to use a basic o-meter with customised colours. Colours are used to indicate how close the meter is to its [optimum value](https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-optimum).
 
 To customise meter colours set the following CSS Customer Properties:
+
 - `--o-meter-background-color`: The background colour for the empty meter.
 - `--o-meter-low-color` (bad): The CSS colour for the meter element when its value is at its worse, less than sub optimal. E.g:
-	- value < low and optimum > high; or
-	- value > high and optimum < low
+  - value < low and optimum > high; or
+  - value > high and optimum < low
 - `--o-meter-high-color` (suboptimal): The CSS colour for the meter element when its value is suboptimal. E.g:
-	- value > low, value < high, and optimum > high
-	- value < high, value > lower, and optimum < low
+  - value > low, value < high, and optimum > high
+  - value < high, value > lower, and optimum < low
 - `--o-meter-optimum-color` (good): The CSS colour for the meter element when its value is optimal. E.g:
-	- value > high and optimum > high
-	- value < low and optimum < low
+  - value > high and optimum > high
+  - value < low and optimum < low
 
 This example uses inline styles but you may want to create a custom CSS class to share these styles with other meter elements in your project.
 
 ```html
-	<meter class="o-meter" style="
+<meter
+	class="o-meter"
+	style="
 		--o-meter-background-color: lightgray;
 		--o-meter-optimum-color: deeppink;
 		--o-meter-sub-optimum-color: hotpink;
-		--o-meter-less-than-sub-optimum-color: pink;" aria-label="a meter component" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="35">
+		--o-meter-less-than-sub-optimum-color: pink;"
+	aria-label="a meter component"
+	data-o-component="o-meter"
+	min="0"
+	max="100"
+	low="25"
+	high="75"
+	optimum="100"
+	value="35"
+>
 	35
-	</meter>
+</meter>
 ```
+
 This HTML demonstrates a way to use an extended o-meter with customised width and height
+
 ```html
-	<div class="o-meter-container" style="--o-meter-width: 70%; --o-meter-height: 2em">
-		<meter class="o-meter" aria-label="a meter component" data-o-component="o-meter" min="0" max="10" value="2.5">
+<div
+	class="o-meter-container"
+	style="--o-meter-width: 70%; --o-meter-height: 2em"
+>
+	<meter
+		class="o-meter"
+		aria-label="a meter component"
+		data-o-component="o-meter"
+		min="0"
+		max="10"
+		value="2.5"
+	>
 		2.5
-		</meter>
-		<span class="o-meter-value" style="left: 25%">
-			2.5
-		</span>
-	</div>
+	</meter>
+	<span class="o-meter-value" style="left: 25%"> 2.5 </span>
+</div>
 ```
 
 ## Sass
+
 ```scss
 @include oMeter;
 ```
 
 ## Support
+
 The `meter` tag is currently supported by Chrome, Safari, Firefox, Edge browsers. It is not supported by IE.
 If `o-meter` needs to be used on IE, please use a fallback - include the value in the meter tag, for example:
+
 ```html
-<meter data-o-component="o-meter" class='o-meter' value="0.6">60%</meter>
+<meter data-o-component="o-meter" class="o-meter" value="0.6">60%</meter>
 ```
 
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-⚠ maintained | 2 | 2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.0 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       4       |        N/A         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.2         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                           -                           |
 
 ## Contact
 

--- a/components/o-multi-select/MIGRATION.md
+++ b/components/o-multi-select/MIGRATION.md
@@ -1,34 +1,49 @@
 ## Migration Guide
 
+### Migrating from v2 to v3
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v1 to v2
 
 V2 changes the `o-multi-select` TSX template API. If you are using TSX templates you will need to update your code to use new API. Before users were able to pass array of strings to render the component but that did not enable users to set selected on render. Now users will need to pass an object to match this type:
 
 ```ts
 type MultiSelectType = {
- label: string;
- selected: boolean;
-}
+	label: string;
+	selected: boolean;
+};
 ```
 
 Before users used our component like this:
 
 ```jsx
-
 const fruits = ['Apple', 'Banana', 'Orange'];
 
-<MultiSelect options={fruits} />
+<MultiSelect options={fruits} />;
 ```
 
 Now users will need to use our component like this:
 
 ```jsx
-
 const fruits = [
- { label: 'Apple', selected: false },
- { label: 'Banana', selected: true },
- { label: 'Orange', selected: false },
+	{label: 'Apple', selected: false},
+	{label: 'Banana', selected: true},
+	{label: 'Orange', selected: false},
 ];
 
-<MultiSelect options={fruits} />
+<MultiSelect options={fruits} />;
 ```

--- a/components/o-multi-select/README.md
+++ b/components/o-multi-select/README.md
@@ -148,8 +148,9 @@ detail: {
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ⚠ maintained |       1       |        1.0         |                          N/A                          |
+| ⚠ maintained |       3       |        2.0         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.2         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                          N/A                          |
 
 ## Contact
 

--- a/components/o-overlay/MIGRATION.md
+++ b/components/o-overlay/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v3 to v4
 
@@ -78,10 +95,10 @@ its dependencies. See [the Bower config for these](./bower.json).
 
 ## Migrating from v1 to v2
 
-- Arrows functionality has now been removed. __Resolution__ If you need an overlay with an arrow, please use [o-tooltip](http://github.com/financial-times/o-tooltip).
-- A dependency on [o-icons](http://github.com/financial-times/o-icons) v4 or v5 has been introduced. This will break any builds that use o-icons <v3. __Resolution__: Ideally you should upgrade to o-icons v5, but if you still need to use the old icon set (in v4) then upgrading to o-icons v4 will also work.
-- A dependency on [o-visual-effects](http://github.com/financial-times/o-visual-effects) v1 has been introduced. This will break any builds that use o-visual-effects <v1. __Resolution__: Update to v1 of o-visual-effects.
+- Arrows functionality has now been removed. **Resolution** If you need an overlay with an arrow, please use [o-tooltip](http://github.com/financial-times/o-tooltip).
+- A dependency on [o-icons](http://github.com/financial-times/o-icons) v4 or v5 has been introduced. This will break any builds that use o-icons <v3. **Resolution**: Ideally you should upgrade to o-icons v5, but if you still need to use the old icon set (in v4) then upgrading to o-icons v4 will also work.
+- A dependency on [o-visual-effects](http://github.com/financial-times/o-visual-effects) v1 has been introduced. This will break any builds that use o-visual-effects <v1. **Resolution**: Update to v1 of o-visual-effects.
 - A dependency on [o-normalise](http://github.com/financial-times/o-normalise) v1 has been introduced. This is not likely to introduce any conflicts as it is only v1.
-- The mixin oOverlayCompactCloseIcon (deprecated in v1.3.0) has been removed. __Resolution__ Use the `@oOverlayCloseIcon` mixin.
-- All extends (deprecated in v1.2.0) have been removed. __Resolution__: Use the mixins instead.
+- The mixin oOverlayCompactCloseIcon (deprecated in v1.3.0) has been removed. **Resolution** Use the `@oOverlayCloseIcon` mixin.
+- All extends (deprecated in v1.2.0) have been removed. **Resolution**: Use the mixins instead.
 - The o-colors and o-visual-effects dependencies have been bumped to the latest major. These will create bower conflicts which should be resolved by updating to the newest release of o-colors and o-visual-effects.

--- a/components/o-overlay/README.md
+++ b/components/o-overlay/README.md
@@ -206,10 +206,11 @@ _o-overlays will throw an error if the options aren't set correctly._
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       4       |        N/A         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ⚠ maintained |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-| ⚠ maintained |       2       |        2.7         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ╳ deprecated |       1       |       1.17.0       |                          N/A                          |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.7         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.17        |                           -                           |
 
 ## Contact
 

--- a/components/o-share/MIGRATION.md
+++ b/components/o-share/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration guide
 
+## Migrating from v10 to v11
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v9 to v10
 
 o-share v10 replaces the "Twitter" brand for "X". As this is a major change due to inlined SVG markup, we have also decided to update the o-share API to remove references to "Twitter". To migrate make the following changes.
@@ -17,12 +34,15 @@ If your project is using Sass and the `oShare` mixin to selectively include soci
     'inverse': true
 ));
 ```
+
 ### Update your markup
 
 Update your markup according to whether your project is using o-share TSX templates or copying HTML directly.
+
 #### Copying HTML
 
 If copying component HTML, update:
+
 1. The share icon class name.
 2. The icon SVG.
 3. The share text description.
@@ -42,13 +62,16 @@ To do this, obtain the full markup required from [the o-share demos](https://reg
   </span>
 </a>
 ```
+
 #### TSX templates
 
 If using TSX templates:
+
 1. Replace any "twitter" icon for "x".
 2. Update your `urlProps` to remove Twitter references.
-  - The key `relatedTwitterAccounts` becomes `relatedXAccounts`
-  - We recommend referring to "X, formally known as Twitter" in title and summary text descriptions for now.
+
+- The key `relatedTwitterAccounts` becomes `relatedXAccounts`
+- We recommend referring to "X, formally known as Twitter" in title and summary text descriptions for now.
 
 ```diff
 <Share {...shareProps}>
@@ -64,7 +87,7 @@ If using TSX templates:
 
 o-share v9 incudes a number of changes to improve accessibility. To migrate follow these steps and see below for more details:
 
-* o-share no longer provides client side JavaScript to generate markup. New markup can be copied from the [Origami registry](https://registry.origami.ft.com/components/o-share) or [StoryBook](https://origami.ft.com/storybook/) via the `HTML` tab.
+- o-share no longer provides client side JavaScript to generate markup. New markup can be copied from the [Origami registry](https://registry.origami.ft.com/components/o-share) or [StoryBook](https://origami.ft.com/storybook/) via the `HTML` tab.
 
 ### Inlined SVG icons
 
@@ -72,18 +95,18 @@ Icons in version 9 use inline SVGs. In order to use them with `o-share`, we reco
 
 ```html
 <li class="o-share__action">
-   <a
-    class="o-share__icon o-share__icon--{{className}}"
-    href="{{link}}"
-    rel="noopener"
-   >
-    <div class="o-share__icon__image">
-    <!-- SVG code -->
-    </div>
-    <span class="o-share__text">
-     Share {{title}} on {{name}} (opens a new window)
-    </span>
-   </a>
+	<a
+		class="o-share__icon o-share__icon--{{className}}"
+		href="{{link}}"
+		rel="noopener"
+	>
+		<div class="o-share__icon__image">
+			<!-- SVG code -->
+		</div>
+		<span class="o-share__text">
+			Share {{title}} on {{name}} (opens a new window)
+		</span>
+	</a>
 </li>
 ```
 
@@ -92,15 +115,16 @@ Icons in version 9 use inline SVGs. In order to use them with `o-share`, we reco
 Usage of `o-share` with client side Javascript initialisation is now deprecated. Projects that use this will no longer work:
 
 ```html
-<div data-o-component="o-share"
- class="o-share"
- data-o-share-links="{{links}}"
- data-o-share-url="{{url}}"
- data-o-share-title="{{title}}"
- data-o-share-titleExtra="{{titleExtra}}"
- data-o-share-summary="{{summary}}"
- data-o-share-location="{{locationOfShareComponent}}">
-</div>
+<div
+	data-o-component="o-share"
+	class="o-share"
+	data-o-share-links="{{links}}"
+	data-o-share-url="{{url}}"
+	data-o-share-title="{{title}}"
+	data-o-share-titleExtra="{{titleExtra}}"
+	data-o-share-summary="{{summary}}"
+	data-o-share-location="{{locationOfShareComponent}}"
+></div>
 ```
 
 Instead use full markup of the component:
@@ -108,18 +132,20 @@ Instead use full markup of the component:
 ```html
 <!-- see the registry demos for full markup -->
 <div data-o-component="o-share" class="o-share">
- <ul>
-  <!-- a share to twitter action example -->
-  <!-- href tag is not shown, see the registry demos for full markup  -->
-  <li class="o-share__action">
-   <a class="o-share__icon o-share__icon--twitter"
-    href="#twitter-link-here"
-    rel="noopener">
-    <span class="o-share__text">Twitter</span>
-   </a>
-  </li>
-  <!-- more o-share actions -->
- </ul>
+	<ul>
+		<!-- a share to twitter action example -->
+		<!-- href tag is not shown, see the registry demos for full markup  -->
+		<li class="o-share__action">
+			<a
+				class="o-share__icon o-share__icon--twitter"
+				href="#twitter-link-here"
+				rel="noopener"
+			>
+				<span class="o-share__text">Twitter</span>
+			</a>
+		</li>
+		<!-- more o-share actions -->
+	</ul>
 </div>
 ```
 
@@ -187,7 +213,7 @@ The following usecases have been removed. Please contact the Origami Team if you
 The variable `$o-share-colors` is now private ans must not be used. Instead use colour usecases, e.g:
 
 ```scss
-$twitter-color: oColorsByName('facebook', $from: 'o-share')
+$twitter-color: oColorsByName('facebook', $from: 'o-share');
 ```
 
 ### Mixins

--- a/components/o-share/README.md
+++ b/components/o-share/README.md
@@ -3,23 +3,23 @@
 Social media buttons.
 
 - [o-share ](#o-share-)
-	- [Overview](#overview)
-	- [Usage](#usage)
-	- [Markup](#markup)
-		- [Small](#small)
-			- [Open In A New Tab](#open-in-a-new-tab)
-			- [Text Labels](#text-labels)
-			- [Custom Actions](#custom-actions)
-	- [Sass](#sass)
-		- [Colour Usecases](#colour-usecases)
-	- [JavaScript](#javascript)
-		- [Events](#events)
-			- [oShare.ready](#oshareready)
-			- [oShare.open](#oshareopen)
-	- [TSX Template](#tsx-template)
-	- [Migration guide](#migration-guide)
-	- [Contact](#contact)
-	- [Licence](#licence)
+  - [Overview](#overview)
+  - [Usage](#usage)
+  - [Markup](#markup)
+    - [Small](#small)
+      - [Open In A New Tab](#open-in-a-new-tab)
+      - [Text Labels](#text-labels)
+      - [Custom Actions](#custom-actions)
+  - [Sass](#sass)
+    - [Colour Usecases](#colour-usecases)
+  - [JavaScript](#javascript)
+    - [Events](#events)
+      - [oShare.ready](#oshareready)
+      - [oShare.open](#oshareopen)
+  - [TSX Template](#tsx-template)
+  - [Migration guide](#migration-guide)
+  - [Contact](#contact)
+  - [Licence](#licence)
 
 ## Overview
 
@@ -40,18 +40,20 @@ Include the [complete markup, available in the Origami registry](https://registr
 ```html
 <!-- see the registry demos for full markup -->
 <div data-o-component="o-share" class="o-share">
- <ul>
-  <!-- a share to X action example -->
-  <!-- href tag is not shown, see the registry demos for full markup  -->
-  <li class="o-share__action">
-   <a class="o-share__icon o-share__icon--x"
-    href="#x-link-here"
-    rel="noopener">
-    <span class="o-share__text">X</span>
-   </a>
-  </li>
-  <!-- more o-share actions -->
- </ul>
+	<ul>
+		<!-- a share to X action example -->
+		<!-- href tag is not shown, see the registry demos for full markup  -->
+		<li class="o-share__action">
+			<a
+				class="o-share__icon o-share__icon--x"
+				href="#x-link-here"
+				rel="noopener"
+			>
+				<span class="o-share__text">X</span>
+			</a>
+		</li>
+		<!-- more o-share actions -->
+	</ul>
 </div>
 ```
 
@@ -94,15 +96,20 @@ Form markup is allowed within the `o-share__action` label to to handle custom sh
 ```html
 <!-- see the registry demos for full markup -->
 <li class="o-share__action o-share__action--labelled">
-  <!-- demo only: forms with a submit button may be used for custom actions -->
-  <form method="post" action="#">
-    <button type="submit" class="o-share__icon o-share__icon--share" title="[Describe your custom action]" aria-label="[Describe your custom action]">
-      <span class="o-share__icon__image">
-        <!-- custom svg icon -->
-      </span>
-      <span class="o-share__text" data-variant-label="">Custom Action</span>
-    </button>
-  </form>
+	<!-- demo only: forms with a submit button may be used for custom actions -->
+	<form method="post" action="#">
+		<button
+			type="submit"
+			class="o-share__icon o-share__icon--share"
+			title="[Describe your custom action]"
+			aria-label="[Describe your custom action]"
+		>
+			<span class="o-share__icon__image">
+				<!-- custom svg icon -->
+			</span>
+			<span class="o-share__text" data-variant-label="">Custom Action</span>
+		</button>
+	</form>
 </li>
 ```
 
@@ -125,11 +132,23 @@ We recommend passing the `oShare` mixin an optional argument `$opts`, to specify
 For example:
 
 ```scss
-@include oShare($opts: (
- 'sizes': ('small'), // output styles for a small variation of o-share i.e. o-share--small
- 'vertical': true, // output styles for a vertical o-share i.e. o-share--vertical
- 'icons': ('x', 'facebook', 'whatsapp') // output styles for select share icons
-));
+@include oShare(
+	$opts: (
+		'sizes': (
+			'small',
+		),
+		// output styles for a small variation of o-share i.e. o-share--small
+		'vertical': true,
+		// output styles for a vertical o-share i.e. o-share--vertical
+		'icons':
+			(
+				'x',
+				'facebook',
+				'whatsapp',
+			)
+			// output styles for select share icons,,,,,,,
+	)
+);
 ```
 
 All `$opts` options include:
@@ -152,17 +171,17 @@ All `$opts` options include:
 
 `o-share` sets custom colour usecases for matching the colour of share buttons. These usecases are limited, for example they do not provide colours for the inverse variant, and not recommended for new projects (it is possible to output custom icons using the `oShare` mixin, without matching colours).
 
-| Usecase                           | Property                 | Uses                                                                                                   |
-|-----------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------|
-| `o-share/default-icon`            | background, border, text | Default colours, used by icons without a state (e.g. before hover).                                    |
-| `o-share/ft-icon`                 | background, border, text | Colours to highlight FT icon social buttons like email (e.g. on hover).                                |
+| Usecase                           | Property                 | Uses                                                                                             |
+| --------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `o-share/default-icon`            | background, border, text | Default colours, used by icons without a state (e.g. before hover).                              |
+| `o-share/ft-icon`                 | background, border, text | Colours to highlight FT icon social buttons like email (e.g. on hover).                          |
 | `o-share/[social-icon-name]-icon` | background, border, text | Colours to highlight social buttons with a brand, like Twitter (e.g. `o-share/x-icon` on hover). |
 
 Use the [oColorsByUsecase mixin from o-colors](https://registry.origami.ft.com/components/o-colors/sassdoc?brand=core#function-ocolorsbyusecase) to retrieve custom colour usecases set by o-share.
 
 ```scss
 .my-icon:hover {
- background-color: oColorsByUsecase('o-share/ft-icon', 'background');
+	background-color: oColorsByUsecase('o-share/ft-icon', 'background');
 }
 ```
 
@@ -172,7 +191,9 @@ To instantiate the JavaScript:
 
 ```javascript
 import oShare from '@financial-times/o-share';
-var oShareInstance = new oShare(document.querySelector('[data-o-component=o-share]'));
+var oShareInstance = new oShare(
+	document.querySelector('[data-o-component=o-share]')
+);
 ```
 
 The markup will be generated for that instance of `o-share`.
@@ -182,8 +203,8 @@ You can also instantiate all instances in your page by running `oShare.init` whi
 Alternatively, an `o.DOMContentLoaded` event can be dispatched on the `document` to run `#init()`:
 
 ```js
-document.addEventListener("DOMContentLoaded", function() {
- document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+document.addEventListener('DOMContentLoaded', function () {
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
 ```
 
@@ -219,35 +240,34 @@ The event provides the following properties:
 `o-share` component publishes TSX templates to NPM and can be consumed by importing tsx template from our source directory:
 
 ```jsx
-import { Share } from "@financial-times/o-share/src/tsx/share";
-import { ShareIcon } from "@financial-times/o-share/src/tsx/shareIcon";
+import {Share} from '@financial-times/o-share/src/tsx/share';
+import {ShareIcon} from '@financial-times/o-share/src/tsx/shareIcon';
 
 <Share {...ShareProps}>
- <ShareIcon {...ShareIconProps} />
-</Share>
-
+	<ShareIcon {...ShareIconProps} />
+</Share>;
 ```
 
 The prop Types for each component:
 
 ```ts
 interface ShareProps {
- small?: boolean;
- vertical?: boolean;
- inverse?: boolean;
+	small?: boolean;
+	vertical?: boolean;
+	inverse?: boolean;
 }
 
 interface ShareIconProps {
- icon: "x" | "facebook" | "linkedin" | "whatsapp";
- urlProps: {
-  url: string;
-  title: string;
-  titleExtra: string;
-  summary: string;
-  relatedXAccounts: string;
- };
- showLabel?: boolean;
- label?: string;
+	icon: 'x' | 'facebook' | 'linkedin' | 'whatsapp';
+	urlProps: {
+		url: string;
+		title: string;
+		titleExtra: string;
+		summary: string;
+		relatedXAccounts: string;
+	};
+	showLabel?: boolean;
+	label?: string;
 }
 ```
 
@@ -255,24 +275,25 @@ TSX template doesn't import styles and doesn't initialise javaScript by itself. 
 
 ## Migration guide
 
-|    State     | Major Version | Last Minor Release |                    Migration guide                    |
-|:------------:|:-------------:|:------------------:|:-----------------------------------------------------:|
-| ✨ active    |       9       |        N/A         | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
-| ⚠ maintained |       9       |        9.0         | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-| ╳ deprecated |       8       |        8.3         | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
-| ╳ deprecated |       7       |        7.6         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-| ╳ deprecated |       6       |        6.5         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ╳ deprecated |       5       |        5.0         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated |       3       |        3.0         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-| ╳ deprecated |       2       |        2.1         |                           -                           |
-| ╳ deprecated |       1       |        1.7         |                           -                           |
+|    State     | Major Version | Last Minor Release |                     Migration guide                     |
+| :----------: | :-----------: | :----------------: | :-----------------------------------------------------: |
+| ⚠ maintained |      11       |        N/A         | [migrate to 11](MIGRATION.md#migrating-from-v10-to-11)  |
+| ╳ deprecated |      10       |        10.0        | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
+| ╳ deprecated |       9       |        9.0         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)  |
+| ╳ deprecated |       8       |        8.3         |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)  |
+| ╳ deprecated |       7       |        7.6         |  [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7)  |
+| ╳ deprecated |       6       |        6.5         |  [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6)  |
+| ╳ deprecated |       5       |        5.0         |  [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5)  |
+| ╳ deprecated |       4       |        4.0         |  [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4)  |
+| ╳ deprecated |       3       |        3.0         |  [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3)  |
+| ╳ deprecated |       2       |        2.1         |                            -                            |
+| ╳ deprecated |       1       |        1.7         |                            -                            |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-share/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-social-follow/MIGRATION.md
+++ b/components/o-social-follow/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migration Guide
+## Migration Guide
 
-## Migrating from v2 to v3
+### Migrating from v1 to v2
 
 This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
 
@@ -16,11 +16,3 @@ To upgrade, replace the following "o2" components with their "o3" equivalent:
 - [o-big-number](../o-big-number/MIGRATION.md)
 - [o-quote](../o-quote/MIGRATION.md)
 - [o-fonts](../o-fonts/MIGRATION.md)
-
-### Migrating from v1 to v2
-
-Support for Bower and version 2 of the Origami Build Service have been removed.
-
-CSS is also now wrapped into a `gAudio` mixin.
-
-Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).

--- a/components/o-social-follow/README.md
+++ b/components/o-social-follow/README.md
@@ -21,6 +21,7 @@ It should not be used to re-share content, for this use [o-share](https://regist
 ## Socials
 
 Social icons currently supported include:
+
 - twitter
 - facebook
 - linkedin
@@ -31,23 +32,24 @@ Social icons currently supported include:
 
 `o-social-share` markup consists of a containing section with label, to group social media links in a landmark. Within the container is 1 or more social media links `o-social-follow-icon`. A visually hidden label identifies the icon to users of assistive technologies such as screen readers.
 
-
 The following example shows a single Facebook link.
-```html
-<section class="o-social-follow"  aria-label="Follow on social media">
 
+```html
+<section class="o-social-follow" aria-label="Follow on social media">
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--facebook">
 		<span class="o-social-follow-icon__label">on facebook</span>
 	</a>
-
 </section>
 ```
 
 The next example shows multiple social media links.
+
 ```html
 <section class="o-social-follow" aria-label="Follow on social media">
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--twitter">
-		<span class="o-social-follow-icon__label">on X, formerly know as Twitter</span>
+		<span class="o-social-follow-icon__label"
+			>on X, formerly know as Twitter</span
+		>
 	</a>
 	<a href="#" class="o-social-follow-icon o-social-follow-icon--facebook">
 		<span class="o-social-follow-icon__label">on facebook</span>
@@ -101,19 +103,35 @@ Call `oSocialFollow` to output all `o-social-follow` styles.
 We recommend passing the `oSocialFollow` mixin an optional argument `$opts`, to specify styles granularly and keep your CSS bundle small.
 
 For example:
+
 ```scss
-@include oSocialFollow($opts: (
-	'icons': ('twitter', 'facebook', 'linkedin', 'youtube', 'instagram'),
-	'standalone': true,
-	'themes': ('inverse')
-));
+@include oSocialFollow(
+	$opts: (
+		'icons': (
+			'twitter',
+			'facebook',
+			'linkedin',
+			'youtube',
+			'instagram',
+		),
+		'standalone': true,
+		'themes': (
+			'inverse',
+		),
+	)
+);
 ```
+
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       2       |        n/a         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                          N/A                          |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-social-follow/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-stepped-progress/MIGRATION.md
+++ b/components/o-stepped-progress/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v3 to v4
 

--- a/components/o-stepped-progress/README.md
+++ b/components/o-stepped-progress/README.md
@@ -23,14 +23,12 @@ The markup for a stepped progress element is as follows. Markup is commented for
 Base class and attribute hook for JavaScript
 -->
 <div class="o-stepped-progress" data-o-component="o-stepped-progress">
-
 	<!--
 	The steps live in an ordered list, which ensures that assistive
 	technology can read this appropriately. Also if CSS does not load
 	then a sensible fallback is in place
 	-->
 	<ol class="o-stepped-progress__steps">
-
 		<!--
 		Each step lives inside a list item. This item does not need any
 		classes applied. The following modifiers are available to indicate
@@ -40,23 +38,25 @@ Base class and attribute hook for JavaScript
 		  - error: a step that something went wrong with
 		-->
 		<li>
-
 			<!--
 			The step itself is either an anchor or span element. We encourage
 			using an anchor for completed and current steps, as this offers a
 			better experience for screen readers - all of the text inside is
 			read as one block rather than each span separately.
 			-->
-			<a href="/step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+			<a
+				href="/step-1"
+				class="o-stepped-progress__step o-stepped-progress__step--complete"
+			>
 				<span class="o-stepped-progress__label">
-
 					<!--
 					The o-stepped-progress__status element is required to make
 					the step label accessible for assistive technology, older
 					browsers, and when CSS fails to load. This element is
 					visually hidden otherwise
 					-->
-					Example Completed Step <span class="o-stepped-progress__status">(completed)</span>
+					Example Completed Step
+					<span class="o-stepped-progress__status">(completed)</span>
 				</span>
 			</a>
 		</li>
@@ -66,9 +66,13 @@ Base class and attribute hook for JavaScript
 		and including accessible text in the label
 		-->
 		<li>
-			<a href="/step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+			<a
+				href="/step-2"
+				class="o-stepped-progress__step o-stepped-progress__step--current"
+			>
 				<span class="o-stepped-progress__label">
-					Example Current Step <span class="o-stepped-progress__status">(current step)</span>
+					Example Current Step
+					<span class="o-stepped-progress__status">(current step)</span>
 				</span>
 			</a>
 		</li>
@@ -81,12 +85,9 @@ Base class and attribute hook for JavaScript
 		-->
 		<li>
 			<span class="o-stepped-progress__step">
-				<span class="o-stepped-progress__label">
-					Example Future Step
-				</span>
+				<span class="o-stepped-progress__label"> Example Future Step </span>
 			</span>
 		</li>
-
 	</ol>
 </div>
 ```
@@ -133,6 +134,7 @@ Once you have stepped progress instances, you can interact with them using the m
 There is [full API documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-stepped-progress/jsdoc).
 
 ## Sass
+
 To output all styles call `@include oSteppedProgress();` in your Sass:
 
 ```scss
@@ -161,38 +163,38 @@ The `oSteppedProgress` mixin is used to output base styles as well as styles for
 If you wish to specify a subset of themes to output styles for, you can pass in an `$opts` parameter (see [themes](#themes) for available options):
 
 ```scss
-@include oSteppedProgress($opts: (
-	'themes': (
-		'heavy'
+@include oSteppedProgress(
+	$opts: (
+		'themes': (
+			'heavy',
+		),
 	)
-));
+);
 ```
 
 There is [full Sass documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-stepped-progress/sassdoc).
-
 
 ### Themes
 
 This table outlines all of the possible themes you can request in the [`oSteppedProgress` mixin](#mixin-osteppedprogress):
 
-| Theme  | Description                               | Brand support |
-|--------|-------------------------------------------|---------------|
-| heavy  | Label with heavier lines and larger type. | internal      |
-
+| Theme | Description                               | Brand support |
+| ----- | ----------------------------------------- | ------------- |
+| heavy | Label with heavier lines and larger type. | internal      |
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.2 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.0 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.0 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.2         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.0         |                          N/A                          |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-stepped-progress/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
-
 
 ## Licence
 

--- a/components/o-subs-card/MIGRATION.md
+++ b/components/o-subs-card/MIGRATION.md
@@ -1,10 +1,28 @@
 # Migration Guide
 
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v5 to v6
 
 The "more/less" toggle has been updated to use a `button` element instead of a `div` to improve keyboard accessibility.
 
 To upgrade, replace the "read more" `div` tag with a `button` tag in your markup.
+
 ```diff
 - <div class='o-subs-card__read-more'>Read more</div>
 + <button class='o-subs-card__read-more'></button>
@@ -12,6 +30,7 @@ To upgrade, replace the "read more" `div` tag with a `button` tag in your markup
 
 The button copy is added dynamically, and now includes hidden text to provide screen reader users more context based on the title of the card e.g. `Read more about Print`.
 A new CSS class has been added to have visually hidden elements but to be used for screen reader users.
+
 ```
 .o-subs-card-visually-hidden {
     @include oNormaliseVisuallyHidden;
@@ -21,6 +40,7 @@ A new CSS class has been added to have visually hidden elements but to be used f
 ## Migrating from v4 to v5
 
 The mixin `oSubsCard` has been renamed to `oSubsCardBase`.
+
 ```diff
 - @include oSubsCard;
 + @include oSubsCardBase;
@@ -29,7 +49,7 @@ The mixin `oSubsCard` has been renamed to `oSubsCardBase`.
 A "primary mixin" has been added named `oSubsCard`. The primary mixin outputs all component CSS when no arguments are given.
 
 ```scss
-@import '@financial-times/o-subs-card/main';
+@import "@financial-times/o-subs-card/main";
 @include oSubsCard();
 ```
 
@@ -112,6 +132,7 @@ The markup has been rearranged, and some classes have been removed.
 		</div>
 + </div>
 ```
+
 - There is now a container to wrap all cards in.
 - The `<img>` tag has been removed.
 - The charge value has been moved into a `div` of its down and has been moved below the 'select' button.

--- a/components/o-subs-card/README.md
+++ b/components/o-subs-card/README.md
@@ -20,7 +20,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 The subs card will expand to fill the width of its containing element, so you will need to build your own container system depending on how you want to arrange your page. An example of several subs packages together in a collection can be seen in the demos on the [registry](http://registry.origami.ft.com/components/o-subs-card)
 
 ```html
-<div class='o-subs-card__container'>
+<div class="o-subs-card__container">
 	<div class="o-subs-card" data-o-component="o-subs-card">
 		<div class="o-subs-card__top">
 			<div class="o-subs-card__copy-title">Subscription title</div>
@@ -29,14 +29,16 @@ The subs card will expand to fill the width of its containing element, so you wi
 				<div class="o-subs-card__charge__value">£XX.XX per week</div>
 			</div>
 		</div>
-		<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
+		<div class="o-subs-card__copy-pitch">
+			Access to FT.com on your desktop, mobile and tablet
+		</div>
 		<div class="o-subs-card__expander">
 			<div class="o-subs-card__copy-details">
 				<ul class="o-subs-card__copy-benefits">
 					<li>...</li>
 				</ul>
 			</div>
-			<button class='o-subs-card__read-more'></button>
+			<button class="o-subs-card__read-more"></button>
 		</div>
 	</div>
 </div>
@@ -53,14 +55,20 @@ To include all o-subs-card classes use the `oSubsCard` mixin with no arguments:
 To include a specific theme, pass an options argument with the themes to include:
 
 ```scss
-@include oSubsCard($opts: (
-	'themes': ('discount', 'b2b')
-));
+@include oSubsCard(
+	$opts: (
+		"themes": (
+			"discount",
+			"b2b",
+		),
+	)
+);
 ```
 
 ### Themes
 
 The subs card standard theme is teal. To differentiate amongst different subscription tiers, there are some additional themes which you can use with either the mixin or concrete classes:
+
 - `oSubsCardDiscount` / `o-subs-card--discount`
 - `oSubsCardB2B` / `o-subs-card--b2b`
 
@@ -73,37 +81,39 @@ If you aren't using the Build Service, you'll need to fire an `o.DOMContentLoade
 Firing an o.DOMContentLoaded event
 
 ```js
-document.addEventListener('DOMContentLoaded', function() {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+document.addEventListener("DOMContentLoaded", function () {
+	document.dispatchEvent(new CustomEvent("o.DOMContentLoaded"));
 });
 ```
 
 Instantiating your own oSubsCard:
 
 ```js
-import { SubsCard } from '@financial-times/o-subs-card';
+import { SubsCard } from "@financial-times/o-subs-card";
 subsCard.init();
 ```
+
 This will instantiate all subs-cards within the document. Alternatively you can pass in a HTMLElement, or String to be used as a selector to limit the scope of the instantiated subs cards to only child elements of the passed in scope.
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-⚠ maintained | 5 | 5.0.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-⚠ maintained | 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.4 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.1 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.2         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |       5.0.1        | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.1         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.4         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.1         |                          N/A                          |
 
-***
+---
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-subs-card/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-syntax-highlight/MIGRATION.md
+++ b/components/o-syntax-highlight/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration Guide
 
+### Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v3 to v4
 
 V4 has dropped support for use through Bower. If you have been using Bower, you will need to follow the [bower to npm migration guide](https://origami.ft.com/documentation/tutorials/bower-to-npm/).
@@ -8,7 +25,6 @@ When using Sass, you will need to add `node_modules` to your `includePath` as we
 
 - Update your code to use the fully qualified package name, i.e.: `@import "@financial-times/o-brand/main"`, or
 - Also add `node_modules/@financial-times` to the Sass include path
-
 
 ### Migrating from v2 to v3
 
@@ -38,6 +54,7 @@ The main change is how to output syntax-specific styling:
 ```
 
 The primary mixin requires an `$opts` parameter that accepts a 'languages' list. That list can contains any or all of the following:
+
 - 'bash'
 - 'css'
 - 'diff'

--- a/components/o-syntax-highlight/README.md
+++ b/components/o-syntax-highlight/README.md
@@ -6,7 +6,7 @@ A syntax highlighter for Origami-supported documentation that wraps [PrismJs](ht
 - [Overview](#overview)
 - [Markup](#markup)
 - [JavaScript](#javascript)
-	- [Construction](#construction)
+  - [Construction](#construction)
 - [Sass](#sass)
 - [Troubleshooting](#troubleshooting)
 - [Migration guide](#migration-guide)
@@ -29,8 +29,9 @@ o-syntax-highlight works with a single class. As long as this class is present i
 **`<pre>` is whitespace sensitive, so it is important to follow the markup to get the correct spacing for your syntax.**
 
 Every language has its own set of styles — in order to highlight html for example, you would need:
+
 ```html
-<div class="demo" data-o-component='o-syntax-highlight'>
+<div class="demo" data-o-component="o-syntax-highlight">
 	<pre tabindex="0">
 		<code class="o-syntax-highlight--json">
 <!-- everything in this element will be highlighted, including this comment! -->
@@ -46,10 +47,11 @@ Every language has its own set of styles — in order to highlight html for exam
 	"numbers": 1
 }</code>
 		</pre>
-	</div>
+</div>
 ```
 
 The same is true for all other available languages:
+
 - Javascript: `o-syntax-highlight--js` _or_ `o-syntax-highlight--javascript`
 - HTML: `o-syntax-highlight--html`
 - CSS: `o-syntax-highlight--css`
@@ -59,8 +61,9 @@ The same is true for all other available languages:
 - DIFF: `o-syntax-highlight--diff`
 
 It is worth pointing out that the wrapper can hold any html elements. So long as all of the code blocks within the wrapper are written as described above, o-syntax-highlight will ignore everything else.
+
 ```html
-<div class="demo" data-o-component='o-syntax-highlight'>
+<div class="demo" data-o-component="o-syntax-highlight">
 	<div class="example">
 		<p></p>
 		<p></p>
@@ -79,6 +82,7 @@ However, when highlighting `HTML`, there is a caveat.
 Because of the way in which the `<code>` tag works, if you want to highlight markup **which has already been declared**, you will have to replace and `<` with `&lt;` in order for the markup to be read as a string instead of actual HTML.
 
 For example:
+
 ```
 <pre tabindex="0">
 	<code class="o-syntax-highlight--html">
@@ -101,6 +105,7 @@ You must either construct an `o-syntax-highlight` object or fire the `o.DOMConte
 ### Construction
 
 In order to use `o-syntax-highlight` with already declared markup, you can use:
+
 ```js
 import oSyntaxHighlight from '@financial-times/o-syntax-highlight';
 oSyntaxHighlight.init();
@@ -110,7 +115,9 @@ If you are initialising the component imperatively, you will need to supply a st
 
 ```js
 import oSyntaxHighlight from '@financial-times/o-syntax-highlight';
-const highlighter = new oSyntaxHighlight('code to highlight', { language: 'html'});
+const highlighter = new oSyntaxHighlight('code to highlight', {
+	language: 'html',
+});
 
 myElement.innerHTML = highlighter.tokenise();
 ```
@@ -124,15 +131,20 @@ You can include highlighting for all languages by calling:
 ```
 
 You can also be more specific about which languages you would like styling output for by using an `$opts` map:
+
 ```scss
-	@include oSyntaxHighlight($opts: (
+@include oSyntaxHighlight(
+	$opts: (
 		'languages': (
 			'html',
-			'json'
-		)
-	));
+			'json',
+		),
+	)
+);
 ```
+
 `o-syntax-highlight` accepts the following options:
+
 - 'bash'
 - 'css'
 - 'diff'
@@ -142,7 +154,6 @@ You can also be more specific about which languages you would like styling outpu
 - 'scss' _or_ 'sass'
 - 'yaml'
 
-
 ## Troubleshooting
 
 ### How do I use Marked to convert Markdown files to HTML with o-syntax-highlight code blocks?
@@ -151,17 +162,17 @@ When using [Marked](https://www.npmjs.com/package/marked) it is possible to over
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 3 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.0 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.1 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.6.4 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.0         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.1         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |       1.6.4        |                           -                           |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-syntax-highlight/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
-
 
 ## Licence
 

--- a/components/o-table/MIGRATION.md
+++ b/components/o-table/MIGRATION.md
@@ -1,5 +1,22 @@
 ## Migration
 
+### Migrating from v9 to v10
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v8 to v9
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
@@ -7,6 +24,7 @@ Support for Bower and version 2 of the Origami Build Service have been removed.
 Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).
 
 ### Migrating from v7 to v8
+
 - `.o-table-margin-bottom` has been removed. Use `.o-spacing-s4` from [o-spacing](https://registry.origami.ft.com/components/o-spacing) instead, or apply margin as needed, depending on the context of the table e.g.
 
 ```
@@ -14,6 +32,7 @@ Follow [the migration guide on the Origami website](https://origami.ft.com/docum
 	margin-bottom: oSpacingByName('s4');
 }
 ```
+
 - v8 updates the required version on the [o-icons](https://registry.origami.ft.com/components/o-icons) and [ftdomdelegate](https://github.com/Financial-Times/ftdomdelegate) dependencies. Make sure your project still builds with the new versions!
 
 #### Updated dependencies
@@ -23,14 +42,16 @@ If you have any conflicts while installing this version, you'll need to first up
 its dependencies. See [the Bower config for these](./bower.json).
 
 ### Migrating from v6 to v7
+
 - To prevent errors in IE11, add support for `IntersectionObserverEntry` and `IntersectionObserver` with the [polyfill service](https://polyfill.io/).
 - Data attribute `data-o-table-order` has been removed. To specify a custom sort order on `td` cells use `data-o-table-sort-value` instead.
 - Markup updates:
-	- Previous `o-table` demos omitted `thead` and `tbody` from `table`, including their child `tr` element. Ensure your table markup is correct and includes `thead` and `tbody`.
-	- `o-table__caption--top` and `o-table__caption--bottom` have been removed. Remove these classes and add a heading within the caption (e.g. a `<h2>`) with appropriate styling.
-	- `o-table-wrapper` is now `o-table-scroll-wrapper`
-	- Responsive tables are now wrapped in a container div `o-table-container` and overlay div `o-table-overlay-wrapper`.
-	- Responsive tables should now have their type specified via a data attribute e.g. `data-o-table-responsive="overflow"`.
+  - Previous `o-table` demos omitted `thead` and `tbody` from `table`, including their child `tr` element. Ensure your table markup is correct and includes `thead` and `tbody`.
+  - `o-table__caption--top` and `o-table__caption--bottom` have been removed. Remove these classes and add a heading within the caption (e.g. a `<h2>`) with appropriate styling.
+  - `o-table-wrapper` is now `o-table-scroll-wrapper`
+  - Responsive tables are now wrapped in a container div `o-table-container` and overlay div `o-table-overlay-wrapper`.
+  - Responsive tables should now have their type specified via a data attribute e.g. `data-o-table-responsive="overflow"`.
+
 ```diff
 +<div class="o-table-container">
 +    <div class="o-table-overlay-wrapper">
@@ -49,17 +70,19 @@ its dependencies. See [the Bower config for these](./bower.json).
 +   </div>
 +</div>
 ```
+
 - Style updates:
-	- The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. [see o-spacing](https://registry.origami.ft.com/components/o-spacing):
-	```scss
-		.o-table {
-			margin-bottom: oSpacingByName('s4');
-		}
-	```
-	If it's not possible or practical to apply a custom margin, add the  `o-table-margin-bottom` class to the table (or table container, if you are using a responsive table).
+  - The default bottom margin of `o-table` has been removed. Please apply the margin as needed, depending on the context of the table e.g. [see o-spacing](https://registry.origami.ft.com/components/o-spacing):
+  ```scss
+  .o-table {
+  	margin-bottom: oSpacingByName('s4');
+  }
+  ```
+  If it's not possible or practical to apply a custom margin, add the `o-table-margin-bottom` class to the table (or table container, if you are using a responsive table).
 - Mixin updates:
-	- All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit your product.
-	- `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name in your markup. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
+  - All `o-table` mixins have been made private except for a new mixin `@include oTable($opts)`. It accepts an feature list `$opts` to include `o-table` styles granularly. Replace previous mixins with one call to the [`oTable` mixin with an optional `$opts` flag](#silent-mode). Please [contact us](#contact) if this does not suit your product.
+  - `oTableAll` has been replaced with `oTable`, which does not accept a class name `$classname`. Instead use the default `o-table` class name in your markup. As the mixin now output classes directly, they must not be wrapped in an `.o-table` class manually.
+
 ```diff
 -.o-table {
 -    @include oTableBase;
@@ -74,31 +97,32 @@ its dependencies. See [the Bower config for these](./bower.json).
 
 + @include oTable($opts: ('responsive-flat'));
 ```
+
 - JS updates:
-	- `OTable` returns an instance of `BasicTable`, `FlatTable`, `ScrollTable`, `OverflowTable` on construction, according to the type of table. All extend from `BaseTable`.
-	- Table properties removed or made private: `isResponsive`, `listeners`.
-	- Table methods removed or made private:
-		- `wrap`: for a responsive table manually wrap the table in a container and wrapper class.
-		```html
-		<div class="o-table-container">
-			<div class="o-table-scroll-wrapper">
-				<!-- table -->
-			</div>
-		</div>
-		```
-		- `sortRowsByColumn`: arguments are simplified `sortRowsByColumn(columnIndex, sortOrder)` over `sortRowsByColumn(index, sortAscending, isNumericValue, type)`, where `columnIndex` replaces `index` and `sortOrder` is "ascending" or "descending".
-		- `removeEventListeners`
-		- `dispatch`
+  - `OTable` returns an instance of `BasicTable`, `FlatTable`, `ScrollTable`, `OverflowTable` on construction, according to the type of table. All extend from `BaseTable`.
+  - Table properties removed or made private: `isResponsive`, `listeners`.
+  - Table methods removed or made private:
+    - `wrap`: for a responsive table manually wrap the table in a container and wrapper class.
+    ```html
+    <div class="o-table-container">
+    	<div class="o-table-scroll-wrapper">
+    		<!-- table -->
+    	</div>
+    </div>
+    ```
+    - `sortRowsByColumn`: arguments are simplified `sortRowsByColumn(columnIndex, sortOrder)` over `sortRowsByColumn(index, sortAscending, isNumericValue, type)`, where `columnIndex` replaces `index` and `sortOrder` is "ascending" or "descending".
+    - `removeEventListeners`
+    - `dispatch`
 - Events:
-	- Event detail `detail.oTable` is now `detail.instance`.
-	- Event detail `detail.sort` is now `detail.sortOrder`, the value is now "ascending" rather than "ASC", and "descending" rather than "DES".
-	- The `oTable.sorting` event target is no longer the `th` of the column being sorted. To find the sorted column use [the event detail](#get-the-sorted-column-heading-from-a-sort-event) instead.
+  - Event detail `detail.oTable` is now `detail.instance`.
+  - Event detail `detail.sort` is now `detail.sortOrder`, the value is now "ascending" rather than "ASC", and "descending" rather than "DES".
+  - The `oTable.sorting` event target is no longer the `th` of the column being sorted. To find the sorted column use [the event detail](#get-the-sorted-column-heading-from-a-sort-event) instead.
 - Colour:
-	- All [deprecated colour usecases](https://github.com/Financial-Times/o-table/blob/533811d7f8673a7576a31608df8cd71777ff39d5/src/scss/_deprecated.scss) have been removed, ensure `o-table` colours are not used in your project.
+  - All [deprecated colour usecases](https://github.com/Financial-Times/o-table/blob/533811d7f8673a7576a31608df8cd71777ff39d5/src/scss/_deprecated.scss) have been removed, ensure `o-table` colours are not used in your project.
 
 ### Migrating from v5 to v6
 
-- The v6 release updates the dependencies `o-colors` and `o-typography`. Ensure your project  builds successfully and upgrade dependencies if required.
+- The v6 release updates the dependencies `o-colors` and `o-typography`. Ensure your project builds successfully and upgrade dependencies if required.
 
 ### Migrating from v4 to v5
 

--- a/components/o-table/README.md
+++ b/components/o-table/README.md
@@ -581,17 +581,18 @@ document.addEventListener('oTable.sorting', event => {
 
 ## Migration
 
-|    State     | Major Version | Last Minor Release |                    Migration guide                    |
-| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       9       |        N/A         | [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9) |
-|  ✨ active   |       8       |        8.1         | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
-| ⚠ maintained |       7       |        7.4         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-| ╳ deprecated |       6       |        6.9         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ╳ deprecated |       5       |        5.2         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ╳ deprecated |       4       |        4.1         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated |       3       |        3.0         |                          N/A                          |
-| ╳ deprecated |       2       |        2.0         |                          N/A                          |
-| ╳ deprecated |       1       |        1.7         |                          N/A                          |
+|    State     | Major Version | Last Minor Release |                     Migration guide                     |
+| :----------: | :-----------: | :----------------: | :-----------------------------------------------------: |
+| ⚠ maintained |      10       |        N/A         | [migrate to v10](MIGRATION.md#migrating-from-v9-to-v10) |
+| ╳ deprecated |       9       |        9.3         |  [migrate to v9](MIGRATION.md#migrating-from-v8-to-v9)  |
+| ╳ deprecated |       8       |        8.1         |  [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8)  |
+| ╳ deprecated |       7       |        7.4         |  [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7)  |
+| ╳ deprecated |       6       |        6.9         |  [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6)  |
+| ╳ deprecated |       5       |        5.2         |  [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5)  |
+| ╳ deprecated |       4       |        4.1         |  [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4)  |
+| ╳ deprecated |       3       |        3.0         |                            -                            |
+| ╳ deprecated |       2       |        2.0         |                            -                            |
+| ╳ deprecated |       1       |        1.7         |                            -                            |
 
 ## Contact
 

--- a/components/o-tabs/MIGRATION.md
+++ b/components/o-tabs/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v8 to v9
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v7 to v8
 
@@ -30,8 +47,14 @@ The component no longer uses `ul` and `li` elements and instead uses `div` and `
 E.G.
 
 This is the old html:
+
 ```html
-<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
+<ul
+	data-o-component="o-tabs"
+	class="o-tabs"
+	role="tablist"
+	data-o-tabs-update-url
+>
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab"><a href="#tabContent3">Tab 3</a></li>
@@ -39,8 +62,14 @@ This is the old html:
 ```
 
 And this is the new html:
+
 ```html
-<div data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
+<div
+	data-o-component="o-tabs"
+	class="o-tabs"
+	role="tablist"
+	data-o-tabs-update-url
+>
 	<a role="tab" href="#tabContent1">Tab 1</a>
 	<a role="tab" href="#tabContent2">Tab 2</a>
 	<a role="tab" href="#tabContent3">Tab 3</a>

--- a/components/o-tabs/README.md
+++ b/components/o-tabs/README.md
@@ -230,13 +230,15 @@ This table outlines some of the possible button themes you can request in the [`
 
 |    State     | Major Version | Last Minor Release |                    Migration guide                    |
 | :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
-|  ✨ active   |       6       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-| ⚠ maintained |       6       |        6.2         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-| ⚠ maintained |       5       |        5.0         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠ maintained |       4       |        4.3         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated |       3       |        3.0         |                          N/A                          |
-| ╳ deprecated |       2       |        2.2         |                          N/A                          |
-| ╳ deprecated |       1       |        1.0         |                          N/A                          |
+| ⚠ maintained |       9       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v8-to-v9) |
+| ╳ deprecated |       8       |        8.1         | [migrate to v7](MIGRATION.md#migrating-from-v7-to-v8) |
+| ╳ deprecated |       7       |         -          | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.2         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.0         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.3         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.0         |                           -                           |
+| ╳ deprecated |       2       |        2.2         |                           -                           |
+| ╳ deprecated |       1       |        1.0         |                           -                           |
 
 ## Contact
 

--- a/components/o-teaser-collection/MIGRATION.md
+++ b/components/o-teaser-collection/MIGRATION.md
@@ -1,8 +1,25 @@
 ## Migration Guide
 
+### Migrating from v4 to v5
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ### Migrating from v3 to v4
 
-The sass variable named `$o-teaser-collection-is-silent` has had its default value changed from `false` to `true. This means no CSS will be output when `o-teaser-collection`  is imported. Include the `oTeaserCollection` primary mixin to output `o-teaser-collection` CSS.
+The sass variable named `$o-teaser-collection-is-silent` has had its default value changed from `false` to `true. This means no CSS will be output when `o-teaser-collection` is imported. Include the`oTeaserCollection`primary mixin to output`o-teaser-collection` CSS.
 
 Support for Bower and version 2 of the Origami Build Service have been removed.
 
@@ -15,11 +32,13 @@ Confirm the `o-teaser-collection__heading--inverse` modifier is used with `o-tea
 `oTeaserCollection` has changed, it now outputs all `o-teaser-collection` css by default. See the [README](./README.md) for `oTeaserCollection` options to include css granularly.
 
 #### Renamed Mixins
+
 - `oTeaserCollectionHeading` has been renamed `oTeaserCollectionContentHeading` to indicate it has no top level selector. It now excepts an `$opts` map to include parts of the heading more granularly (such as styles for a child anchor tag). See the README for more details.
 
 #### Removed Mixins
 
 If your project uses these mixins replace with a single call to `oTeaserCollection` instead. See the README for `oTeaserCollection` options.
+
 - oTeaserCollectionAssassination
 - oTeaserCollectionStream
 - oTeaserCollectionFrontPage
@@ -33,8 +52,8 @@ If your project uses these mixins replace with a single call to `oTeaserCollecti
 - oTeaserCollectionMidSlice
 - oTeaserCollectionTopStandalone
 
-
 `oTeaserCollectionHeadingLink` has also been removed. If your project is using this mixin to avoid outputting the heading border (divider) use `oTeaserCollectionContentHeading` without the `divider` or `sizes` option. This will output the base heading styles plus the child anchor styles, without the divider.
+
 ```diff
 .my-heading {
 -   // Custom styles replicating the collection heading.
@@ -47,6 +66,7 @@ If your project uses these mixins replace with a single call to `oTeaserCollecti
 ```
 
 `oTeaserCollectionHeadingBorderTypography` has been removed. Replace with a call to `oTeaserCollectionContentHeading` without the `anchor` option.
+
 ```diff
 .my-heading {
 -   @include oTeaserCollectionHeadingBorderTypography;
@@ -69,6 +89,6 @@ its dependencies. See [the Bower config for these](./bower.json).
 
 ### Migrating from v1 to v2
 
-- Deprecated classname `.o-teaser-collection--top-top-stories` has now been removed. __Resolution__ Please use `.o-teaser-collection--top-standalone` instead.
+- Deprecated classname `.o-teaser-collection--top-top-stories` has now been removed. **Resolution** Please use `.o-teaser-collection--top-standalone` instead.
 - Styles for `.o-teaser-collection--stream .o-teaser__action` have been removed.
 - The o-colors and o-typography dependencies have been bumped to the latest major. These will create bower conflicts which should be resolved by updating to the newest release of o-colors and o-typography.

--- a/components/o-teaser-collection/README.md
+++ b/components/o-teaser-collection/README.md
@@ -31,14 +31,14 @@ Teaser collections can be arranged using [o-grid](http://registry.origami.ft.com
 
 ```html
 <div class="o-teaser-collection o-teaser-collection--numbered">
-	<h2 class="o-teaser-collection__heading o-teaser-collection__heading--full-width">Most read</h2>
+	<h2
+		class="o-teaser-collection__heading o-teaser-collection__heading--full-width"
+	>
+		Most read
+	</h2>
 	<ol class="o-teaser-collection__items">
-		<li class="o-teaser-collection__item">
-			teaser goes here
-		</li>
-		<li class="o-teaser-collection__item">
-			teaser goes here
-		</li>
+		<li class="o-teaser-collection__item">teaser goes here</li>
+		<li class="o-teaser-collection__item">teaser goes here</li>
 	</ol>
 </div>
 ```
@@ -58,32 +58,44 @@ To include all styles call the `oTeaserCollection` mixin.
 `o-teaser-collection` css may be included granularly by passing options to the `oTeaserCollection` mixin.
 
 ```scss
-@include oTeaserCollection($opts: (
-	'collections': ('special'), // o-teaser-collection--special
-	'headings': ('inverse'), // o-teaser-collection__heading--inverse
-	'items': ('stretched') // o-teaser-collection__item--stretched
-));
+@include oTeaserCollection(
+	$opts: (
+		'collections': (
+			'special',
+		),
+		// o-teaser-collection--special
+		'headings':
+			(
+				'inverse',
+			),
+		// o-teaser-collection__heading--inverse
+		'items':
+			(
+				'stretched',
+			)
+			// o-teaser-collection__item--stretched,,,,,,,,
+	)
+);
 ```
 
 Options include:
 
-| Key                 | Possible Values                                                                                                                       | Classes Output  |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| collections         | 'horizontal', 'special', 'numbered', 'big-story', 'assassination', 'assassination-related', 'mid-slice', 'stream', 'top-standalone'   | `o-teaser-collection--[option]`. Apply to `o-teaser-collection`, e.g. `class="o-teaser-collection o-teaser-collection--horizontal"`                                  |
-| headings            | 'inverse', 'full-width', 'half-width', 'small'                                                                                        | `o-teaser-collection__heading--[option]`. Apply to `o-teaser-collection__heading`, e.g. `class="o-teaser-collection__heading o-teaser-collection__heading--inverse"` |
-| items               | 'stretched'                                                                                                                           | `o-teaser-collection__item--[option]`. Apply to `o-teaser-collection__item`, e.g. `o-teaser-collection__item o-teaser-collection__item--stretched`                   |
-
+| Key         | Possible Values                                                                                                                     | Classes Output                                                                                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| collections | 'horizontal', 'special', 'numbered', 'big-story', 'assassination', 'assassination-related', 'mid-slice', 'stream', 'top-standalone' | `o-teaser-collection--[option]`. Apply to `o-teaser-collection`, e.g. `class="o-teaser-collection o-teaser-collection--horizontal"`                                  |
+| headings    | 'inverse', 'full-width', 'half-width', 'small'                                                                                      | `o-teaser-collection__heading--[option]`. Apply to `o-teaser-collection__heading`, e.g. `class="o-teaser-collection__heading o-teaser-collection__heading--inverse"` |
+| items       | 'stretched'                                                                                                                         | `o-teaser-collection__item--[option]`. Apply to `o-teaser-collection__item`, e.g. `o-teaser-collection__item o-teaser-collection__item--stretched`                   |
 
 Use `o-teaser-collection--numbered` to number the list of teasers in the collection, see an [example in the registry](http://registry.origami.ft.com/components/o-teaser-collection).
 
 Use `o-teaser-collection--special` to add a darker background across the full width of the containing relative element, see an [example in the registry](http://registry.origami.ft.com/components/o-teaser-collection).
-
 
 ### Headings
 
 To include heading styles output `o-teaser-collection__heading` classes using the `oTeaserCollection` mixin as described above. If your component or project would like to replicate only some parts of the heading style use `oTeaserCollectionContentHeading`.
 
 For example, to replicate only the basic heading style pass an empty map:
+
 ```scss
 .my-heading {
 	@include oTeaserCollectionContentHeading($opts: ());
@@ -91,39 +103,45 @@ For example, to replicate only the basic heading style pass an empty map:
 ```
 
 To replicate the header fully, but without the size modifiers such as `o-teaser-collection__heading--full-width`:
+
 ```scss
 .my-heading {
-	@include oTeaserCollectionContentHeading($opts: (
-		'anchor': true, // Include child anchor styles `.my-heading > a`
-		'divider': true, // Include the top border styles.
-		'sizes': () // Do not output size modifiers such as `.my-heading--small`.
-	));
+	@include oTeaserCollectionContentHeading(
+		$opts: (
+			'anchor': true,
+			// Include child anchor styles `.my-heading > a`
+			'divider': true,
+			// Include the top border styles.
+			'sizes': ()
+				// Do not output size modifiers such as `.my-heading--small`.,,,,,,,,
+		)
+	);
 }
 ```
 
 `oTeaserCollectionContentHeading` options include:
 
-| Key       | Possible Values                                 | Description                                                                  |
-|-----------|-------------------------------------------------|-------------------------------------------------------------------------------|
-| anchor    | Boolean                                         | Output styles for a nested anchor tag, for a collection heading with a link.  |
-| divider   | Boolean                                         | Output styles for a divider (border) above the collection heading.            |
-| sizes     | 'inverse', 'full-width', 'half-width', 'small'  | Output modifier classes for different sizes headings e.g. `my-heading--small`.|
-
+| Key     | Possible Values                                | Description                                                                    |
+| ------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| anchor  | Boolean                                        | Output styles for a nested anchor tag, for a collection heading with a link.   |
+| divider | Boolean                                        | Output styles for a divider (border) above the collection heading.             |
+| sizes   | 'inverse', 'full-width', 'half-width', 'small' | Output modifier classes for different sizes headings e.g. `my-heading--small`. |
 
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.0 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.3 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.2 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       5       |        N/A         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.2         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.0         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.2         |                           -                           |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-teaser-collection/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-teaser/MIGRATION.md
+++ b/components/o-teaser/MIGRATION.md
@@ -1,10 +1,27 @@
 # Migration guide
 
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v5 to v6
 
 v6 drops support for Bower and version 2 of the Origami Build Service.
 
-Follow  [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).
+Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).
 
 ## Migrating from v4 to v5
 
@@ -15,6 +32,7 @@ v5 introduces the font FinancierDisplayWeb at medium weight and normal style. To
 ### Colours and Colour Usecases
 
 All [o-teaser colours and colour usecases](https://github.com/Financial-Times/o-teaser/blob/v3.5.9/src/scss/_color-use-cases.scss) have been renamed to include an o-colors namespace. For example:
+
 - `o-teaser` is now `o-teaser/base`
 - `fast-ft` is now `o-teaser/fast-ft`
 - `o-teaser-tag` is now `o-teaser/tag`
@@ -33,6 +51,7 @@ The deprecated `o-teaser-promoted-prefix` usecase has been removed. Include [o-l
 ### Markup
 
 Deprecated classes have been removed:
+
 - Replace `o-teaser--big-video` with `o-teaser--has-video`
 - Replace `o-teaser__duration` with `o-teaser__tag-suffix`
 

--- a/components/o-teaser/README.md
+++ b/components/o-teaser/README.md
@@ -26,9 +26,16 @@ The basic markup structure for a teaser will look something like this:
 <div class="o-teaser o-teaser--small">
 	<div class="o-teaser__content">
 		<a href="#" class="o-teaser__tag">World</a>
-		<h2 class="o-teaser__heading"><a href="#">Japan sells negative yield 10-year bonds</a></h2>
+		<h2 class="o-teaser__heading">
+			<a href="#">Japan sells negative yield 10-year bonds</a>
+		</h2>
 		<div class="o-teaser__timestamp">
-			<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="2016-02-29T12:35:48Z">2016-02-29T12:35:48Z</time>
+			<time
+				data-o-component="o-date"
+				class="o-teaser__timestamp-date"
+				datetime="2016-02-29T12:35:48Z"
+				>2016-02-29T12:35:48Z</time
+			>
 		</div>
 	</div>
 </div>
@@ -38,14 +45,13 @@ Optionally include the [o-date](https://registry.origami.ft.com/components/o-dat
 
 Teasers support a wide array of [elements](#supported-elements) and can be customised using several [themes](#themes) and should be used as required. For a full list of examples including example markup, see [o-teaser in the Registry](http://registry.origami.ft.com/components/o-teaser).
 
-
 ### Images
 
 To add an image to a teaser, you should use the following markup structure:
 
 ```html
 <div class="o-teaser__image-container">
-	<img src="{image-src}" class="o-teaser__image" alt="{alt text}"/>
+	<img src="{image-src}" class="o-teaser__image" alt="{alt text}" />
 </div>
 ```
 
@@ -54,11 +60,10 @@ To support lazy-loading of images you can use the `o-teaser__image-placeholder` 
 ```html
 <div class="o-teaser__image-container">
 	<div class="o-teaser__image-placeholder">
-		<img src="{image-src}" class="o-teaser__image" alt="{alt text}"/>
+		<img src="{image-src}" class="o-teaser__image" alt="{alt text}" />
 	</div>
 </div>
 ```
-
 
 ### Supported elements
 
@@ -78,10 +83,10 @@ The following elements are supported by default:
 .o-teaser__related-item     # A single item of a related content list
 ```
 
-
 ## Sass
 
 To include styles for all teasers call `oTeaser`:
+
 ```scss
 @import '@financial-times/o-teaser/main';
 
@@ -91,10 +96,19 @@ To include styles for all teasers call `oTeaser`:
 Teasers are made up of various elements (e.g. heading, standfirst, timestamp) and a series of themes (e.g. small, large, video). Pass a list of `elements` and `themes` in an options `$opts` argument to include only the styles you need:
 
 ```scss
-@include oTeaser($opts:(
-	'elements': ('default', 'images'),
-	'themes': ('small', 'large', 'video')
-));
+@include oTeaser(
+	$opts: (
+		'elements': (
+			'default',
+			'images',
+		),
+		'themes': (
+			'small',
+			'large',
+			'video',
+		),
+	)
+);
 ```
 
 Elements are specified via groups, they include:
@@ -168,23 +182,23 @@ Uses the `o-teaser--audio` modifier.
 
 [View example on the Registry](http://registry.origami.ft.com/components/o-teaser#demo-audio)
 
-
 ## Migration guide
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 6 | N/A  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-⚠ maintained | 5 | 5.2  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.5  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.5  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.9 | - |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.4         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.2         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.5         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.5         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.9         |                           -                           |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-teaser/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-tooltip/MIGRATION.md
+++ b/components/o-tooltip/MIGRATION.md
@@ -1,4 +1,21 @@
-# Migration
+# Migration Guide
+
+## Migrating from v5 to v6
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v4 to v5
 

--- a/components/o-tooltip/README.md
+++ b/components/o-tooltip/README.md
@@ -3,9 +3,9 @@
 o-tooltip is a component usually used for annotating or highlighting bits of user interface.
 
 - [Usage](#usage)
-	- [Markup](#markup)
-	- [JavaScript](#javascript)
-	- [Sass](#sass)
+  - [Markup](#markup)
+  - [JavaScript](#javascript)
+  - [Sass](#sass)
 - [Customisation](#customisation)
 - [Migration guide](#migration-guide)
 - [Contact](#contact)
@@ -20,31 +20,33 @@ Check out [how to include Origami components in your project](https://origami.ft
 This HTML demonstrates the declarative way to instantiate o-tooltip. If you are using the Build Service or firing your own `o.DOMContentLoaded` event, this is all you need to create a tooltip.
 
 ```html
-<div class='demo-tooltip-target' id="declarative-tooltip-target">
+<div class="demo-tooltip-target" id="declarative-tooltip-target">
 	A bit of UI to annotate
 </div>
 
-<div data-o-component="o-tooltip"
+<div
+	data-o-component="o-tooltip"
 	data-o-tooltip-position="below"
 	data-o-tooltip-target="declarative-tooltip-target"
-	data-o-tooltip-show-on-construction=true
-	id="my-tooltip-element">
-	<div class='o-tooltip-content'>
-		Some text to go in the tooltip
-	</div>
+	data-o-tooltip-show-on-construction="true"
+	id="my-tooltip-element"
+>
+	<div class="o-tooltip-content">Some text to go in the tooltip</div>
 </div>
 ```
 
 This HTML is an example of the imperative alternative:
+
 ```html
-<div class='demo-tooltip-container'>
-	<button class='o-buttons o-buttons--big imperative-tooltip-target'>
+<div class="demo-tooltip-container">
+	<button class="o-buttons o-buttons--big imperative-tooltip-target">
 		Button description text/icon
 	</button>
 </div>
 ```
 
 Attributes can be set declaratively, or passed in on instantiation in an options object. A full list of data attributes:
+
 - `data-o-tooltip-target`: Required. An ID selector for the target of the tooltip (the thing it points to)
 - `data-o-tooltip-position`: Optional. The preferred position of the tooltip relative to the target. Can be one of `above`, `below`, `left`, `right`. If there isn't room to render the tooltip where the option passed in would render it, this value is flipped (above becomes below, left becomes right). Defaults to below. You can also specify a different position per viewport width ('default', 'S', 'M', 'L', 'XL') eg data-o-tooltip-position-s="left". The position will fall back to the default in data-o-tooltip-position, otherwise 'below'.
 - `data-o-tooltip-show-on-construction`: Optional. Boolean value. Set to true if you want the tooltip to be rendered immediately after it is constructed. Defaults to false.
@@ -64,30 +66,33 @@ Attributes can be set declaratively, or passed in on instantiation in an options
 To apply a theme declaratively add the class `o-tooltip o-tooltip--[theme name]` to your markup. E.g. to output a tooltip for the professional theme:
 
 ```html
-<div class='demo-tooltip-target' id="declarative-tooltip-target">
+<div class="demo-tooltip-target" id="declarative-tooltip-target">
 	A bit of UI to annotate
 </div>
 
-<div data-o-component="o-tooltip"
+<div
+	data-o-component="o-tooltip"
 	class="o-tooltip o-tooltip--professional"
 	data-o-tooltip-position="below"
 	data-o-tooltip-target="declarative-tooltip-target"
-	data-o-tooltip-show-on-construction=true
-	id="my-tooltip-element">
-	<div class='o-tooltip-content'>
-		Some text to go in the tooltip
-	</div>
+	data-o-tooltip-show-on-construction="true"
+	id="my-tooltip-element"
+>
+	<div class="o-tooltip-content">Some text to go in the tooltip</div>
 </div>
 ```
 
 You may also set a theme imperatively using the JavaScript API.
+
 ### JavaScript
 
 No code will run automatically unless you are using the Build Service.
 You must either construct an `o-tooltip` object or fire an `o.DOMContentLoaded` event, which oTooltip listens for.
 
 #### Constructing an o-tooltip
+
 If you have setup your tooltip declaratively, the following applies:
+
 ```js
 import Tooltip from '@financial-times/o-tooltip';
 const tooltipEl = Document.getElementById('my-tooltip-element');
@@ -103,8 +108,8 @@ const opts = {
 	target: 'tooltip-target-imperative',
 	content: 'Click to save to somewhere',
 	showOnConstruction: true,
-	position: 'right'
-}
+	position: 'right',
+};
 
 const tooltip = new Tooltip(tooltipEl, opts);
 ```
@@ -125,8 +130,8 @@ const opts = {
 	content: 'Click to save to somewhere',
 	showOnConstruction: true,
 	position: 'above',
-	appendToBody: true
-}
+	appendToBody: true,
+};
 const tooltip = new Tooltip(tooltipEl, opts);
 ```
 
@@ -135,7 +140,7 @@ _Note! this property can only be used only when constructing the tooltip declara
 #### Firing an oDomContentLoaded event
 
 ```js
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
 ```
@@ -159,49 +164,59 @@ The `oTooltip` mixin is used to output tooltip selectors and styles. This output
 ```
 
 You may also choose to output tooltips for only specific themes:
+
 ```scss
-@include oTooltip($opts: ('professional'));
+@include oTooltip(
+	$opts: (
+		'professional',
+	)
+);
 ```
 
 There is [full Sass documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-tooltip/sassdoc).
+
 ## Custom Themes
 
 Include the `oTooltipAddTheme` mixin to output a custom tooltip theme. The mixin accepts a name for your theme and a map of options:
 
 - `name`: The name of your theme. This is used for the modifier class output `o-tooltip--[name]`.
 - `opts`: A map of options for your theme.
-	- `background-color`: The background color for your tooltip.
-	- `foreground-color`: The foreground/text color for your tooltip.
-	- `close-foreground-color` (optional): The colour of the close button. If not set the `foreground-color` is used.
+  - `background-color`: The background color for your tooltip.
+  - `foreground-color`: The foreground/text color for your tooltip.
+  - `close-foreground-color` (optional): The colour of the close button. If not set the `foreground-color` is used.
 
 The following example shows how to add a custom theme named "my-product-modifier", with a slate background and white foreground. Instead of "my-product-modifier" choose a descriptive name that includes your project name, so it's clear where the custom theme is added.
 
 ```scss
 // Outputs CSS class o-tooltip--my-product-modifier.
 // Uses an o-colors function to fetch Origami colour values.
-@include oTooltipAddTheme('my-product-modifier', (
-	'background-color': oColorsByName('slate'),
-	'foreground-color': oColorsByName('white')
-));
+@include oTooltipAddTheme(
+	'my-product-modifier',
+	(
+		'background-color': oColorsByName('slate'),
+		'foreground-color': oColorsByName('white'),
+	)
+);
 ```
 
 This will output a CSS class `o-tooltip--[name]`. Add this class to your tooltip to view your custom theme.
 
 ## Migration Guide
 
-| State | Major Version | Last Minor Release | Migration guide |
-| :---: | :---: | :---: | :---: |
-| ✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-| ⚠︎ maintained | 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-| ╳ deprecated | 3 | 3.5 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-| ╳ deprecated | 2 | 2.3.7 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-| ╳ deprecated | 1 | 1.1.1 | N/A |
+|     State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :-----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠︎ maintained |       6       |        N/A         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated  |       5       |        5.4         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated  |       4       |        4.1         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated  |       3       |        3.5         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated  |       2       |       2.3.7        | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated  |       1       |       1.1.1        |                          N/A                          |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-tooltip/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
-***
+---
 
 ## Licence
 

--- a/components/o-top-banner/MIGRATION.md
+++ b/components/o-top-banner/MIGRATION.md
@@ -1,6 +1,6 @@
-# Migration Guide
+## Migration Guide
 
-## Migrating from v2 to v3
+### Migrating from v1 to v2
 
 This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
 
@@ -16,11 +16,3 @@ To upgrade, replace the following "o2" components with their "o3" equivalent:
 - [o-big-number](../o-big-number/MIGRATION.md)
 - [o-quote](../o-quote/MIGRATION.md)
 - [o-fonts](../o-fonts/MIGRATION.md)
-
-### Migrating from v1 to v2
-
-Support for Bower and version 2 of the Origami Build Service have been removed.
-
-CSS is also now wrapped into a `gAudio` mixin.
-
-Follow [the migration guide on the Origami website](https://origami.ft.com/documentation/tutorials/bower-to-npm/).

--- a/components/o-top-banner/README.md
+++ b/components/o-top-banner/README.md
@@ -27,16 +27,16 @@ Use the following markup for `o-top-banner`. Replace `o-top-banner--[theme]` wit
 
 ```html
 <div class="o-top-banner o-top-banner--[theme]">
-    <div class="o-top-banner__container">
-        <div class="o-top-banner__content">
-            <h2 class="o-top-banner__heading">Your heading</h2>
-            <p class="o-top-banner__copy">You main copy goes here.</p>
-        </div>
+	<div class="o-top-banner__container">
+		<div class="o-top-banner__content">
+			<h2 class="o-top-banner__heading">Your heading</h2>
+			<p class="o-top-banner__copy">You main copy goes here.</p>
+		</div>
 
-        <div class="o-top-banner__actions">
-            <a href="#" class="o-top-banner__button">Your CTA</a>
-        </div>
-    </div>
+		<div class="o-top-banner__actions">
+			<a href="#" class="o-top-banner__button">Your CTA</a>
+		</div>
+	</div>
 </div>
 ```
 
@@ -45,28 +45,37 @@ Use the following markup for `o-top-banner`. Replace `o-top-banner--[theme]` wit
 Use `@include oTopBanner()` to include styles for all `o-top-banner` [themes](#themes).
 
 ```scss
-@import "@financial-times/o-top-banner";
+@import '@financial-times/o-top-banner';
 
 @include oTopBanner();
 ```
 
-
 Or use the `$opts` argument to output only the specific [themes](#themes) you need:
-```scss
-@import "@financial-times/o-top-banner";
 
-@include oTopBanner($opts: (
-    'themes': ('new-world', 'professional-inverse')
-));
+```scss
+@import '@financial-times/o-top-banner';
+
+@include oTopBanner(
+	$opts: (
+		'themes': (
+			'new-world',
+			'professional-inverse',
+		),
+	)
+);
 ```
+
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 1 | 1.0 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       2       |        N/A         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.1         |                           -                           |
 
 ## Contact
+
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/origami/issues/new?labels=o-top-banner,components), visit [#origami-support](https://financialtimes.slack.com/messages/#origami-support/) or email [origami.support@ft.com](mailto:origami.support@ft.com).
 
 ## Licence
+
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/components/o-topper/MIGRATION.md
+++ b/components/o-topper/MIGRATION.md
@@ -1,4 +1,22 @@
 # Migration guide
+
+## Migrating from v6 to v7
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
+
 ## Migrating from v5 to v6
 
 `o-topper` no longer includes JavaScript to select the correct topper for JSON-formatted FT articles and flags. This helper was deeply tied to the FT.com content store, and included hardcoded UUIDs and business logic beyond the scope of Origami. Origami components focus on providing reusable user interfaces – without business logic assumptions which could limit their use outside specific groups or use-cases.
@@ -10,6 +28,7 @@ To migrate, replace `o-topper` JavaScript with [`n-map-content-to-topper`](https
 +import mapContentToTopper from '@financial-times/n-map-content-to-topper';
 const topper = mapContentToTopper(ftArticle, flags);
 ```
+
 ## Migrating from v4 to v5
 
 The velvet topper (previously used to indicate life and arts) has been removed.
@@ -89,8 +108,8 @@ All other mixins have been removed. Instead make a single `oTopper`, with releva
 - `oTopperColors`
 - `oTopperColor`
 
-
 E.g to include all styles:
+
 ```diff
 -$o-topper-is-silent: false;
 -@import 'o-topper/main';
@@ -100,6 +119,7 @@ E.g to include all styles:
 ```
 
 E.g to include only base styles and some themes:
+
 ```diff
 -.o-topper--branded {
 -	@include _oTopperThemeBranded;

--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -1,6 +1,7 @@
 # o-topper
 
 This component is used for styling the topper sections of an article.
+
 - [Usage](#usage)
 - [Markup](#markup)
 - [Sass](#sass)
@@ -20,12 +21,17 @@ The basic markup structure for a topper will look something like this:
 <div class="o-topper o-topper--basic o-topper--color-o3-color-palette-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
-			<a href="https://www.ft.com/german-election" class="o-topper__topic">German election</a>
+			<a href="https://www.ft.com/german-election" class="o-topper__topic"
+				>German election</a
+			>
 		</div>
 		<h1 class="o-topper__headline">
 			Merkel reaches ‘grand coalition’ breakthrough with Social Democrats
 		</h1>
-		<div class="o-topper__standfirst">Move raises hopes of end to political deadlock that has gripped Germany since September</div>
+		<div class="o-topper__standfirst">
+			Move raises hopes of end to political deadlock that has gripped Germany
+			since September
+		</div>
 	</div>
 
 	<div class="o-topper__background"></div>
@@ -36,23 +42,23 @@ Toppers support a wide array of [elements](#supported-elements) and can be custo
 
 ### Supported elements
 
-| Element                     | Use case                                                                                           |
-|-----------------------------|----------------------------------------------------------------------------------------------------|
-| `.o-topper__content`        | Main content area of topper. Required parent of all elements except `__visual` and `__background`. |
-| `.o-topper__tags`           | Wrapper element for the article concept tag elements `__brand`, `__topic` and `__opinion-genre`.   |
-| `.o-topper__brand`          | A concept tag that represents a brand, e.g. "The Big Read".                                        |
-| `.o-topper__topic`          | A concept tag that represents a topic or generic concept.                                          |
-| `.o-topper__opinion-genre`  | A concept tag that represents the abstract Opinion genre.                                          |
-| `.o-topper__columnist`      | Wrapper element for `__columnist-name`. Should be placed below the headline and standfirst.        |
-| `.o-topper__columnist-name` | Represents the columnist that wrote an Opinion genre article.                                      |
-| `.o-topper__headline`       | The main headline of the article.                                                                  |
-| `.o-topper__standfirst`     | A short introduction to the article.                                                               |
-| `.o-topper__background`     | Element used to display the editorially-chosen colored background of the topper. Must be empty.    |
-| `.o-topper__visual`         | Wrapper for the visual elements `__picture` and `__image`. Should be a `<figure>` tag.             |
-| `.o-topper__picture`        | A `<picture>` tag visual element.                                                                  |
-| `.o-topper__image`          | An `<img>` tag visual element, usually used as fallback for a `<picture>`.                         |
+| Element                     | Use case                                                                                                                                                                                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.o-topper__content`        | Main content area of topper. Required parent of all elements except `__visual` and `__background`.                                                                                                                                                 |
+| `.o-topper__tags`           | Wrapper element for the article concept tag elements `__brand`, `__topic` and `__opinion-genre`.                                                                                                                                                   |
+| `.o-topper__brand`          | A concept tag that represents a brand, e.g. "The Big Read".                                                                                                                                                                                        |
+| `.o-topper__topic`          | A concept tag that represents a topic or generic concept.                                                                                                                                                                                          |
+| `.o-topper__opinion-genre`  | A concept tag that represents the abstract Opinion genre.                                                                                                                                                                                          |
+| `.o-topper__columnist`      | Wrapper element for `__columnist-name`. Should be placed below the headline and standfirst.                                                                                                                                                        |
+| `.o-topper__columnist-name` | Represents the columnist that wrote an Opinion genre article.                                                                                                                                                                                      |
+| `.o-topper__headline`       | The main headline of the article.                                                                                                                                                                                                                  |
+| `.o-topper__standfirst`     | A short introduction to the article.                                                                                                                                                                                                               |
+| `.o-topper__background`     | Element used to display the editorially-chosen colored background of the topper. Must be empty.                                                                                                                                                    |
+| `.o-topper__visual`         | Wrapper for the visual elements `__picture` and `__image`. Should be a `<figure>` tag.                                                                                                                                                             |
+| `.o-topper__picture`        | A `<picture>` tag visual element.                                                                                                                                                                                                                  |
+| `.o-topper__image`          | An `<img>` tag visual element, usually used as fallback for a `<picture>`.                                                                                                                                                                         |
 | `.o-topper__image-credit`   | Element showing credit/copyright for the `__picture` or `__image`, where no image caption is given. If an image caption is provided alongside credit/copyright information use `.o-topper__image-caption` instead. Should be a `<figcaption>` tag. |
-| `.o-topper__image-caption`   | Element showing caption and credit/copyright together for the `__picture` or `__image`. Should be a `<figcaption>` tag. |
+| `.o-topper__image-caption`  | Element showing caption and credit/copyright together for the `__picture` or `__image`. Should be a `<figcaption>` tag.                                                                                                                            |
 
 ### Themes
 
@@ -89,10 +95,10 @@ These colors affect the background of the `.o-topper__background` and `.o-topper
 
 ### Modifiers
 
-| Modifier                                | Use case                                                                                           |
-|-----------------------------------------|----------------------------------------------------------------------------------------------------|
-| `.o-topper__content--background-box`    | Create a background box around the element `.o-topper__content`. The background colour of the box  |
-|                                         | will be defined based on the background of the topper                                              |
+| Modifier                             | Use case                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `.o-topper__content--background-box` | Create a background box around the element `.o-topper__content`. The background colour of the box |
+|                                      | will be defined based on the background of the topper                                             |
 
 ## Sass
 
@@ -106,66 +112,78 @@ To include all o-topper CSS include `oTopper`:
 To include o-topper styles granularly specify which elements, themes, and colours to output styles for using the options `$opts` argument:
 
 ```scss
-@include oTopper($opts: (
-	'themes': (
-		'branded', // .o-topper--branded
-		'opinion', // .o-topper--opinion
-		'has-headshot', // .o-topper--has-headshot
-		'full-bleed-offset',
-		'split-text-left',
-		'split-text-center',
-		'full-bleed-image-center',
-		'full-bleed-image-left',
-		'package',
-		'package-extra',
-		'package-extra-wide',
-		'package-special-report',
-		'right-rail',
-		'centered',
-		'deep-landscape',
-	),
-	'elements': (
-		'content', // .o-topper__content
-		'visual', // .o-topper__visual
-		'background', // .o-topper__background
-		'headline',
-		'headline--large',
-		'summary',
-		'standfirst',
-		'summary--body',
-		'tags',
-		'columnist',
-		'columnist-name',
-		'brand',
-		'topic',
-		'read-next',
-		'image',
-		'image-credit',
-		'image-caption'
-	),
-	'colors': (
-		'o3-color-palette-white', // .o-topper--color-o3-color-palette-white
-		'o3-color-palette-black', // .o-topper--color-o3-color-palette-black
-		'o3-color-palette-claret',
-		'o3-color-palette-oxford',
-		'o3-color-palette-paper',
-		'o3-color-palette-slate',
-		'o3-color-palette-wheat',
-		'o3-color-palette-crimson',
-		'o3-color-palette-sky',
+@include oTopper(
+	$opts: (
+		'themes': (
+			'branded',
+			// .o-topper--branded
+			'opinion',
+			// .o-topper--opinion
+			'has-headshot',
+			// .o-topper--has-headshot
+			'full-bleed-offset',
+			'split-text-left',
+			'split-text-center',
+			'full-bleed-image-center',
+			'full-bleed-image-left',
+			'package',
+			'package-extra',
+			'package-extra-wide',
+			'package-special-report',
+			'right-rail',
+			'centered',
+			'deep-landscape',
+		),
+		'elements': (
+			'content',
+			// .o-topper__content
+			'visual',
+			// .o-topper__visual
+			'background',
+			// .o-topper__background
+			'headline',
+			'headline--large',
+			'summary',
+			'standfirst',
+			'summary--body',
+			'tags',
+			'columnist',
+			'columnist-name',
+			'brand',
+			'topic',
+			'read-next',
+			'image',
+			'image-credit',
+			'image-caption',
+		),
+		'colors': (
+			'o3-color-palette-white',
+			// .o-topper--color-o3-color-palette-white
+			'o3-color-palette-black',
+			// .o-topper--color-o3-color-palette-black
+			'o3-color-palette-claret',
+			'o3-color-palette-oxford',
+			'o3-color-palette-paper',
+			'o3-color-palette-slate',
+			'o3-color-palette-wheat',
+			'o3-color-palette-crimson',
+			'o3-color-palette-sky',
+		),
 	)
-));
+);
 ```
+
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 6 | N/A  | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-⚠ maintained | 5 | N/A  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.1  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.7  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.2  | - |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       7       |        N/A         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.0         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |         -          | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.0         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.7         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.2         |                           -                           |
 
 ## Contact
 

--- a/components/o-video/MIGRATION.md
+++ b/components/o-video/MIGRATION.md
@@ -1,5 +1,21 @@
-
 # Migration Guide
+
+## Migrating from v7 to v8
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons. It also removes peer dependencies from deprecated "o2" components.
+
+To upgrade, replace the following "o2" components with their "o3" equivalent:
+
+- [o-normalise](../o-normalise/MIGRATION.md)
+- [o-spacing](../o-spacing/MIGRATION.md)
+- [o-colors](../o-colors/MIGRATION.md)
+- [o-icons](../o-icons/MIGRATION.md)
+- [o-buttons](../o-buttons/MIGRATION.md)
+- [o-typography](../o-typography/MIGRATION.md)
+- [o-editorial-typography](../o-editorial-typography/MIGRATION.md)
+- [o-big-number](../o-big-number/MIGRATION.md)
+- [o-quote](../o-quote/MIGRATION.md)
+- [o-fonts](../o-fonts/MIGRATION.md)
 
 ## Migrating from v6 to v7
 
@@ -56,7 +72,7 @@ Version 4 introduces the new majors of `o-colors`, `o-loading`, and `o-typograph
 
 The `videoSource` and `captionsUrl` options no longer exist. Captions can be toggled on or off by using the `showCaptions` boolean. This defaults to `true`, so if the video data (now gotten from the [next-media-api](https://github.com/Financial-Times/next-media-api)) contains captions, then the component will present them to the user.
 
-Since 3.0, if `showCaptions` is *true*, calling `addVideo()` directly will throw an error. This is due to the fact the component needs to source the `captionsUrl` first. Either leave `autorender` as *true* or call `init()` instead.
+Since 3.0, if `showCaptions` is _true_, calling `addVideo()` directly will throw an error. This is due to the fact the component needs to source the `captionsUrl` first. Either leave `autorender` as _true_ or call `init()` instead.
 
 In the previous version, the call to the API could be skipped by using the `data` option, passing in a response from `next-video-api`. This option can still be used, but the data will now need to match a `next-media-api` response – [see an example](https://next-media-api.ft.com/v1/eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526).
 
@@ -91,7 +107,6 @@ The `placeholdertitle` property no longer exists, it has been replaced by `place
 ```
 
 The `optimumwidth` property is no longer used for the video width, it is now only used for the poster image width. To choose an optimum video width you can use the new property `optimumvideowidth`.
-
 
 ```diff
 <div class="video-container">

--- a/components/o-video/README.md
+++ b/components/o-video/README.md
@@ -6,8 +6,8 @@ Creates a video player and attaches analytics. Also supports pre roll ads.
 - [Markup](#markup)
 - [Sass](#sass)
 - [JavaScript](#javascript)
-	- [Config](#config)
-	- [With a playlist](#with-a-playlist)
+  - [Config](#config)
+  - [With a playlist](#with-a-playlist)
 - [Testing](#testing)
 - [Migration](#migration)
 - [Contact](#contact)
@@ -34,7 +34,7 @@ Videos can be styled in three different sizes, namely 'small', 'medium' and 'lar
 In order to output every size and attribute of `o-video`, you'll need to include the following:
 
 ```scss
-@import '@financial-times/o-video/main';
+@import "@financial-times/o-video/main";
 
 @include oVideo();
 ```
@@ -42,24 +42,31 @@ In order to output every size and attribute of `o-video`, you'll need to include
 You can be more selective about which sizes and attributes you would like to output, by using an `$opts` map. It accepts the following lists:
 
 **attributes**
+
 - `'ads'`
 - `'info'`
 - `'placeholder'`
 
 **sizes**
+
 - `'small'`
 - `'medium'`
 - `'large'`
 
 ```scss
-@import '@financial-times/o-video';
+@import "@financial-times/o-video";
 
-@include oVideo($opts:(
-	'attributes': ('ads'),
-	'sizes': ('small', 'large')
-))
-
-// outputs small and large video styles, and styling support for ads
+@include oVideo(
+	$opts: (
+		"attributes": (
+			"ads",
+		),
+		"sizes": (
+			"small",
+			"large",
+		),
+	)
+); // outputs small and large video styles, and styling support for ads
 ```
 
 ## JavaScript
@@ -67,13 +74,13 @@ You can be more selective about which sizes and attributes you would like to out
 In order to initialise `o-video`, you will need the following:
 
 ```js
-import Video from '@financial-times/o-video';
+import Video from "@financial-times/o-video";
 const opts = {
 	id: 4165329773001,
 	optimumwidth: 710,
 	placeholder: true,
-	classes: ['video'],
-	systemcode: 'my-biz-ops-code'
+	classes: ["video"],
+	systemcode: "my-biz-ops-code",
 };
 const video = new Video(document.body, opts);
 ```
@@ -83,10 +90,10 @@ const video = new Video(document.body, opts);
 Where `opts` is an optional object with properties
 
 - `id` `[String]` Source's ID of the video (`brightcoveId` or `uuid`)
-- `autorender` `[Boolean]` Whether to have the video render automatically. If-false* then you will need to call `init()` when ready
+- `autorender` `[Boolean]` Whether to have the video render automatically. If-false\* then you will need to call `init()` when ready
 - `optimumwidth` `[Number]` The optimum width of the video placeholder image
 - `optimumvideowidth` `[Number]` The optimum width of the video itself, used when there are multiple video renditions available to
- decide which to display (the smallest one that's at least as large as this width, if it exists)
+  decide which to display (the smallest one that's at least as large as this width, if it exists)
 - `placeholder` `[Boolean]` Show just the poster image, load (and play) video on click
 - `placeholderHint` `[String]` An optional hint to display alongside the play icon (defaults to empty)
 - `placeholderInfo` `[Array]` A list of extra information to display on the placeholder (Available: title, description, brand)
@@ -97,19 +104,20 @@ Where `opts` is an optional object with properties
 - `data` `[Object]` JSON object representing a [response from next-media-api](https://next-media-api.ft.com/v1/eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526). If used, the component will not make a call to the API and use this data instead.
 - `systemcode` `[String]` a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems) for the project using `o-video`.
 - `adsTargeting` (previously `targeting`) `[Object]` object containing the targeting data used to configure, serve and track video ads. If targeting is passed as an option but is missing properties, it will use the properties set in the `defaultTargeting` object instead. here is what each property on the targeting object affects:
-	- `site:` refers to the ad unit that contains the line items for video creatives (part of the ad request).
-	- `position:` sets the `pos` param on the ad request which is used to target video ads similar to how `pos: native` is used to target partner content.
-	- `sizes:` also added to ad request to specify video ad sizes to be returned.
-	- `videoId:` added to targeting as a param for targeting ads at a specific video.
-	- `customParams` `[Object]` object containing custom parameters that are used to request video ads. Values include, but are not limited to: user ID, page type, subscription level, resolution.
+  - `site:` refers to the ad unit that contains the line items for video creatives (part of the ad request).
+  - `position:` sets the `pos` param on the ad request which is used to target video ads similar to how `pos: native` is used to target partner content.
+  - `sizes:` also added to ad request to specify video ad sizes to be returned.
+  - `videoId:` added to targeting as a param for targeting ads at a specific video.
+  - `customParams` `[Object]` object containing custom parameters that are used to request video ads. Values include, but are not limited to: user ID, page type, subscription level, resolution.
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 
 ```html
-<div data-o-component="o-video o-video--large"
+<div
+	data-o-component="o-video o-video--large"
 	data-o-video-id="4165329773001"
-	data-o-video-optimumwidth="710">
-</div>
+	data-o-video-optimumwidth="710"
+></div>
 ```
 
 ### With a playlist
@@ -117,24 +125,24 @@ The config options can also be set as data attribute to instantiate the module d
 Playlists may take a queue of videos and play them one after another.
 
 ```js
-import Video from '@financial-times/o-video';
+import Video from "@financial-times/o-video";
 
-const queue = [
-	'4165329773001',
-	'4907997821001',
-	'4165329773001'
-];
+const queue = ["4165329773001", "4907997821001", "4165329773001"];
 
-const player = new Video(document.body, { autorender: false, systemcode: 'my-biz-ops-code' });
+const player = new Video(document.body, {
+	autorender: false,
+	systemcode: "my-biz-ops-code",
+});
 const playlist = new Video.Playlist({ player, queue });
 
-document.querySelector('.next-btn').onclick = () => playlist.next();
-document.querySelector('.prev-btn').onclick = () => playlist.prev();
+document.querySelector(".next-btn").onclick = () => playlist.next();
+document.querySelector(".prev-btn").onclick = () => playlist.prev();
 ```
 
 The queue is an `array` containing Brightcove video ID strings.
 
 ## Testing
+
 See [Origami build tools](https://github.com/Financial-Times/origami-build-tools).
 
 ```
@@ -143,18 +151,18 @@ $ obt test
 
 Requires Firefox (v38.0.0 to test with polyfills and mirror CI)
 
-
 ## Migration
 
-State | Major Version | Last Minor Release | Migration guide |
-:---: | :---: | :---: | :---:
-✨ active | 7 | N/A | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
-⚠ maintained | 6 | 6.1 | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
-╳ deprecated | 5 | 5.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
-╳ deprecated| 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-╳ deprecated | 3 | 3.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-╳ deprecated | 2 | 2.5 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
-╳ deprecated | 1 | 1.4 | N/A |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+| ⚠ maintained |       8       |        N/A         | [migrate to v8](MIGRATION.md#migrating-from-v7-to-v8) |
+| ╳ deprecated |       7       |        7.3         | [migrate to v7](MIGRATION.md#migrating-from-v6-to-v7) |
+| ╳ deprecated |       6       |        6.1         | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+| ╳ deprecated |       5       |        5.1         | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+| ╳ deprecated |       4       |        4.1         | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+| ╳ deprecated |       3       |        3.1         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.5         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.4         |                           -                           |
 
 ## Contact
 

--- a/components/o3-button/MIGRATION.md
+++ b/components/o3-button/MIGRATION.md
@@ -2,7 +2,9 @@
 
 ## Migrating from v2 to v3
 
-o3-button v3 introduces renamed icons, with an updated api to match. It also includes some potentially visually breaking changes.
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons.
+
+To upgrade, first ensure peer dependencies including `o3-foundation` are upgraded.
 
 ### Rename icons
 

--- a/components/o3-editorial-typography/README.md
+++ b/components/o3-editorial-typography/README.md
@@ -384,9 +384,11 @@ import {Heading} from '@financial-times/o3-editorial-typography/cjs';
 
 ## Migration
 
-|   State   | Major Version | Last Minor Release | Migration guide |
-| :-------: | :-----------: | :----------------: | :-------------: |
-| ✨ active |       1       |        N/A         |       N/A       |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+|  ✨ active   |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |         -          |                          N/A                          |
 
 ## Contact
 

--- a/components/o3-foundation/README.md
+++ b/components/o3-foundation/README.md
@@ -127,7 +127,7 @@ Use typography use cases to style body content with bolder styles:
 
 ```html
 <p class="o3-type-body-base">
-  This is <strong class="o3-type-body">really</strong> important.
+	This is <strong class="o3-type-body">really</strong> important.
 </p>
 ```
 
@@ -260,7 +260,7 @@ See our documentation website for a [full list of spacing tokens](https://origam
 
 ### Grid
 
->  ⚠️ **NOTE:** Grid is experimental and open to change without notice. Please contact the Origami team before using.
+> ⚠️ **NOTE:** Grid is experimental and open to change without notice. Please contact the Origami team before using.
 
 The `o3-grid` system, provided by `o3-foundation`, standardises usage of grid across ft. The `o3-grid` is responsive on different screen sizes and differs from [`o-grid`](https://o2.origami.ft.com/?path=/docs/o2-core_components-o-grid-readme--docs) component. For more detailed guidelines on grid system check our documentation for [`o3-grid`](https://origami-beta.ft.com/guides/grid/).
 
@@ -349,9 +349,11 @@ For advanced usage `o3-foundation` provides CSS Custom Properties for grid that 
 
 ## Migration
 
-|   State   | Major Version | Last Minor Release | Migration guide |
-| :-------: | :-----------: | :----------------: | :-------------: |
-| ✨ active |       1       |        N/A         |       N/A       |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+|  ✨ active   |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |         -          |                          N/A                          |
 
 ## Contact
 

--- a/components/o3-social-sign-in/MIGRATION.md
+++ b/components/o3-social-sign-in/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration Guide
+
+## Migrating from v2 to v3
+
+This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons.
+
+To upgrade, first ensure peer dependencies including `o3-foundation` are upgraded.

--- a/components/o3-social-sign-in/README.md
+++ b/components/o3-social-sign-in/README.md
@@ -3,10 +3,10 @@
 A button for social sign-in providers.
 
 - [o3-social-sign-in](#o3-social-sign-in)
-    - [Markup](#markup)
-    - [Migration](#migration)
-    - [Contact](#contact)
-    - [Licence](#licence)
+  - [Markup](#markup)
+  - [Migration](#migration)
+  - [Contact](#contact)
+  - [Licence](#licence)
 
 ## Markup
 
@@ -15,22 +15,21 @@ o3-social-sign-in supports [JSX templates for React users](#jsx), or direct HTML
 Two providers are supported: Google and Apple. We recommend you follow their guides to integrate `o3-social-sign-on` to
 their sign-in flows:
 
-* [Displaying Sign in with Apple buttons on the web](https://developer.apple.com/documentation/sign_in_with_apple/displaying_sign_in_with_apple_buttons_on_the_web)
-* [Building a custom Google Sign-In button](https://developers.google.com/identity/sign-in/web/build-button)
+- [Displaying Sign in with Apple buttons on the web](https://developer.apple.com/documentation/sign_in_with_apple/displaying_sign_in_with_apple_buttons_on_the_web)
+- [Building a custom Google Sign-In button](https://developers.google.com/identity/sign-in/web/build-button)
 
 ```html
-
 <button
-        id="appleid-signin"
-        class="o3-social-sign-in-button o3-social-sign-in-button--apple"
+	id="appleid-signin"
+	class="o3-social-sign-in-button o3-social-sign-in-button--apple"
 >
-  <span class="o3-social-sign-in-button__copy">Sign in with Apple</span>
+	<span class="o3-social-sign-in-button__copy">Sign in with Apple</span>
 </button>
 <button
-        id="gSignInWrapper"
-        class="o3-social-sign-in-button o3-social-sign-in-button--google"
+	id="gSignInWrapper"
+	class="o3-social-sign-in-button o3-social-sign-in-button--google"
 >
-  <span class="o3-social-sign-in-button__copy">Sign in with Google</span>
+	<span class="o3-social-sign-in-button__copy">Sign in with Google</span>
 </button>
 ```
 
@@ -43,6 +42,7 @@ When using the TSX component, ids will automatically be set. For Apple sign in, 
 Google it is `gSignInWrapper`.
 
 By default, the TSX component will display the button with default copy. Use the `text` property to customise it:
+
 ```tsx
 <SocialSignIn provider="apple" text="Register with Apple" />
 <SocialSignIn provider="google" text="Register with Google" />
@@ -51,15 +51,16 @@ By default, the TSX component will display the button with default copy. Use the
 ### Properties
 
 | Property   | Values             | Description                                                                                                                            |
-|------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ---------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `provider` | `apple`, `google`  | Styles the button according to the sign in provider's design                                                                           |
-| `text`      | Any `string` value | (Optional) Lets users override copy with custom content. If no string is provided then `Sign in with <provider>` will display instead. |
+| `text`     | Any `string` value | (Optional) Lets users override copy with custom content. If no string is provided then `Sign in with <provider>` will display instead. |
 
 ## Migration
 
-|  State   | Major Version | Last Minor Release | Migration guide |
-|:--------:|:-------------:|:------------------:|:---------------:|
-| ✨ active |       1       |        N/A         |       N/A       |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+|  ✨ active   |       2       |        2.0         | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ╳ deprecated |       1       |        1.1         |                           -                           |
 
 ## Contact
 

--- a/components/o3-tooltip/MIGRATION.md
+++ b/components/o3-tooltip/MIGRATION.md
@@ -1,0 +1,5 @@
+# Migration Guide
+
+## Migrating from v2 to v3
+
+Upgrade peer dependencies including `o3-foundation`. No other changes are required. This major release introduces a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons.

--- a/components/o3-tooltip/README.md
+++ b/components/o3-tooltip/README.md
@@ -26,23 +26,23 @@ Below are examples of how to use `<o3-tooltip-onboarding>` and `<o3-tooltip-togg
 ```html
 <!-- <o3-tooltip-onboarding> -->
 <div data-o3-brand="[your brand]">
- <button
-  id="demo-o3-tooltip-id"
-  class="o3-button o3-button--secondary o3-button--big demo-tooltip-target"
-  aria-describedby="demo-o3-tooltip-content"
- >
-  Share
- </button>
- <o3-tooltip-onboarding
-  role="tooltip"
-  placement="top"
-  target-id="demo-o3-tooltip-id"
-  class="o3-tooltip"
-  content="Tool tip content that is quite long, Tool tip content that is quite long, Tool tip content that is quite long"
-  title="Title"
-  content-id="demo-o3-tooltip-content"
- >
- </o3-tooltip-onboarding>
+	<button
+		id="demo-o3-tooltip-id"
+		class="o3-button o3-button--secondary o3-button--big demo-tooltip-target"
+		aria-describedby="demo-o3-tooltip-content"
+	>
+		Share
+	</button>
+	<o3-tooltip-onboarding
+		role="tooltip"
+		placement="top"
+		target-id="demo-o3-tooltip-id"
+		class="o3-tooltip"
+		content="Tool tip content that is quite long, Tool tip content that is quite long, Tool tip content that is quite long"
+		title="Title"
+		content-id="demo-o3-tooltip-content"
+	>
+	</o3-tooltip-onboarding>
 </div>
 ```
 
@@ -51,14 +51,14 @@ Below are examples of how to use `<o3-tooltip-onboarding>` and `<o3-tooltip-togg
 ```html
 <!-- <o3-tooltip-toggle> -->
 <div data-o3-brand="[your brand]">
- <o3-tooltip-toggle
-  placement="bottom"
-  class="o3-tooltip"
-  content="click the button to see the tooltip"
-  title="Title"
-  info-label="more information"
- >
- </o3-tooltip-toggle> 
+	<o3-tooltip-toggle
+		placement="bottom"
+		class="o3-tooltip"
+		content="click the button to see the tooltip"
+		title="Title"
+		info-label="more information"
+	>
+	</o3-tooltip-toggle>
 </div>
 ```
 
@@ -86,8 +86,8 @@ To style `o3-tooltip` import brand specific css, this varies depending on your p
 
 ```jsx
 import {
- TooltipOnboarding,
- TooltipToggle,
+	TooltipOnboarding,
+	TooltipToggle,
 } from '@financial-times/o3-tooltip/cjs';
 
 import '@financial-times/o3-tooltip'; // import the JavaScript needed for custom elements on client side
@@ -95,11 +95,11 @@ import '@financial-times/o3-tooltip'; // import the JavaScript needed for custom
 import '@finacial-times/o3-tooltip/css/[your brand].css'; // tooltip styling
 
 <div className="o3-brand-[your brand]">
- <button id="target" aria-describedby="contentId">
-  Target element
- </button>
- <TooltipOnboarding {...props} />;
- <TooltipToggle {...props} />
+	<button id="target" aria-describedby="contentId">
+		Target element
+	</button>
+	<TooltipOnboarding {...props} />;
+	<TooltipToggle {...props} />
 </div>;
 ```
 
@@ -109,18 +109,18 @@ The `TooltipOnboarding` JSX element accepts the following `props`:
 
 ```ts
 type Placement =
- | 'top'
- | 'bottom'
- | 'left'
- | 'right'
- | 'top-start'
- | 'top-end'
- | 'bottom-start'
- | 'bottom-end'
- | 'left-start'
- | 'left-end'
- | 'right-start'
- | 'right-end';
+	| 'top'
+	| 'bottom'
+	| 'left'
+	| 'right'
+	| 'top-start'
+	| 'top-end'
+	| 'bottom-start'
+	| 'bottom-end'
+	| 'left-start'
+	| 'left-end'
+	| 'right-start'
+	| 'right-end';
 ```
 
 |   Prop    |    type     | required | default |             description             |
@@ -139,18 +139,20 @@ The `ToggleTooltip` JSX element accepts the following `props`:
 type Placement = 'top' | 'bottom' | 'left' | 'right';
 ```
 
-|   Prop    |    type     | required |      default       |       description        |
-| :-------: | :---------: | :------: | :----------------: | :----------------------: |
-|  content  |   string    |   true   |         -          |  Content of the tooltip  |
-|   title   |   string    |  false   |         -          |   Title of the tooltip   |
-| placement | `Placement` |  false   |       'top'        | Placement of the tooltip |
-| infoLabel |   string    |   false   | more information | Label for screen readers |
+|   Prop    |    type     | required |     default      |       description        |
+| :-------: | :---------: | :------: | :--------------: | :----------------------: |
+|  content  |   string    |   true   |        -         |  Content of the tooltip  |
+|   title   |   string    |  false   |        -         |   Title of the tooltip   |
+| placement | `Placement` |  false   |      'top'       | Placement of the tooltip |
+| infoLabel |   string    |  false   | more information | Label for screen readers |
 
 ## Migration Guide
 
-|   State   | Major Version | Last Minor Release | Migration guide |
-| :-------: | :-----------: | :----------------: | :-------------: |
-| ✨ active |       0       |       0.0.1        |       N/A       |
+|    State     | Major Version | Last Minor Release |                    Migration guide                    |
+| :----------: | :-----------: | :----------------: | :---------------------------------------------------: |
+|  ✨ active   |       3       |        N/A         | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ╳ deprecated |       2       |        2.3         |                           -                           |
+| ╳ deprecated |       1       |         -          |                          N/A                          |
 
 ## Contact
 


### PR DESCRIPTION
**To review**: Ensure all components we expect to release (listed below) have a file change to trigger an automated release. Ensure other components, do not.

This releases a new design language and visually breaking changes. This includes mobile optimised typography, icons, and buttons.

**Release a major for "o3" components**:
- o3-foundation
- o3-button
- o3-editorial-typography
- o3-tooltip

**Should not release o2 components with an o3 alternative:**
- o-normalise
- o-fonts
- o-spacing
- o-colors
- o-icons
- o-typography
- o-buttons
- o-editorial-typography
- o-quote
- o-big-number

**Release a major for remaining "o2" components to remove deprecated components as dependencies:**
- o-tooltip
- o-video
- o-topper
- o-stepped-progress
- o-top-banner
- o-tabs
- o-subs-card
- o-teaser-collection
- o-table
- o-syntax-highlight
- o-teaser
- o-overlay
- o-share
- o-labels
- o-social-follow
- o-message
- o-layout
- o-meter
- o-footer-services
- o-loading
- o-multi-select
- o-header-services
- o-footer
- o-ft-affiliate-ribbon
- o-forms
- o-header
- o-editorial-layout
- o-comments
- g-audio
- o-cookie-message
- o-expander
- o-banner
- o-autocomplete
- n-notification
- ft-concept-button