### PR TITLE
fix: peer depend on o-icons

### DIFF
--- a/components/o-header/package.json
+++ b/components/o-header/package.json
@@ -26,11 +26,12 @@
 	"peerDependencies": {
 		"@financial-times/math": "^1.0.0",
 		"@financial-times/o-brand": "^4.1.0",
+		"@financial-times/o-forms": "^10.0.0",
+		"@financial-times/o-icons": "^7.8.0",
+		"@financial-times/o-private-foundation": "^1.0.0",
 		"@financial-times/o-toggle": "^3.2.6",
 		"@financial-times/o-utils": "^2.0.0",
-		"@financial-times/o-viewport": "^5.1.2",
-		"@financial-times/o-forms": "^10.0.0",
-		"@financial-times/o-private-foundation": "^1.0.0"
+		"@financial-times/o-viewport": "^5.1.2"
 	},
 	"devDependencies": {
 		"@financial-times/o-fonts": "^5.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2813,6 +2813,7 @@
 				"@financial-times/math": "^1.0.0",
 				"@financial-times/o-brand": "^4.1.0",
 				"@financial-times/o-forms": "^10.0.0",
+				"@financial-times/o-icons": "^7.8.0",
 				"@financial-times/o-private-foundation": "^1.0.0",
 				"@financial-times/o-toggle": "^3.2.6",
 				"@financial-times/o-utils": "^2.0.0",


### PR DESCRIPTION
## Describe your changes

o-header uses o-icons but does not depend on it, leading to issues.

* adds peer dependency on o-icons to o-header

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
