### PR TITLE
fix: round non-navigational buttons on o-header

### DIFF
--- a/components/o-header/main.scss
+++ b/components/o-header/main.scss
@@ -71,7 +71,7 @@
 					)
 				);
 			}
-			.o-header__top-button,
+
 			.o-header__nav-button {
 				border-radius: 0;
 			}

--- a/components/o-header/src/scss/features/_search.scss
+++ b/components/o-header/src/scss/features/_search.scss
@@ -66,7 +66,6 @@
 				'size': 'big',
 			)
 		);
-		border-radius: 0;
 		display: flex;
 		gap: 10px;
 		align-items: center;


### PR DESCRIPTION
## Describe your changes
* Introduces rounding to search and subscribe buttons.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
