### PR TITLE
fix: Add oBrandGetCurrent to return the current brand

### DIFF
--- a/libraries/o-brand/README.md
+++ b/libraries/o-brand/README.md
@@ -55,6 +55,15 @@ $o-brand: internal; // Defined in the product using branded Origami components.
 $chosen-brand: oBrandIs('internal'); // true
 $chosen-brand: oBrandIs('core'); // false
 ```
+### oBrandGetCurrent
+
+This function returns the current brand, or the default brand if not set.
+
+```scss
+$o-brand: internal; // Defined in the product using branded Origami components.
+
+$chosen-brand: oBrandGetCurrent('internal'); // internal
+```
 
 ### oBrandDefine
 


### PR DESCRIPTION
This triggers a release, added in a previous commit.