### PR TITLE
fix: use same colour on editorial typography bullets as text

### DIFF
--- a/components/o3-editorial-typography/list.css
+++ b/components/o3-editorial-typography/list.css
@@ -22,10 +22,11 @@
 
 .o3-editorial-typography-list-unordered li::before {
 	content: '';
-	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='10' cy='10' r='10' /%3E%3C/svg%3E");
-	background-size: 0.7ch;
-	background-repeat: no-repeat;
-	background-position: left center;
+	mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='10' cy='10' r='10' /%3E%3C/svg%3E");
+	mask-size: 0.7ch;
+	mask-repeat: no-repeat;
+	mask-position: left center;
+	background-color: currentColor;
 	height: var(--_o3-body-line-height);
 	display: inline-block;
 	flex-shrink: 0;


### PR DESCRIPTION
## Describe your changes

Fixes an issue where unordered list bullets would not match the colour of the text on inverse themes.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
