### PR TITLE
fix: remove o-colors usages in o-private-foundation

### DIFF
--- a/components/o-private-foundation/src/scss/o-typography/main.scss
+++ b/components/o-private-foundation/src/scss/o-typography/main.scss
@@ -212,13 +212,11 @@
 
 	// Generate optional theme colours.
 	@if (not $decoration-color) {
-		// TODO: replace oColorsMix
-		$decoration-color: oColorsMix($base-color, $context-color, $percentage: 20);
+		$decoration-color: oPrivateColorsMix($base-color, $context-color, $percentage: 20);
 	}
 
 	@if (not $hover-decoration-color) {
-		// TODO: replace oColorsMix
-		$hover-decoration-color: oColorsMix(
+		$hover-decoration-color: oPrivateColorsMix(
 			$base-color,
 			$context-color,
 			$percentage: 40


### PR DESCRIPTION
## Describe your changes

o-colors was used in o-private-foundation, these have been replaced with `oPrivateColors` functions.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
