### PR TITLE
chore: apply inverse styles to caption, remove caption classes

### DIFF
--- a/components/o3-foundation/src/css/components/typography/caption.css
+++ b/components/o3-foundation/src/css/components/typography/caption.css
@@ -1,8 +1,0 @@
-.o3-typography-caption,
-.o3-typography-wrapper > figcaption {
-	color: var(--o3-type-caption-color);
-	font-family: var(--o3-type-caption-font-family);
-	font-size: var(--o3-type-caption-font-size);
-	font-weight: var(--o3-type-caption-font-weight);
-	line-height: var(--o3-type-caption-line-height);
-}

--- a/components/o3-foundation/src/css/components/typography/index.css
+++ b/components/o3-foundation/src/css/components/typography/index.css
@@ -1,6 +1,5 @@
 @import './link.css';
 @import './list.css';
-@import './caption.css';
 @import './usecases.css';
 
 :root {

--- a/components/o3-foundation/src/css/components/typography/usecases.css
+++ b/components/o3-foundation/src/css/components/typography/usecases.css
@@ -91,6 +91,7 @@
 }
 
 /* DETAIL / LABEL */
+.o3-typography-wrapper > figcaption,
 .o3-type-detail {
 	font-family: var(--o3-type-detail-font-family);
 	font-size: var(--o3-type-detail-font-size);
@@ -135,7 +136,7 @@
 		[class~='type-body'],
 		.o3-type-detail,
 		.o3-type-highlight,
-		.o3-typography-wrapper > p
+		.o3-typography-wrapper > :is(p, figcaption)
 	) {
 	color: var(--o3-color-use-case-body-text);
 	[data-o3-theme='inverse']&,

--- a/components/o3-foundation/stories/story-templates.tsx
+++ b/components/o3-foundation/stories/story-templates.tsx
@@ -145,7 +145,7 @@ export const WrapperStory = {
 					<li>List ordered</li>
 				</ol>
 
-				<footer>Footer such as copyright notice.</footer>
+				<figcaption>This is a caption</figcaption>
 			</Wrapper>
 		);
 	},


### PR DESCRIPTION
…wrapper

## Describe your changes

`o3-typography-caption` was replaced with `o3-type-detail`, the former classes have been removed to reflect this.

* removes `o3-typography-caption` classes
* ensures inverse colours apply correctly for `o3-type-detail` and `figcaption` elements in wrapper

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
