### PR TITLE
docs: Restructure o2 storybook

### DIFF
--- a/apps/o2-storybook-composition/.storybook/main.ts
+++ b/apps/o2-storybook-composition/.storybook/main.ts
@@ -1,10 +1,7 @@
 import type {StorybookConfig} from '@storybook/react-webpack5';
 
 const config: StorybookConfig = {
-	stories: [
-		'../stories/*.stories.@(js|jsx|mjs|ts|tsx|mdx)',
-		'../../../libraries/o-tracking/stories/*.stories.@(js|jsx|mjs|ts|tsx|mdx)',
-	],
+	stories: ['../stories/*.stories.@(js|jsx|mjs|ts|tsx|mdx)'],
 	addons: [
 		'@storybook/addon-links',
 		'@storybook/addon-essentials',

--- a/apps/o2-storybook-composition/stories/home.stories.mdx
+++ b/apps/o2-storybook-composition/stories/home.stories.mdx
@@ -1,12 +1,10 @@
-import {Meta} from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Legacy Origami" />
+<Meta title="Origami 2 (o2)" />
 
-# Legacy Origami
+# Origami 2 (o2)
 
-This Storybook includes documentation and demos for legacy "o2" Origami components. These are still actively used and will continue to be supported by the Origami team until further notice. However, for new projects or features, we recommend using our [new Origami components](https://origami-for-everyone.ft.com). These have been rethought from the ground up, with aligned Figma libraries, design guidelines, and brand support powered by design tokens.
-
-To learn more about the future of Origami component documentation, see our [January 2024 newsletter](https://origami.ft.com/blog/2024/02/12/newsletter/).
+This Storybook includes documentation and demos for Origami 2 “o2” packages. These include foundational styles, components, and patterns. These will be gradually deprecated over time, as we conduct design audits and build Origami 3 “o3” alternatives. Where components are deprecated, [begin to use the o3 alternative](https://origami-beta.ft.com/o2-components/).
 
 Please contact the Origami team in the [#origami-support](https://financialtimes.slack.com/messages/origami-support) Slack channel for support or to share feedback.
 
@@ -25,7 +23,3 @@ Used on internal applications.
 ### Whitelabel
 
 Components with lightweight, minimal styling – to build new brands from.
-
-### Brandless
-
-Any components which have no brand styling. Typically, libraries, such as for tracking.

--- a/components/ft-concept-button/stories/concept-button.stories.tsx
+++ b/components/ft-concept-button/stories/concept-button.stories.tsx
@@ -3,7 +3,7 @@ import {useArgs} from '@storybook/client-api';
 import './concept-button.scss';
 
 export default {
-	title: 'Components/ft-concept-button',
+	title: 'Maintained/ft-concept-button',
 	component: ConceptButton,
 	// @deprecated The concept pill is a candidate for deprecation.
 	// They were only ever intended as use as links button use a
@@ -15,7 +15,7 @@ export default {
 		'ConceptPill',
 		'OpinionPill',
 		'InversePill',
-		'MonochromePill'
+		'MonochromePill',
 	],
 	parameters: {
 		design: {

--- a/components/ft-concept-button/stories/concept-link.stories.tsx
+++ b/components/ft-concept-button/stories/concept-link.stories.tsx
@@ -2,7 +2,7 @@ import {ConceptLink as ConceptLinkTemplate} from '../src/tsx/concept-button';
 import './concept-button.scss';
 
 export default {
-	title: 'Components/ft-concept-button',
+	title: 'Maintained/ft-concept-button',
 	component: ConceptLinkTemplate,
 	parameters: {
 		design: {
@@ -24,9 +24,7 @@ export default {
 };
 
 const ConceptLinkStory = args => {
-	return (
-		<ConceptLinkTemplate {...args} />
-	);
+	return <ConceptLinkTemplate {...args} />;
 };
 
 export const ConceptPillLink = ConceptLinkStory.bind({});

--- a/components/ft-concept-button/stories/jsdoc.stories.mdx
+++ b/components/ft-concept-button/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/ft-concept-button/JSDoc"
+title="Maintained/ft-concept-button/JSDoc"
 />
 
 <Markdown>

--- a/components/ft-concept-button/stories/readme.stories.mdx
+++ b/components/ft-concept-button/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/ft-concept-button/Readme"
+	title="Maintained/ft-concept-button/Readme"
 />
 
 

--- a/components/g-audio/stories/core/block.stories.tsx
+++ b/components/g-audio/stories/core/block.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/g-audio/Block',
+	title: 'Maintained/g-audio/Block',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Block = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=block&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=block&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/g-audio/stories/core/inline.stories.tsx
+++ b/components/g-audio/stories/core/inline.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/g-audio/Inline',
+	title: 'Maintained/g-audio/Inline',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Inline = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=inline&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=g-audio%402.0.2&demo=inline&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/g-audio/stories/jsdoc.stories.mdx
+++ b/components/g-audio/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/g-audio/JSDoc"
+title="Maintained/g-audio/JSDoc"
 />
 
 <Markdown>

--- a/components/g-audio/stories/readme.stories.mdx
+++ b/components/g-audio/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/g-audio/Readme"
+	title="Maintained/g-audio/Readme"
 />
 
 

--- a/components/g-audio/stories/sassdoc.stories.mdx
+++ b/components/g-audio/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/g-audio/SassDoc"
+title="Maintained/g-audio/SassDoc"
 />
 
 <Markdown>

--- a/components/n-notification/stories/core/display-notifications.stories.tsx
+++ b/components/n-notification/stories/core/display-notifications.stories.tsx
@@ -1,26 +1,27 @@
-
 export default {
-	title: 'Components/n-notification/Display notifications',
+	title: 'Maintained/n-notification/Display notifications',
 	args: {},
 	parameters: {
 		html: {},
 	},
 };
 
-export const Displaynotifications = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=n-notification%408.2.5&demo=all&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+export const Displaynotifications = (args) => {
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=n-notification%408.2.5&demo=all&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/n-notification/stories/core/pa11y-test.stories.tsx
+++ b/components/n-notification/stories/core/pa11y-test.stories.tsx
@@ -1,26 +1,27 @@
-
 export default {
-	title: 'Components/n-notification/Pa11y test',
+	title: 'Maintained/n-notification/Pa11y test',
 	args: {},
 	parameters: {
 		html: {},
 	},
 };
 
-export const Pa11ytest = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=n-notification%408.2.5&demo=pa11y&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+export const Pa11ytest = (args) => {
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=n-notification%408.2.5&demo=pa11y&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/n-notification/stories/jsdoc.stories.mdx
+++ b/components/n-notification/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/n-notification/JSDoc"
+title="Maintained/n-notification/JSDoc"
 />
 
 <Markdown>

--- a/components/n-notification/stories/readme.stories.mdx
+++ b/components/n-notification/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/n-notification/Readme"
+	title="Maintained/n-notification/Readme"
 />
 
 

--- a/components/o-audio/stories/core/native-player.stories.tsx
+++ b/components/o-audio/stories/core/native-player.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-audio/Native player',
+	title: "Maintained/o-audio/Native player",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Nativeplayer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-audio%402.1.3&demo=native&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-audio%402.1.3&demo=native&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-audio/stories/jsdoc.stories.mdx
+++ b/components/o-audio/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-audio/JSDoc"
+title="Maintained/o-audio/JSDoc"
 />
 
 <Markdown>

--- a/components/o-audio/stories/readme.stories.mdx
+++ b/components/o-audio/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-audio/Readme"
+	title="Maintained/o-audio/Readme"
 />
 
 

--- a/components/o-audio/stories/sassdoc.stories.mdx
+++ b/components/o-audio/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-audio/SassDoc"
+title="Maintained/o-audio/SassDoc"
 />
 
 <Markdown>

--- a/components/o-autocomplete/stories/dynamic-complex.stories.tsx
+++ b/components/o-autocomplete/stories/dynamic-complex.stories.tsx
@@ -8,7 +8,7 @@ import {data} from './data.js';
 oForms.init();
 
 export default {
-	title: 'Components/o-autocomplete',
+	title: 'Maintained/o-autocomplete',
 	parameters: {
 		html: {},
 	},

--- a/components/o-autocomplete/stories/dynamic-delayed.stories.tsx
+++ b/components/o-autocomplete/stories/dynamic-delayed.stories.tsx
@@ -6,7 +6,7 @@ import oAutoComplete from '../main.js';
 import {debounce} from '@financial-times/o-utils';
 
 export default {
-	title: 'Components/o-autocomplete',
+	title: 'Maintained/o-autocomplete',
 	parameters: {
 		html: {},
 	},

--- a/components/o-autocomplete/stories/dynamic.stories.tsx
+++ b/components/o-autocomplete/stories/dynamic.stories.tsx
@@ -5,7 +5,7 @@ import '@financial-times/o-forms';
 import {useEffect} from 'react';
 
 export default {
-	title: 'Components/o-autocomplete',
+	title: 'Maintained/o-autocomplete',
 	parameters: {
 		html: {},
 	},

--- a/components/o-autocomplete/stories/jsdoc.stories.mdx
+++ b/components/o-autocomplete/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-autocomplete/JSDoc"
+title="Maintained/o-autocomplete/JSDoc"
 />
 
 <Markdown>

--- a/components/o-autocomplete/stories/readme.stories.mdx
+++ b/components/o-autocomplete/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-autocomplete/Readme"
+	title="Maintained/o-autocomplete/Readme"
 />
 
 

--- a/components/o-autocomplete/stories/sassdoc.stories.mdx
+++ b/components/o-autocomplete/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-autocomplete/SassDoc"
+title="Maintained/o-autocomplete/SassDoc"
 />
 
 <Markdown>

--- a/components/o-autocomplete/stories/static.stories.tsx
+++ b/components/o-autocomplete/stories/static.stories.tsx
@@ -5,7 +5,7 @@ import '@financial-times/o-forms';
 import {useEffect} from 'react';
 
 export default {
-	title: 'Components/o-autocomplete',
+	title: 'Maintained/o-autocomplete',
 	parameters: {
 		html: {},
 	},

--- a/components/o-banner/stories/banner.stories.tsx
+++ b/components/o-banner/stories/banner.stories.tsx
@@ -4,7 +4,7 @@ import javascript from '../main';
 import './banner.scss';
 
 export default {
-	title: 'Components/o-banner',
+	title: 'Maintained/o-banner',
 	component: Banner,
 	args: {},
 	parameters: {
@@ -35,7 +35,7 @@ Default.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {
@@ -60,7 +60,7 @@ FormPrimaryAction.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {
@@ -89,7 +89,7 @@ Small.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {
@@ -114,7 +114,7 @@ Compact.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {
@@ -139,7 +139,7 @@ Marketing.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {
@@ -161,7 +161,7 @@ Product.args = {
 	content:
 		"Try the new compact homepage. A list view of today's homepage with fewer images.",
 	abbreviatedContent: 'Try it now',
-	navigationLabel: "Try the new homepage",
+	navigationLabel: 'Try the new homepage',
 	showCloseButton: true,
 	closeButtonLabel: 'Close',
 	primaryAction: {

--- a/components/o-banner/stories/jsdoc.stories.mdx
+++ b/components/o-banner/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-banner/JSDoc"
+title="Maintained/o-banner/JSDoc"
 />
 
 <Markdown>

--- a/components/o-banner/stories/readme.stories.mdx
+++ b/components/o-banner/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-banner/Readme"
+	title="Maintained/o-banner/Readme"
 />
 
 

--- a/components/o-banner/stories/sassdoc.stories.mdx
+++ b/components/o-banner/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-banner/SassDoc"
+title="Maintained/o-banner/SassDoc"
 />
 
 <Markdown>

--- a/components/o-big-number/stories/big-number.stories.tsx
+++ b/components/o-big-number/stories/big-number.stories.tsx
@@ -2,7 +2,7 @@ import './big-number.scss';
 import {BigNumber} from '../src/tsx/big-number';
 
 export default {
-	title: 'Components/o-big-number',
+	title: 'Deprecated/o-big-number',
 	component: BigNumber,
 	args: {},
 	parameters: {

--- a/components/o-big-number/stories/readme.stories.mdx
+++ b/components/o-big-number/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-big-number/Readme"
+	title="Deprecated/o-big-number/Readme"
 />
 
 

--- a/components/o-big-number/stories/sassdoc.stories.mdx
+++ b/components/o-big-number/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-big-number/SassDoc"
+title="Deprecated/o-big-number/SassDoc"
 />
 
 <Markdown>

--- a/components/o-buttons/stories/button-group.stories.tsx
+++ b/components/o-buttons/stories/button-group.stories.tsx
@@ -3,7 +3,7 @@ import {ButtonGroup} from '../src/tsx/group';
 import './button.scss';
 
 export default {
-	title: 'Components/o-buttons',
+	title: 'Deprecated/o-buttons',
 	component: ButtonGroup,
 	args: {},
 	parameters: {
@@ -13,20 +13,28 @@ export default {
 	},
 };
 
-const ButtonGroupStory = args => <ButtonGroup>
-	{args.buttons.map((buttonProps, index) => <Button {...buttonProps} key={index}/>)}
-</ButtonGroup>;
+const ButtonGroupStory = args => (
+	<ButtonGroup>
+		{args.buttons.map((buttonProps, index) => (
+			<Button {...buttonProps} key={index} />
+		))}
+	</ButtonGroup>
+);
 
 export const GroupedButtons = ButtonGroupStory.bind({});
 GroupedButtons.args = {
-	buttons: [{
-		label: 'button one',
-		type: 'secondary',
-	}, {
-		label: 'button two',
-		type: 'secondary',
-	}, {
-		label: 'button three',
-		type: 'secondary',
-	}]
+	buttons: [
+		{
+			label: 'button one',
+			type: 'secondary',
+		},
+		{
+			label: 'button two',
+			type: 'secondary',
+		},
+		{
+			label: 'button three',
+			type: 'secondary',
+		},
+	],
 };

--- a/components/o-buttons/stories/button-pagination.stories.tsx
+++ b/components/o-buttons/stories/button-pagination.stories.tsx
@@ -1,9 +1,9 @@
 import {ButtonPagination} from '../src/tsx/pagination';
 import './button.scss';
-import { useState } from 'react';
+import {useState} from 'react';
 
 export default {
-	title: 'Components/o-buttons',
+	title: 'Deprecated/o-buttons',
 	component: ButtonPagination,
 	args: {},
 	parameters: {
@@ -15,11 +15,13 @@ export default {
 
 const ButtonPaginationStory = args => {
 	const configuredCurrentPage = args.pages.find(page => page.current);
-	const [currentPageSelection, setCurrentPageSelection] = useState(configuredCurrentPage ? configuredCurrentPage.number : 0);
+	const [currentPageSelection, setCurrentPageSelection] = useState(
+		configuredCurrentPage ? configuredCurrentPage.number : 0
+	);
 
 	function updatePages(currentPageSelection) {
 		setCurrentPageSelection(currentPageSelection);
-		args.pages.forEach(p => p.current = p.number === currentPageSelection);
+		args.pages.forEach(p => (p.current = p.number === currentPageSelection));
 	}
 
 	args.pages.forEach(page => {
@@ -39,7 +41,7 @@ const ButtonPaginationStory = args => {
 		updatePages(currentPageSelection - 1);
 	};
 
-	return <ButtonPagination {...args} />
+	return <ButtonPagination {...args} />;
 };
 
 export const Pagination = ButtonPaginationStory.bind({});
@@ -48,19 +50,21 @@ Pagination.args = {
 	size: 'big',
 	previousPager: {
 		href: '#previous',
-		label: 'previous results'
+		label: 'previous results',
 	},
-  	pages: Array(10).fill(null).map((page, index) => {
-		const number = index + 1;
-		const currentPageNumber = 3;
-		return {
-			href: '#',
-			current: number === currentPageNumber,
-			number,
-		};
-	}),
+	pages: Array(10)
+		.fill(null)
+		.map((page, index) => {
+			const number = index + 1;
+			const currentPageNumber = 3;
+			return {
+				href: '#',
+				current: number === currentPageNumber,
+				number,
+			};
+		}),
 	nextPager: {
 		href: '#next',
-		label: 'next results'
+		label: 'next results',
 	},
 };

--- a/components/o-buttons/stories/button.stories.tsx
+++ b/components/o-buttons/stories/button.stories.tsx
@@ -1,8 +1,8 @@
-import { Button, LinkButton } from "../src/tsx/button";
-import "./button.scss";
+import {Button, LinkButton} from '../src/tsx/button';
+import './button.scss';
 
 export default {
-	title: "Components/o-buttons",
+	title: 'Deprecated/o-buttons',
 	component: Button,
 	args: {
 		onClick: {
@@ -13,33 +13,33 @@ export default {
 	},
 	parameters: {
 		design: {
-			type: "figma",
-			url: "https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/FT-UI-Library?node-id=29%3A1131",
+			type: 'figma',
+			url: 'https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/FT-UI-Library?node-id=29%3A1131',
 		},
 		guidelines: {
-			notion: "448d914df4fd4bb68fdf5bc5e85c4b46",
+			notion: '448d914df4fd4bb68fdf5bc5e85c4b46',
 		},
 		html: {},
 	},
 	argTypes: {
 		icon: {
-			control: "select",
+			control: 'select',
 			options: [
-				"arrow-left",
-				"arrow-right",
-				"upload",
-				"tick",
-				"plus",
-				"warning",
-				"arrow-down",
-				"arrow-up",
-				"grid",
-				"list",
-				"edit",
-				"download",
-				"search",
-				"refresh",
-				"cross",
+				'arrow-left',
+				'arrow-right',
+				'upload',
+				'tick',
+				'plus',
+				'warning',
+				'arrow-down',
+				'arrow-up',
+				'grid',
+				'list',
+				'edit',
+				'download',
+				'search',
+				'refresh',
+				'cross',
 			],
 		},
 	},
@@ -50,59 +50,59 @@ const LinkButtonStory = args => <LinkButton {...args} />;
 
 export const PrimaryButton = ButtonStory.bind({});
 PrimaryButton.args = {
-	label: "Press button",
-	type: "primary",
+	label: 'Press button',
+	type: 'primary',
 };
 
 export const SecondaryButton = ButtonStory.bind({});
 SecondaryButton.args = {
-	label: "Press button",
-	type: "secondary",
+	label: 'Press button',
+	type: 'secondary',
 };
 
 export const LinkAsButton = LinkButtonStory.bind({});
 LinkAsButton.args = {
-	label: "Link button",
-	type: "secondary",
-	href: "#",
+	label: 'Link button',
+	type: 'secondary',
+	href: '#',
 };
 
 export const BigButton = ButtonStory.bind({});
 BigButton.args = {
-	size: "big",
-	label: "Press button",
+	size: 'big',
+	label: 'Press button',
 };
 
 export const InverseButton = ButtonStory.bind({});
 InverseButton.args = {
-	label: "Press button",
-	theme: "inverse",
+	label: 'Press button',
+	theme: 'inverse',
 };
 InverseButton.parameters = {
-	origamiBackground: "slate",
+	origamiBackground: 'slate',
 };
 
 export const MonoButton = ButtonStory.bind({});
 MonoButton.args = {
-	label: "Press button",
-	theme: "mono",
+	label: 'Press button',
+	theme: 'mono',
 };
 
 export const GhostButton = ButtonStory.bind({});
 GhostButton.args = {
-	label: "Press button",
-	type: "ghost",
+	label: 'Press button',
+	type: 'ghost',
 };
 
 export const ButtonWithIcon = ButtonStory.bind({});
 ButtonWithIcon.args = {
-	label: "Upload",
-	icon: "upload",
+	label: 'Upload',
+	icon: 'upload',
 };
 
 export const IconOnlyButton = ButtonStory.bind({});
 IconOnlyButton.args = {
-	label: "Next",
-	icon: "arrow-right",
+	label: 'Next',
+	icon: 'arrow-right',
 	iconOnly: true,
 };

--- a/components/o-buttons/stories/readme.stories.mdx
+++ b/components/o-buttons/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-buttons/Readme"
+	title="Deprecated/o-buttons/Readme"
 />
 
 

--- a/components/o-buttons/stories/sassdoc.stories.mdx
+++ b/components/o-buttons/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-buttons/SassDoc"
+title="Deprecated/o-buttons/SassDoc"
 />
 
 <Markdown>

--- a/components/o-colors/stories/core/color-mixer.stories.tsx
+++ b/components/o-colors/stories/core/color-mixer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Color Mixer',
+	title: 'Deprecated/o-colors/Color Mixer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ColorMixer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-color-mixer&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-color-mixer&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/contrast-ratio-checker.stories.tsx
+++ b/components/o-colors/stories/core/contrast-ratio-checker.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Contrast ratio checker',
+	title: 'Deprecated/o-colors/Contrast ratio checker',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Contrastratiochecker = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-contrast-checker&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-contrast-checker&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/ft-professional-palette.stories.tsx
+++ b/components/o-colors/stories/core/ft-professional-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/FT Professional Palette',
+	title: 'Deprecated/o-colors/FT Professional Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FTProfessionalPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-professional-palette&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-professional-palette&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/ft-professional-tones-and-mixes.stories.tsx
+++ b/components/o-colors/stories/core/ft-professional-tones-and-mixes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/FT Professional Tones and Mixes',
+	title: 'Deprecated/o-colors/FT Professional Tones and Mixes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FTProfessionalTonesandMixes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-professional-tones&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-professional-tones&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/partner-content-palette.stories.tsx
+++ b/components/o-colors/stories/core/partner-content-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Partner Content Palette',
+	title: 'Deprecated/o-colors/Partner Content Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const PartnerContentPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-partner-content-palette&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-partner-content-palette&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/primary-palette.stories.tsx
+++ b/components/o-colors/stories/core/primary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Primary Palette',
+	title: 'Deprecated/o-colors/Primary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const PrimaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-primary-palette&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-primary-palette&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/secondary-palette.stories.tsx
+++ b/components/o-colors/stories/core/secondary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Secondary Palette',
+	title: 'Deprecated/o-colors/Secondary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SecondaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-secondary-palette&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-secondary-palette&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/tertiary-palette.stories.tsx
+++ b/components/o-colors/stories/core/tertiary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Tertiary Palette',
+	title: 'Deprecated/o-colors/Tertiary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TertiaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-tertiary-palette&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-tertiary-palette&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/core/tones-and-mixes.stories.tsx
+++ b/components/o-colors/stories/core/tones-and-mixes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Tones and Mixes',
+	title: 'Deprecated/o-colors/Tones and Mixes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TonesandMixes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-tones&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=core-tones&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/color-mixer.stories.tsx
+++ b/components/o-colors/stories/internal/color-mixer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Color Mixer',
+	title: 'Deprecated/o-colors/Color Mixer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ColorMixer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-color-mixer&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-color-mixer&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/contrast-ratio-checker.stories.tsx
+++ b/components/o-colors/stories/internal/contrast-ratio-checker.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Contrast ratio checker',
+	title: 'Deprecated/o-colors/Contrast ratio checker',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Contrastratiochecker = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-contrast-checker&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-contrast-checker&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/primary-palette.stories.tsx
+++ b/components/o-colors/stories/internal/primary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Primary Palette',
+	title: 'Deprecated/o-colors/Primary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const PrimaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-primary-palette&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-primary-palette&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/secondary-palette.stories.tsx
+++ b/components/o-colors/stories/internal/secondary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Secondary Palette',
+	title: 'Deprecated/o-colors/Secondary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SecondaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-secondary-palette&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-secondary-palette&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/tertiary-palette.stories.tsx
+++ b/components/o-colors/stories/internal/tertiary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Tertiary Palette',
+	title: 'Deprecated/o-colors/Tertiary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TertiaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-tertiary-palette&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-tertiary-palette&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/internal/tones-and-mixes.stories.tsx
+++ b/components/o-colors/stories/internal/tones-and-mixes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Tones and Mixes',
+	title: 'Deprecated/o-colors/Tones and Mixes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TonesandMixes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-tones&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=internal-tones&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/readme.stories.mdx
+++ b/components/o-colors/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-colors/Readme"
+	title="Deprecated/o-colors/Readme"
 />
 
 

--- a/components/o-colors/stories/sassdoc.stories.mdx
+++ b/components/o-colors/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-colors/SassDoc"
+title="Deprecated/o-colors/SassDoc"
 />
 
 <Markdown>

--- a/components/o-colors/stories/whitelabel/primary-palette.stories.tsx
+++ b/components/o-colors/stories/whitelabel/primary-palette.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Primary Palette',
+	title: 'Deprecated/o-colors/Primary Palette',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const PrimaryPalette = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=whitelabel-primary-palette&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=whitelabel-primary-palette&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-colors/stories/whitelabel/tones-and-mixes.stories.tsx
+++ b/components/o-colors/stories/whitelabel/tones-and-mixes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-colors/Tones and Mixes',
+	title: 'Deprecated/o-colors/Tones and Mixes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TonesandMixes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=whitelabel-tones&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-colors%406.6.2&demo=whitelabel-tones&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-comments/stories/core/comments-count.stories.tsx
+++ b/components/o-comments/stories/core/comments-count.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-comments/Comments Count',
+	title: "Maintained/o-comments/Comments Count",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const CommentsCount = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-count&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-count&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-comments/stories/core/comments-stream-staging.stories.tsx
+++ b/components/o-comments/stories/core/comments-stream-staging.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-comments/Comments Stream Staging',
+	title: "Maintained/o-comments/Comments Stream Staging",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const CommentsStreamStaging = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-stream-staging&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-stream-staging&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-comments/stories/core/comments-stream.stories.tsx
+++ b/components/o-comments/stories/core/comments-stream.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-comments/Comments Stream',
+	title: "Maintained/o-comments/Comments Stream",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const CommentsStream = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-stream&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-comments%4010.3.3&demo=comments-stream&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-comments/stories/jsdoc.stories.mdx
+++ b/components/o-comments/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-comments/JSDoc"
+title="Maintained/o-comments/JSDoc"
 />
 
 <Markdown>

--- a/components/o-comments/stories/readme.stories.mdx
+++ b/components/o-comments/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-comments/Readme"
+	title="Maintained/o-comments/Readme"
 />
 
 

--- a/components/o-comments/stories/sassdoc.stories.mdx
+++ b/components/o-comments/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-comments/sassDoc"
+title="Maintained/o-comments/sassDoc"
 />
 
 <Markdown>

--- a/components/o-cookie-message/stories/cookie-message.stories.tsx
+++ b/components/o-cookie-message/stories/cookie-message.stories.tsx
@@ -4,7 +4,7 @@ import javascript from '../main';
 import './cookie-message.scss';
 
 export default {
-	title: 'Components/o-cookie-message',
+	title: 'Maintained/o-cookie-message',
 	component: CookieMessage,
 	args: {},
 	parameters: {

--- a/components/o-cookie-message/stories/jsdoc.stories.mdx
+++ b/components/o-cookie-message/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-cookie-message/JSDoc"
+title="Maintained/o-cookie-message/JSDoc"
 />
 
 <Markdown>

--- a/components/o-cookie-message/stories/readme.stories.mdx
+++ b/components/o-cookie-message/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-cookie-message/Readme"
+	title="Maintained/o-cookie-message/Readme"
 />
 
 

--- a/components/o-date/stories/date.stories.tsx
+++ b/components/o-date/stories/date.stories.tsx
@@ -16,7 +16,7 @@ defaultDateTimeObj.setHours(new Date().getHours() - 6);
 const defaultDateTime = defaultDateTimeObj.getTime();
 
 export default {
-	title: 'Components/o-date',
+	title: 'Maintained/o-date',
 	component: ODate,
 	argTypes: {
 		dateTime: {control: 'date', defaultValue: defaultDateTime},
@@ -33,18 +33,15 @@ export default {
 			],
 		},
 		textCase: {
-			options: [
-				null,
-				'sentence'
-			],
+			options: [null, 'sentence'],
 			control: {
 				type: 'select',
 				labels: {
-					'null': 'Default',
-					'sentence': 'Sentence'
+					null: 'Default',
+					sentence: 'Sentence',
 				},
-			}
-		}
+			},
+		},
 	},
 	parameters: {controls: {sort: 'requiredFirst'}},
 } as ComponentMeta<typeof ODate>;

--- a/components/o-date/stories/jsdoc.stories.mdx
+++ b/components/o-date/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-date/JSDoc"
+title="Maintained/o-date/JSDoc"
 />
 
 <Markdown>

--- a/components/o-date/stories/readme.stories.mdx
+++ b/components/o-date/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-date/Readme"
+	title="Maintained/o-date/Readme"
 />
 
 

--- a/components/o-editorial-layout/stories/core/editorial-layout-body.stories.tsx
+++ b/components/o-editorial-layout/stories/core/editorial-layout-body.stories.tsx
@@ -1,15 +1,17 @@
-import {ComponentMeta} from "@storybook/react";
+import {ComponentMeta} from '@storybook/react';
 import './editorialLayout.scss';
-import {EditorialLayoutBody} from "../../src/tsx/editorial-layout-body";
+import {EditorialLayoutBody} from '../../src/tsx/editorial-layout-body';
 
 export default {
-	title: 'Components/o-editorial-layout',
+	title: 'Maintained/o-editorial-layout',
 	component: EditorialLayoutBody,
 } as ComponentMeta<typeof EditorialLayoutBody>;
 
 const Template = args => {
 	return (
-		<EditorialLayoutBody {...args}>Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo, quaerat!</EditorialLayoutBody>
+		<EditorialLayoutBody {...args}>
+			Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo, quaerat!
+		</EditorialLayoutBody>
 	);
 };
 

--- a/components/o-editorial-layout/stories/core/editorial-layout-heading.stories.tsx
+++ b/components/o-editorial-layout/stories/core/editorial-layout-heading.stories.tsx
@@ -1,17 +1,17 @@
-import {ComponentMeta} from "@storybook/react";
-import {EditorialLayoutHeading} from "../../src/tsx/editorial-layout-heading";
+import {ComponentMeta} from '@storybook/react';
+import {EditorialLayoutHeading} from '../../src/tsx/editorial-layout-heading';
 import './editorialLayout.scss';
 
 export default {
-	title: 'Components/o-editorial-layout',
+	title: 'Maintained/o-editorial-layout',
 	component: EditorialLayoutHeading,
 	args: {
-		title: 'What I learnt in my days on the mountain in Davos'
-	}
+		title: 'What I learnt in my days on the mountain in Davos',
+	},
 } as ComponentMeta<typeof EditorialLayoutHeading>;
 
 const Template = args => {
-	const {title,  ...headingArgs} = args
+	const {title, ...headingArgs} = args;
 	return (
 		<EditorialLayoutHeading {...headingArgs}>{title}</EditorialLayoutHeading>
 	);
@@ -19,5 +19,5 @@ const Template = args => {
 
 export const Heading = Template.bind({});
 Heading.args = {
-	headingLevel: '1'
-}
+	headingLevel: '1',
+};

--- a/components/o-editorial-layout/stories/core/editorial-layout-wrapper.stories.tsx
+++ b/components/o-editorial-layout/stories/core/editorial-layout-wrapper.stories.tsx
@@ -1,11 +1,11 @@
-import {ComponentMeta} from "@storybook/react";
-import {EditorialLayoutWrapper} from "../../src/tsx/editorial-layout-wrapper";
+import {ComponentMeta} from '@storybook/react';
+import {EditorialLayoutWrapper} from '../../src/tsx/editorial-layout-wrapper';
 import './editorialLayout.scss';
-import {EditorialLayoutHeading} from "../../src/tsx/editorial-layout-heading";
-import {EditorialLayoutBody} from "../../src/tsx/editorial-layout-body";
+import {EditorialLayoutHeading} from '../../src/tsx/editorial-layout-heading';
+import {EditorialLayoutBody} from '../../src/tsx/editorial-layout-body';
 
 export default {
-	title: 'Components/o-editorial-layout',
+	title: 'Maintained/o-editorial-layout',
 	component: EditorialLayoutWrapper,
 } as ComponentMeta<typeof EditorialLayoutWrapper>;
 
@@ -45,7 +45,11 @@ const WrapperTemplate = () => {
 				Veritatis dicta veniam odit provident rerum aperiam ipsa ducimus
 				architecto voluptate optio, perferendis quidem beatae magnam ut est
 				facilis,
-				<strong><i>quos vitae<sup>sup</sup> neque facere</i></strong>
+				<strong>
+					<i>
+						quos vitae<sup>sup</sup> neque facere
+					</i>
+				</strong>
 				quisquam. Culpa animi, recusandae tempore maxime incidunt molestias,
 				dolore nulla facilis porro illo mollitia consectetur modi ex iusto
 				exercitationem dolorem voluptates nostrum nisi fuga laboriosam sequi
@@ -100,7 +104,9 @@ const WrapperTemplate = () => {
 					Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo,
 					quaerat!
 				</p>
-				<footer><cite>Lorem, ipsum dolor.</cite></footer>
+				<footer>
+					<cite>Lorem, ipsum dolor.</cite>
+				</footer>
 			</blockquote>
 
 			<p>
@@ -195,8 +201,12 @@ export const WrapperWithNestedElements = WrapperTemplate.bind({});
 const ContentBodyMarginsTemplate = () => {
 	return (
 		<>
-			<EditorialLayoutHeading headingLevel='1'>heading 1</EditorialLayoutHeading>
-			<EditorialLayoutHeading headingLevel='2'>heading 2</EditorialLayoutHeading>
+			<EditorialLayoutHeading headingLevel="1">
+				heading 1
+			</EditorialLayoutHeading>
+			<EditorialLayoutHeading headingLevel="2">
+				heading 2
+			</EditorialLayoutHeading>
 
 			<EditorialLayoutBody>
 				Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex velit beatae
@@ -226,31 +236,35 @@ const ContentBodyMarginsTemplate = () => {
 			<EditorialLayoutBody>
 				Veritatis dicta veniam odit provident rerum aperiam ipsa ducimus
 				architecto voluptate optio, perferendis quidem beatae magnam ut est
-				facilis, quos vitae neque facere quisquam. Culpa animi, recusandae tempore
-				maxime incidunt molestias, dolore nulla facilis porro illo mollitia
-				consectetur modi ex iusto exercitationem dolorem voluptates nostrum nisi
-				fuga laboriosam sequi beatae! Incidunt doloremque commodi ipsam adipisci!
-				Officiis quod eum aliquam molestiae facere beatae nisi nam esse veniam
-				delectus dolore harum suscipit, odit voluptatibus officia temporibus
-				ducimus! Officia cumque voluptates ipsa saepe perferendis ab impedit
-				labore, tempore, deserunt ducimus at? Doloremque ea consequatur temporibus
-				nisi nulla! Vero laudantium quas molestiae commodi deleniti.
+				facilis, quos vitae neque facere quisquam. Culpa animi, recusandae
+				tempore maxime incidunt molestias, dolore nulla facilis porro illo
+				mollitia consectetur modi ex iusto exercitationem dolorem voluptates
+				nostrum nisi fuga laboriosam sequi beatae! Incidunt doloremque commodi
+				ipsam adipisci! Officiis quod eum aliquam molestiae facere beatae nisi
+				nam esse veniam delectus dolore harum suscipit, odit voluptatibus
+				officia temporibus ducimus! Officia cumque voluptates ipsa saepe
+				perferendis ab impedit labore, tempore, deserunt ducimus at? Doloremque
+				ea consequatur temporibus nisi nulla! Vero laudantium quas molestiae
+				commodi deleniti.
 			</EditorialLayoutBody>
 			<EditorialLayoutBody>
-				Expedita error placeat soluta odit modi. Voluptatem, illum neque inventore
-				hic voluptatum, esse optio recusandae numquam nostrum magni, quibusdam
-				animi earum tenetur sit eius perspiciatis. Quas quidem atque id? Est
-				architecto exercitationem, voluptate sint beatae repudiandae vitae neque
-				nostrum, ut tempora eligendi blanditiis saepe praesentium delectus omnis
-				molestiae quibusdam aliquam rerum deleniti molestias quas, maiores
-				consequatur reprehenderit! Dolores libero tempore incidunt dolorem
-				distinctio! Sapiente, repellat, dicta reiciendis velit in illo ducimus
-				ullam, laborum nam obcaecati mollitia nulla. Saepe ipsa fugit fuga non
-				nihil praesentium commodi dolorem nesciunt, ducimus quod deleniti aperiam
-				vel distinctio cumque dicta dolor pariatur enim dolore illum.
+				Expedita error placeat soluta odit modi. Voluptatem, illum neque
+				inventore hic voluptatum, esse optio recusandae numquam nostrum magni,
+				quibusdam animi earum tenetur sit eius perspiciatis. Quas quidem atque
+				id? Est architecto exercitationem, voluptate sint beatae repudiandae
+				vitae neque nostrum, ut tempora eligendi blanditiis saepe praesentium
+				delectus omnis molestiae quibusdam aliquam rerum deleniti molestias
+				quas, maiores consequatur reprehenderit! Dolores libero tempore incidunt
+				dolorem distinctio! Sapiente, repellat, dicta reiciendis velit in illo
+				ducimus ullam, laborum nam obcaecati mollitia nulla. Saepe ipsa fugit
+				fuga non nihil praesentium commodi dolorem nesciunt, ducimus quod
+				deleniti aperiam vel distinctio cumque dicta dolor pariatur enim dolore
+				illum.
 			</EditorialLayoutBody>
 
-			<EditorialLayoutHeading headingLevel='3'>heading 3</EditorialLayoutHeading>
+			<EditorialLayoutHeading headingLevel="3">
+				heading 3
+			</EditorialLayoutHeading>
 
 			<EditorialLayoutBody>
 				Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex velit beatae
@@ -280,18 +294,21 @@ const ContentBodyMarginsTemplate = () => {
 			<EditorialLayoutBody>
 				Veritatis dicta veniam odit provident rerum aperiam ipsa ducimus
 				architecto voluptate optio, perferendis quidem beatae magnam ut est
-				facilis, quos vitae neque facere quisquam. Culpa animi, recusandae tempore
-				maxime incidunt molestias, dolore nulla facilis porro illo mollitia
-				consectetur modi ex iusto exercitationem dolorem voluptates nostrum nisi
-				fuga laboriosam sequi beatae! Incidunt doloremque commodi ipsam adipisci!
-				Officiis quod eum aliquam molestiae facere beatae nisi nam esse veniam
-				delectus dolore harum suscipit, odit voluptatibus officia temporibus
-				ducimus! Officia cumque voluptates ipsa saepe perferendis ab impedit
-				labore, tempore, deserunt ducimus at? Doloremque ea consequatur temporibus
-				nisi nulla! Vero laudantium quas molestiae commodi deleniti.
+				facilis, quos vitae neque facere quisquam. Culpa animi, recusandae
+				tempore maxime incidunt molestias, dolore nulla facilis porro illo
+				mollitia consectetur modi ex iusto exercitationem dolorem voluptates
+				nostrum nisi fuga laboriosam sequi beatae! Incidunt doloremque commodi
+				ipsam adipisci! Officiis quod eum aliquam molestiae facere beatae nisi
+				nam esse veniam delectus dolore harum suscipit, odit voluptatibus
+				officia temporibus ducimus! Officia cumque voluptates ipsa saepe
+				perferendis ab impedit labore, tempore, deserunt ducimus at? Doloremque
+				ea consequatur temporibus nisi nulla! Vero laudantium quas molestiae
+				commodi deleniti.
 			</EditorialLayoutBody>
 
-			<EditorialLayoutHeading headingLevel='4'>heading 4</EditorialLayoutHeading>
+			<EditorialLayoutHeading headingLevel="4">
+				heading 4
+			</EditorialLayoutHeading>
 
 			<EditorialLayoutBody>
 				Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex velit beatae
@@ -319,7 +336,9 @@ const ContentBodyMarginsTemplate = () => {
 				hic inventore dolorum laudantium ullam, aspernatur explicabo?
 			</EditorialLayoutBody>
 
-			<EditorialLayoutHeading headingLevel='5'>heading 5</EditorialLayoutHeading>
+			<EditorialLayoutHeading headingLevel="5">
+				heading 5
+			</EditorialLayoutHeading>
 
 			<EditorialLayoutBody>
 				Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex velit beatae
@@ -334,6 +353,6 @@ const ContentBodyMarginsTemplate = () => {
 				illum voluptatibus. Explicabo perferendis voluptas consequuntur ea.
 			</EditorialLayoutBody>
 		</>
-	)
-}
+	);
+};
 export const ContentBodyMargins = ContentBodyMarginsTemplate.bind({});

--- a/components/o-editorial-layout/stories/readme.stories.mdx
+++ b/components/o-editorial-layout/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-editorial-layout/Readme"
+	title="Maintained/o-editorial-layout/Readme"
 />
 
 

--- a/components/o-editorial-layout/stories/sassdoc.stories.mdx
+++ b/components/o-editorial-layout/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-editorial-layout/SassDoc"
+title="Maintained/o-editorial-layout/SassDoc"
 />
 
 <Markdown>

--- a/components/o-editorial-typography/stories/core/body.stories.tsx
+++ b/components/o-editorial-typography/stories/core/body.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Body',
+	title: 'Deprecated/o-editorial-typography/Body',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Body = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=body&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=body&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/byline-with-timestamp.stories.tsx
+++ b/components/o-editorial-typography/stories/core/byline-with-timestamp.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Byline With Timestamp',
+	title: 'Deprecated/o-editorial-typography/Byline With Timestamp',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BylineWithTimestamp = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=byline&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=byline&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/caption.stories.tsx
+++ b/components/o-editorial-typography/stories/core/caption.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Caption',
+	title: 'Deprecated/o-editorial-typography/Caption',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Caption = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=caption&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=caption&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/display.stories.tsx
+++ b/components/o-editorial-typography/stories/core/display.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-editorial-typography/Headline Large',
+	title: 'Deprecated/o-editorial-typography/Headline Large',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-editorial-typography/stories/core/headings.stories.tsx
+++ b/components/o-editorial-typography/stories/core/headings.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Headings',
+	title: 'Deprecated/o-editorial-typography/Headings',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Headings = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=headings&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=headings&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/headline-large.stories.tsx
+++ b/components/o-editorial-typography/stories/core/headline-large.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Headline Large',
+	title: 'Deprecated/o-editorial-typography/Headline Large',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const HeadlineLarge = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=headline&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=headline&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/links-inverse.stories.tsx
+++ b/components/o-editorial-typography/stories/core/links-inverse.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Links Inverse',
+	title: 'Deprecated/o-editorial-typography/Links Inverse',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const LinksInverse = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=links-inverse&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=links-inverse&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/links.stories.tsx
+++ b/components/o-editorial-typography/stories/core/links.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Links',
+	title: 'Deprecated/o-editorial-typography/Links',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Links = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=links&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=links&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/ordered-list.stories.tsx
+++ b/components/o-editorial-typography/stories/core/ordered-list.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Ordered List',
+	title: 'Deprecated/o-editorial-typography/Ordered List',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const OrderedList = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=ordered-list&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=ordered-list&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/standfirst.stories.tsx
+++ b/components/o-editorial-typography/stories/core/standfirst.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Standfirst',
+	title: 'Deprecated/o-editorial-typography/Standfirst',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Standfirst = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=standfirst&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=standfirst&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/topic-tag.stories.tsx
+++ b/components/o-editorial-typography/stories/core/topic-tag.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Topic Tag',
+	title: 'Deprecated/o-editorial-typography/Topic Tag',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const TopicTag = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=topic-tag&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=topic-tag&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/core/unordered-list.stories.tsx
+++ b/components/o-editorial-typography/stories/core/unordered-list.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-editorial-typography/Unordered List',
+	title: 'Deprecated/o-editorial-typography/Unordered List',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const UnorderedList = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=unordered-list&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-editorial-typography%402.4.0&demo=unordered-list&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-editorial-typography/stories/readme.stories.mdx
+++ b/components/o-editorial-typography/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-editorial-typography/Readme"
+	title="Deprecated/o-editorial-typography/Readme"
 />
 
 

--- a/components/o-expander/stories/expander.stories.tsx
+++ b/components/o-expander/stories/expander.stories.tsx
@@ -4,7 +4,7 @@ import './expander.scss';
 import {useEffect} from 'react';
 
 export default {
-	title: 'Components/o-expander',
+	title: 'Maintained/o-expander',
 	component: Expander,
 	parameters: {
 		html: {},

--- a/components/o-expander/stories/jsdoc.stories.mdx
+++ b/components/o-expander/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-expander/JSDoc"
+title="Maintained/o-expander/JSDoc"
 />
 
 <Markdown>

--- a/components/o-expander/stories/nested-expander.stories.tsx
+++ b/components/o-expander/stories/nested-expander.stories.tsx
@@ -14,33 +14,29 @@ export const NestedExpander = ({children, ...args}) => {
 				<li>three</li>
 				<li>four</li>
 			</ul>
-			<button className="o-expander__toggle">Secondary toggler button first expander</button>
+			<button className="o-expander__toggle">
+				Secondary toggler button first expander
+			</button>
 			<div className="innerExpanderItem">
 				<Expander {...args} header={<h3>Second Expander</h3>}>
-				<p>Second expander details</p>
-				<ul>
-					<li>ten</li>
-					<li>eleven</li>
-					<li>twelve</li>
-					<li>thirteen</li>
-				</ul>
-			</Expander>
+					<p>Second expander details</p>
+					<ul>
+						<li>ten</li>
+						<li>eleven</li>
+						<li>twelve</li>
+						<li>thirteen</li>
+					</ul>
+				</Expander>
 			</div>
 		</Expander>
 	);
 };
 
 export default {
-	title: 'Components/o-expander',
+	title: 'Maintained/o-expander',
 	component: NestedExpander,
 	parameters: {
 		html: {},
 	},
-	args: {
-
-	},
+	args: {},
 };
-
-
-
-

--- a/components/o-expander/stories/readme.stories.mdx
+++ b/components/o-expander/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-expander/Readme"
+	title="Maintained/o-expander/Readme"
 />
 
 

--- a/components/o-expander/stories/sassdoc.stories.mdx
+++ b/components/o-expander/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-expander/SassDoc"
+title="Maintained/o-expander/SassDoc"
 />
 
 <Markdown>

--- a/components/o-fonts/stories/core/financier-display.stories.tsx
+++ b/components/o-fonts/stories/core/financier-display.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-fonts/Financier Display',
+	title: 'Deprecated/o-fonts/Financier Display',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FinancierDisplay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=financierdisplayweb&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=financierdisplayweb&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-fonts/stories/core/metric.stories.tsx
+++ b/components/o-fonts/stories/core/metric.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-fonts/Metric',
+	title: 'Deprecated/o-fonts/Metric',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Metric = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=metricweb&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=metricweb&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-fonts/stories/internal/metric.stories.tsx
+++ b/components/o-fonts/stories/internal/metric.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-fonts/Metric',
+	title: 'Deprecated/o-fonts/Metric',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Metric = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=metricweb&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-fonts%405.3.4&demo=metricweb&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-fonts/stories/readme.stories.mdx
+++ b/components/o-fonts/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-fonts/Readme"
+	title="Deprecated/o-fonts/Readme"
 />
 
 

--- a/components/o-fonts/stories/sassdoc.stories.mdx
+++ b/components/o-fonts/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-fonts/SassDoc"
+title="Deprecated/o-fonts/SassDoc"
 />
 
 <Markdown>

--- a/components/o-footer-services/stories/core/brand-strip.stories.tsx
+++ b/components/o-footer-services/stories/core/brand-strip.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Brand Strip',
+	title: 'Maintained/o-footer-services/Brand Strip',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BrandStrip = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/dark-theme.stories.tsx
+++ b/components/o-footer-services/stories/core/dark-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Dark Theme',
+	title: 'Maintained/o-footer-services/Dark Theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const DarkTheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=dark-footer&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=dark-footer&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer-content-only.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-content-only.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Content Only',
+	title: 'Maintained/o-footer-services/Footer Content Only',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterContentOnly = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer-legal.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-legal.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Legal',
+	title: 'Maintained/o-footer-services/Footer Legal',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLegal = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer-links.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-links.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Links',
+	title: 'Maintained/o-footer-services/Footer Links',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLinks = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer-logo---content.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-logo---content.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-footer-services/Footer Logo and Content',
+	title: 'Maintained/o-footer-services/Footer Logo and Content',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-footer-services/stories/core/footer-logo.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-logo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Logo',
+	title: 'Maintained/o-footer-services/Footer Logo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLogo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer-no-content.stories.tsx
+++ b/components/o-footer-services/stories/core/footer-no-content.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer No Content',
+	title: 'Maintained/o-footer-services/Footer No Content',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterNoContent = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/footer.stories.tsx
+++ b/components/o-footer-services/stories/core/footer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer',
+	title: 'Maintained/o-footer-services/Footer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Footer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/core/sassdoc.stories.mdx
+++ b/components/o-footer-services/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-footer-services/SassDoc"
+title="Maintained/o-footer-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-footer-services/stories/internal/brand-strip.stories.tsx
+++ b/components/o-footer-services/stories/internal/brand-strip.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Brand Strip',
+	title: 'Maintained/o-footer-services/Brand Strip',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BrandStrip = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer-content-only.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-content-only.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Content Only',
+	title: 'Maintained/o-footer-services/Footer Content Only',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterContentOnly = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer-legal.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-legal.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Legal',
+	title: 'Maintained/o-footer-services/Footer Legal',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLegal = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer-links.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-links.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Links',
+	title: 'Maintained/o-footer-services/Footer Links',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLinks = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer-logo---content.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-logo---content.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-footer-services/Footer Logo and Content',
+	title: 'Maintained/o-footer-services/Footer Logo and Content',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-footer-services/stories/internal/footer-logo.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-logo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Logo',
+	title: 'Maintained/o-footer-services/Footer Logo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLogo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer-no-content.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer-no-content.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer No Content',
+	title: 'Maintained/o-footer-services/Footer No Content',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterNoContent = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/footer.stories.tsx
+++ b/components/o-footer-services/stories/internal/footer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer',
+	title: 'Maintained/o-footer-services/Footer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Footer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/internal/sassdoc.stories.mdx
+++ b/components/o-footer-services/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-footer-services/SassDoc"
+title="Maintained/o-footer-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-footer-services/stories/readme.stories.mdx
+++ b/components/o-footer-services/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-footer-services/Readme"
+	title="Maintained/o-footer-services/Readme"
 />
 
 

--- a/components/o-footer-services/stories/whitelabel/brand-strip.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/brand-strip.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Brand Strip',
+	title: 'Maintained/o-footer-services/Brand Strip',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BrandStrip = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=brand-strip&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer-content-only.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-content-only.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Content Only',
+	title: 'Maintained/o-footer-services/Footer Content Only',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterContentOnly = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-content-only&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer-legal.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-legal.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Legal',
+	title: 'Maintained/o-footer-services/Footer Legal',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLegal = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-legal&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer-links.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-links.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Links',
+	title: 'Maintained/o-footer-services/Footer Links',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLinks = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-links&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer-logo---content.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-logo---content.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-footer-services/Footer Logo and Content',
+	title: 'Maintained/o-footer-services/Footer Logo and Content',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-footer-services/stories/whitelabel/footer-logo.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-logo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer Logo',
+	title: 'Maintained/o-footer-services/Footer Logo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterLogo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-logo&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer-no-content.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer-no-content.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer No Content',
+	title: 'Maintained/o-footer-services/Footer No Content',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FooterNoContent = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer-no-content&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/footer.stories.tsx
+++ b/components/o-footer-services/stories/whitelabel/footer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer-services/Footer',
+	title: 'Maintained/o-footer-services/Footer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Footer = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer-services%404.2.7&demo=footer&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer-services/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-footer-services/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-footer-services/SassDoc"
+title="Maintained/o-footer-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-footer/stories/core/dark-theme.stories.tsx
+++ b/components/o-footer/stories/core/dark-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer/Dark theme',
+	title: 'Maintained/o-footer/Dark theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Darktheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=footer&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=footer&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer/stories/core/light-theme.stories.tsx
+++ b/components/o-footer/stories/core/light-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer/Light theme',
+	title: 'Maintained/o-footer/Light theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Lighttheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=footer-light&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=footer-light&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer/stories/core/short-footer.stories.tsx
+++ b/components/o-footer/stories/core/short-footer.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-footer/Short footer',
+	title: 'Maintained/o-footer/Short footer',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Shortfooter = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=simple-footer&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-footer%409.2.8&demo=simple-footer&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-footer/stories/jsdoc.stories.mdx
+++ b/components/o-footer/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-footer/JSDoc"
+title="Maintained/o-footer/JSDoc"
 />
 
 <Markdown>

--- a/components/o-footer/stories/readme.stories.mdx
+++ b/components/o-footer/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-footer/Readme"
+	title="Maintained/o-footer/Readme"
 />
 
 

--- a/components/o-footer/stories/sassdoc.stories.mdx
+++ b/components/o-footer/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-footer/SassDoc"
+title="Maintained/o-footer/SassDoc"
 />
 
 <Markdown>

--- a/components/o-forms/stories/boxRadioBtns.stories.tsx
+++ b/components/o-forms/stories/boxRadioBtns.stories.tsx
@@ -12,17 +12,17 @@ const hideArg = {
 
 const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const themeControl =
-	Brand === "core"
+	Brand === 'core'
 		? {
 				control: {
-					type: "select",
+					type: 'select',
 				},
-				options: [undefined, "professional", "professional-inverse", "ft-live"],
+				options: [undefined, 'professional', 'professional-inverse', 'ft-live'],
 		  }
 		: hideArg;
 
 export default {
-	title: 'Components/o-forms/box-radio-buttons',
+	title: 'Maintained/o-forms/box-radio-buttons',
 	component: RadioBtnsBox,
 	args: {},
 	argTypes: {
@@ -51,54 +51,54 @@ export const StateBoxRadioButton = Template.bind({});
 
 BoxRadioButton.args = {
 	children: [
-		<RadioBtn name="default" value="Daily" checked/>,
-		<RadioBtn name="default" value="Weekly"/>,
+		<RadioBtn name="default" value="Daily" checked />,
+		<RadioBtn name="default" value="Weekly" />,
 	],
 	title: 'Box style radio buttons',
 	description: 'Optional prompt text',
-	isOptional: true
+	isOptional: true,
 };
 
 NegativeHighlight.args = {
 	children: [
-		<RadioBtn name="default" value="Yes"/>,
-		<RadioBtn name="default" value="No" checked isNegative/>,
+		<RadioBtn name="default" value="Yes" />,
+		<RadioBtn name="default" value="No" checked isNegative />,
 	],
 	title: 'Negative highlight',
-	description: 'Requires a modifier on the label'
+	description: 'Requires a modifier on the label',
 };
 
 MultipleBoxRadioButton.args = {
 	children: [
-		<RadioBtn name="default" value="Daily"/>,
-		<RadioBtn name="default" value="Weekly" checked/>,
-		<RadioBtn name="default" value="Monthly"/>,
+		<RadioBtn name="default" value="Daily" />,
+		<RadioBtn name="default" value="Weekly" checked />,
+		<RadioBtn name="default" value="Monthly" />,
 	],
-	title: 'Multiple box-styled radio buttons'
+	title: 'Multiple box-styled radio buttons',
 };
 
 DisabledBoxRadioButton.args = {
 	children: [
-		<RadioBtn name="default" value="Daily" checked disabled/>,
-		<RadioBtn name="default" value="Weekly" checked disabled/>,
+		<RadioBtn name="default" value="Daily" checked disabled />,
+		<RadioBtn name="default" value="Weekly" checked disabled />,
 	],
-	title: 'Disabled box-styled radio buttons'
+	title: 'Disabled box-styled radio buttons',
 };
 ErrorBoxRadioButton.args = {
 	children: [
-		<RadioBtn name="default" value="Yes"/>,
-		<RadioBtn name="default" value="No"/>,
+		<RadioBtn name="default" value="Yes" />,
+		<RadioBtn name="default" value="No" />,
 	],
 	title: 'Error box-style radio buttons',
-	errorMessage: 'An example error. Try again.'
+	errorMessage: 'An example error. Try again.',
 };
 
 StateBoxRadioButton.args = {
 	children: [
-		<RadioBtn name="default" value="Daily" checked/>,
-		<RadioBtn name="default" value="Weekly"/>,
+		<RadioBtn name="default" value="Daily" checked />,
+		<RadioBtn name="default" value="Weekly" />,
 	],
 	title: 'Stateful Box Button',
 	description: 'Also available with icon only',
-	state: 'saving'
+	state: 'saving',
 };

--- a/components/o-forms/stories/boxRadioLinks.stories.tsx
+++ b/components/o-forms/stories/boxRadioLinks.stories.tsx
@@ -12,11 +12,11 @@ const hideArg = {
 };
 
 export default {
-	title: 'Components/o-forms/pseudo-box-radio-links',
+	title: 'Maintained/o-forms/pseudo-box-radio-links',
 	component: RadioBoxLinks,
 	argTypes: {
 		children: hideArg,
-    theme: hideArg,
+		theme: hideArg,
 		...demoArgs,
 	},
 } as ComponentMeta<typeof RadioBoxLinks>;

--- a/components/o-forms/stories/checkboxes.stories.tsx
+++ b/components/o-forms/stories/checkboxes.stories.tsx
@@ -1,8 +1,8 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useEffect } from "react";
-import { Checkbox, Checkboxes } from "../src/tsx/o-forms";
-import "./forms.scss";
-import javascript from "../main.js";
+import {ComponentStory, ComponentMeta} from '@storybook/react';
+import {useEffect} from 'react';
+import {Checkbox, Checkboxes} from '../src/tsx/o-forms';
+import './forms.scss';
+import javascript from '../main.js';
 
 const hideArg = {
 	table: {
@@ -12,18 +12,17 @@ const hideArg = {
 
 const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const themeControl =
-	Brand === "core"
+	Brand === 'core'
 		? {
 				control: {
-					type: "select",
+					type: 'select',
 				},
-				options: [undefined, "professional", "professional-inverse", "ft-live"],
+				options: [undefined, 'professional', 'professional-inverse', 'ft-live'],
 		  }
 		: hideArg;
 
-
 export default {
-	title: "Components/o-forms/checkboxes",
+	title: 'Maintained/o-forms/checkboxes',
 	component: Checkboxes,
 	argTypes: {
 		children: hideArg,
@@ -56,8 +55,8 @@ CheckboxesStacked.args = {
 		<Checkbox name="default" value="Weekly" />,
 		<Checkbox name="default" value="Monthly" checked />,
 	],
-	title: "Stacked checkboxes",
-	description: "Optional description text",
+	title: 'Stacked checkboxes',
+	description: 'Optional description text',
 	isOptional: true,
 };
 CheckboxesWithDescription.args = {
@@ -74,8 +73,8 @@ CheckboxesWithDescription.args = {
 			description="Lorem, ipsum dolor sit amet consectetur adipisicing elit. Aperiam numquam aspernatur error voluptas dolorem ab."
 		/>,
 	],
-	title: "Checkbox inputs with description",
-	description: "Optional description text",
+	title: 'Checkbox inputs with description',
+	description: 'Optional description text',
 };
 
 DisabledCheckboxes.args = {
@@ -83,15 +82,15 @@ DisabledCheckboxes.args = {
 		<Checkbox name="default" value="Daily" checked disabled />,
 		<Checkbox name="default" value="Weekly" disabled />,
 	],
-	title: "Disabled checkboxes",
+	title: 'Disabled checkboxes',
 };
 ErrorCheckboxes.args = {
 	children: [
 		<Checkbox name="default" value="Yes" />,
 		<Checkbox name="default" value="No" />,
 	],
-	title: "Error checkboxes",
-	errorMessage: "An example error. Try again.",
+	title: 'Error checkboxes',
+	errorMessage: 'An example error. Try again.',
 };
 
 InlineField.args = {
@@ -100,14 +99,14 @@ InlineField.args = {
 		<Checkbox name="default" value="Weekly" checked />,
 		<Checkbox name="default" value="Monthly" />,
 	],
-	title: "Inline field: ",
+	title: 'Inline field: ',
 	inlineField: true,
-	description: "with stacked radio buttons",
+	description: 'with stacked radio buttons',
 };
 
 LabelFirst.args = {
 	children: [<Checkbox name="default" value="Show Password" labelFirst />],
-	title: "Label first checkbox",
+	title: 'Label first checkbox',
 };
 
 InlineFieldAndInputs.args = {
@@ -115,7 +114,7 @@ InlineFieldAndInputs.args = {
 		<Checkbox name="default" value="Daily" checked />,
 		<Checkbox name="default" value="Weekly" />,
 	],
-	title: "Inline field and checkboxes: ",
+	title: 'Inline field and checkboxes: ',
 	inlineInputs: true,
 	inlineField: true,
 };

--- a/components/o-forms/stories/dateInput.stories.tsx
+++ b/components/o-forms/stories/dateInput.stories.tsx
@@ -11,12 +11,12 @@ const hideArg = {
 };
 
 export default {
-	title: 'Components/o-forms/date-input',
+	title: 'Maintained/o-forms/date-input',
 	component: DateInput,
 	argTypes: {
 		onChange: hideArg,
 		values: hideArg,
-    theme: hideArg
+		theme: hideArg,
 	},
 } as ComponentMeta<typeof DateInput>;
 

--- a/components/o-forms/stories/fileInput.stories.tsx
+++ b/components/o-forms/stories/fileInput.stories.tsx
@@ -11,11 +11,11 @@ const hideArg = {
 };
 
 export default {
-	title: 'Components/o-forms/file-input',
+	title: 'Maintained/o-forms/file-input',
 	component: FileInput,
 	argTypes: {
 		value: hideArg,
-		theme: hideArg
+		theme: hideArg,
 	},
 } as ComponentMeta<typeof FileInput>;
 

--- a/components/o-forms/stories/jsdoc.stories.mdx
+++ b/components/o-forms/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-forms/JSDoc"
+title="Maintained/o-forms/JSDoc"
 />
 
 <Markdown>

--- a/components/o-forms/stories/radioBtns.stories.tsx
+++ b/components/o-forms/stories/radioBtns.stories.tsx
@@ -22,7 +22,7 @@ const themeControl =
 		: hideArg;
 
 export default {
-	title: 'Components/o-forms/radio-buttons',
+	title: 'Maintained/o-forms/radio-buttons',
 	component: RadioBtns,
 	argTypes: {
 		children: hideArg,

--- a/components/o-forms/stories/readme.stories.mdx
+++ b/components/o-forms/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-forms/Readme"
+	title="Maintained/o-forms/Readme"
 />
 
 

--- a/components/o-forms/stories/sassdoc.stories.mdx
+++ b/components/o-forms/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-forms/SassDoc"
+title="Maintained/o-forms/SassDoc"
 />
 
 <Markdown>

--- a/components/o-forms/stories/select.stories.tsx
+++ b/components/o-forms/stories/select.stories.tsx
@@ -11,7 +11,7 @@ const hideArg = {
 };
 
 export default {
-	title: 'Components/o-forms/select-box',
+	title: 'Maintained/o-forms/select-box',
 	component: Select,
 	argTypes: {
 		onChange: hideArg,

--- a/components/o-forms/stories/textBox.stories.tsx
+++ b/components/o-forms/stories/textBox.stories.tsx
@@ -11,7 +11,7 @@ const hideArg = {
 };
 
 export default {
-	title: 'Components/o-forms/text-box',
+	title: 'Maintained/o-forms/text-box',
 	component: TextInput,
 	argTypes: {
 		onChange: hideArg,

--- a/components/o-forms/stories/toggleCheckboxes.stories.tsx
+++ b/components/o-forms/stories/toggleCheckboxes.stories.tsx
@@ -10,12 +10,12 @@ const hideArg = {
 	},
 };
 export default {
-	title: 'Components/o-forms/toggle-checkboxes',
+	title: 'Maintained/o-forms/toggle-checkboxes',
 	component: Checkboxes,
 	argTypes: {
 		children: hideArg,
-		theme: hideArg
-	}
+		theme: hideArg,
+	},
 } as ComponentMeta<typeof Checkboxes>;
 
 const Template: ComponentStory<typeof Checkboxes> = args => {

--- a/components/o-ft-affiliate-ribbon/stories/ft-affiliate-ribon.stories.tsx
+++ b/components/o-ft-affiliate-ribbon/stories/ft-affiliate-ribon.stories.tsx
@@ -1,12 +1,12 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
-import "./ft-affiliate-ribbon.scss";
-import { FtAffiliateRibbon } from "../src/tsx/ft-affiliate-ribbon";
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import './ft-affiliate-ribbon.scss';
+import {FtAffiliateRibbon} from '../src/tsx/ft-affiliate-ribbon';
 
 export default {
-	title: "Components/o-ft-affiliate-ribbon",
+	title: 'Maintained/o-ft-affiliate-ribbon',
 	component: FtAffiliateRibbon,
 	parameters: {
-		layout: "fullscreen",
+		layout: 'fullscreen',
 	},
 } as ComponentMeta<typeof FtAffiliateRibbon>;
 
@@ -15,4 +15,4 @@ export const FtAffiliateRibbonStory: ComponentStory<
 > = () => {
 	return <FtAffiliateRibbon />;
 };
-FtAffiliateRibbonStory.storyName = "Default FT Affiliate Ribbon";
+FtAffiliateRibbonStory.storyName = 'Default FT Affiliate Ribbon';

--- a/components/o-ft-affiliate-ribbon/stories/readme.stories.mdx
+++ b/components/o-ft-affiliate-ribbon/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-ft-affiliate-ribbon/Readme"
+	title="Maintained/o-ft-affiliate-ribbon/Readme"
 />
 
 

--- a/components/o-grid/stories/core/default-grid.stories.tsx
+++ b/components/o-grid/stories/core/default-grid.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-grid/Default Grid',
+	title: 'Maintained/o-grid/Default Grid',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const DefaultGrid = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=default&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=default&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-grid/stories/core/fixed-grid.stories.tsx
+++ b/components/o-grid/stories/core/fixed-grid.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-grid/Fixed Grid',
+	title: 'Maintained/o-grid/Fixed Grid',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FixedGrid = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=always-fixed&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=always-fixed&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-grid/stories/core/responsive-grid.stories.tsx
+++ b/components/o-grid/stories/core/responsive-grid.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-grid/Responsive Grid',
+	title: 'Maintained/o-grid/Responsive Grid',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveGrid = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=resized&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=resized&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-grid/stories/core/snappy-grid.stories.tsx
+++ b/components/o-grid/stories/core/snappy-grid.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-grid/Snappy Grid',
+	title: 'Maintained/o-grid/Snappy Grid',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SnappyGrid = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=snappy&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-grid%406.1.7&demo=snappy&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-grid/stories/internal/default-grid.stories.tsx
+++ b/components/o-grid/stories/internal/default-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Default Grid',
+	title: 'Maintained/o-grid/Default Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/internal/fixed-grid.stories.tsx
+++ b/components/o-grid/stories/internal/fixed-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Fixed Grid',
+	title: 'Maintained/o-grid/Fixed Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/internal/responsive-grid.stories.tsx
+++ b/components/o-grid/stories/internal/responsive-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Responsive Grid',
+	title: 'Maintained/o-grid/Responsive Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/internal/snappy-grid.stories.tsx
+++ b/components/o-grid/stories/internal/snappy-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Snappy Grid',
+	title: 'Maintained/o-grid/Snappy Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/readme.stories.mdx
+++ b/components/o-grid/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-grid/Readme"
+	title="Maintained/o-grid/Readme"
 />
 
 

--- a/components/o-grid/stories/sassdoc.stories.mdx
+++ b/components/o-grid/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-grid/SassDoc"
+title="Maintained/o-grid/SassDoc"
 />
 
 <Markdown>

--- a/components/o-grid/stories/whitelabel/default-grid.stories.tsx
+++ b/components/o-grid/stories/whitelabel/default-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Default Grid',
+	title: 'Maintained/o-grid/Default Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/whitelabel/fixed-grid.stories.tsx
+++ b/components/o-grid/stories/whitelabel/fixed-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Fixed Grid',
+	title: 'Maintained/o-grid/Fixed Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/whitelabel/responsive-grid.stories.tsx
+++ b/components/o-grid/stories/whitelabel/responsive-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Responsive Grid',
+	title: 'Maintained/o-grid/Responsive Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-grid/stories/whitelabel/snappy-grid.stories.tsx
+++ b/components/o-grid/stories/whitelabel/snappy-grid.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-grid/Snappy Grid',
+	title: 'Maintained/o-grid/Snappy Grid',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-header-services/stories/core/sassdoc.stories.mdx
+++ b/components/o-header-services/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-header-services/SassDoc"
+title="Maintained/o-header-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-header-services/stories/header-services.stories.tsx
+++ b/components/o-header-services/stories/header-services.stories.tsx
@@ -1,19 +1,19 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { HeaderServices } from "../src/tsx/header-services";
-import "./header-services.scss";
+import {ComponentStory, ComponentMeta} from '@storybook/react';
+import {HeaderServices} from '../src/tsx/header-services';
+import './header-services.scss';
 import {
 	DummyText,
 	primaryNavData,
 	secondaryNavData,
 	relatedContent,
-} from "./fixtures";
-import js from "../main";
-import { useEffect } from "react";
+} from './fixtures';
+import js from '../main';
+import {useEffect} from 'react';
 
 const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ThemeMapping = {
-	B2B: "b2b",
-	B2C: "b2c",
+	B2B: 'b2b',
+	B2C: 'b2c',
 	Default: undefined,
 };
 
@@ -24,24 +24,24 @@ const DummyTextDecorator = Story => (
 	</>
 );
 export default {
-	title: "Components/o-header-services",
+	title: 'Maintained/o-header-services',
 	component: HeaderServices,
 	decorators: [DummyTextDecorator],
 	parameters: {
-		layout: "fullscreen",
+		layout: 'fullscreen',
 	},
 	args: {
 		bleeedHeader: false,
-		relatedContentAlwaysVisible: false
+		relatedContentAlwaysVisible: false,
 	},
 	argTypes: {
 		theme: {
 			table: {
-				disable: Brand !== "core" && true,
+				disable: Brand !== 'core' && true,
 			},
 			options: Object.keys(ThemeMapping),
 			mapping: ThemeMapping,
-			control: "select",
+			control: 'select',
 		},
 	},
 } as ComponentMeta<typeof HeaderServices>;
@@ -56,9 +56,9 @@ export const HeaderWithPrimaryAndSecondaryNavigation: ComponentStory<
 > = HeaderServicesStory.bind({});
 
 HeaderWithPrimaryAndSecondaryNavigation.args = {
-	title: "Financial Times",
-	tagline: "The world’s leading global business publication",
-	titleUrl: "https://www.ft.com",
+	title: 'Financial Times',
+	tagline: 'The world’s leading global business publication',
+	titleUrl: 'https://www.ft.com',
 	relatedContent,
 	primaryNavData,
 	secondaryNavData,
@@ -68,9 +68,9 @@ export const HeaderWithTitleSection: ComponentStory<typeof HeaderServices> =
 	HeaderServicesStory.bind({});
 
 HeaderWithTitleSection.args = {
-	title: "Financial Times",
-	tagline: "The world’s leading global business publication",
-	titleUrl: "https://www.ft.com",
+	title: 'Financial Times',
+	tagline: 'The world’s leading global business publication',
+	titleUrl: 'https://www.ft.com',
 	relatedContent,
 };
 

--- a/components/o-header-services/stories/internal/sassdoc.stories.mdx
+++ b/components/o-header-services/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-header-services/SassDoc"
+title="Maintained/o-header-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-header-services/stories/jsdoc.stories.mdx
+++ b/components/o-header-services/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-header-services/JSDoc"
+title="Maintained/o-header-services/JSDoc"
 />
 
 <Markdown>

--- a/components/o-header-services/stories/readme.stories.mdx
+++ b/components/o-header-services/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-header-services/Readme"
+	title="Maintained/o-header-services/Readme"
 />
 
 

--- a/components/o-header-services/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-header-services/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-header-services/SassDoc"
+title="Maintained/o-header-services/SassDoc"
 />
 
 <Markdown>

--- a/components/o-header/stories/header.stories.tsx
+++ b/components/o-header/stories/header.stories.tsx
@@ -1,25 +1,25 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useEffect } from "react";
+import {ComponentStory, ComponentMeta} from '@storybook/react';
+import {useEffect} from 'react';
 import {
 	MainHeader,
 	LogoOnly,
 	NoOutboundLinksHeader,
 	InverseHeader,
-} from "../src/tsx/header";
-import javascript from "../main";
-import "./header.scss";
-import storyData from "./storybook-data";
-import profileStoryData from "./storybook-data/profile";
-import { argTypes } from "./arg-types";
-import { Drawer } from "../src/tsx/drawer";
+} from '../src/tsx/header';
+import javascript from '../main';
+import './header.scss';
+import storyData from './storybook-data';
+import profileStoryData from './storybook-data/profile';
+import {argTypes} from './arg-types';
+import {Drawer} from '../src/tsx/drawer';
 export default {
-	title: "Components/o-header",
+	title: 'Maintained/o-header',
 	component: MainHeader,
 	parameters: {
-		layout: "fullscreen",
+		layout: 'fullscreen',
 	},
 	args: {
-		currentPath: "/",
+		currentPath: '/',
 	},
 	argTypes,
 } as ComponentMeta<typeof MainHeader>;
@@ -41,10 +41,10 @@ export const HeaderPrimary: ComponentStory<typeof MainHeader> = args => {
 		</>
 	);
 };
-HeaderPrimary.storyName = "Default header with drawer and sticky header";
+HeaderPrimary.storyName = 'Default header with drawer and sticky header';
 HeaderPrimary.args = {
 	...storyData,
-	variant: "simple",
+	variant: 'simple',
 	showSubNavigation: true,
 	showMegaNav: true,
 	showUserNavigation: true,
@@ -56,7 +56,7 @@ HeaderPrimary.args = {
 };
 HeaderPrimary.parameters = {
 	controls: {
-		exclude: ["data", "variant", "userIsAnonymous", "extraHeaderProps"],
+		exclude: ['data', 'variant', 'userIsAnonymous', 'extraHeaderProps'],
 	},
 };
 
@@ -77,7 +77,7 @@ export const DefaultHeaderWithRightAlignedSubnav: ComponentStory<
 	);
 };
 DefaultHeaderWithRightAlignedSubnav.storyName =
-	"Default header with right aligned subnav";
+	'Default header with right aligned subnav';
 DefaultHeaderWithRightAlignedSubnav.args = {
 	...profileStoryData,
 	showSubNavigation: true,
@@ -90,11 +90,11 @@ DefaultHeaderWithRightAlignedSubnav.args = {
 DefaultHeaderWithRightAlignedSubnav.parameters = {
 	controls: {
 		exclude: [
-			"data",
-			"variant",
-			"userIsSubscribed",
-			"userIsAnonymous",
-			"extraHeaderProps",
+			'data',
+			'variant',
+			'userIsSubscribed',
+			'userIsAnonymous',
+			'extraHeaderProps',
 		],
 	},
 };
@@ -104,32 +104,32 @@ export const LogoOnlyHeader: ComponentStory<typeof LogoOnly> = args => {
 	return <LogoOnly {...args} />;
 };
 LogoOnlyHeader.args = {
-	variant: "simple",
+	variant: 'simple',
 	showLogoLink: false,
 };
 LogoOnlyHeader.argTypes = {
 	variant: {
 		control: {
-			type: "radio",
-			options: { default: "simple", large: "large" },
+			type: 'radio',
+			options: {default: 'simple', large: 'large'},
 		},
 	},
 };
 LogoOnlyHeader.parameters = {
 	controls: {
 		exclude: [
-			"data",
-			"currentPath",
-			"userIsLoggedIn",
-			"showAskButton",
-			"showSubNavigation",
-			"showUserNavigation",
-			"showMegaNav",
-			"userIsSubscribed",
-			"showStickyHeader",
-			"userIsAnonymous",
-			"extraHeaderProps",
-			"data",
+			'data',
+			'currentPath',
+			'userIsLoggedIn',
+			'showAskButton',
+			'showSubNavigation',
+			'showUserNavigation',
+			'showMegaNav',
+			'userIsSubscribed',
+			'showStickyHeader',
+			'userIsAnonymous',
+			'extraHeaderProps',
+			'data',
 		],
 	},
 };
@@ -141,7 +141,7 @@ export const NoOutboundLinks: ComponentStory<
 	return <NoOutboundLinksHeader {...args} />;
 };
 
-NoOutboundLinks.storyName = "No Outbound links";
+NoOutboundLinks.storyName = 'No Outbound links';
 NoOutboundLinks.args = {
 	...storyData,
 	showSubNavigation: true,
@@ -153,16 +153,16 @@ NoOutboundLinks.args = {
 NoOutboundLinks.parameters = {
 	controls: {
 		exclude: [
-			"data",
-			"currentPath",
-			"variant",
-			"showAskButton",
-			"showMegaNav",
-			"userIsSubscribed",
-			"showStickyHeader",
-			"userIsAnonymous",
-			"extraHeaderProps",
-			"data",
+			'data',
+			'currentPath',
+			'variant',
+			'showAskButton',
+			'showMegaNav',
+			'userIsSubscribed',
+			'showStickyHeader',
+			'userIsAnonymous',
+			'extraHeaderProps',
+			'data',
 		],
 	},
 };
@@ -173,27 +173,27 @@ export const InverseSimpleHeader: ComponentStory<
 	useEffect(() => void javascript.init(), []);
 	return <InverseHeader {...args} />;
 };
-InverseSimpleHeader.storyName = "Simple transparent (inverse) header";
+InverseSimpleHeader.storyName = 'Simple transparent (inverse) header';
 InverseSimpleHeader.args = {
 	...storyData,
 	showUserNavigation: true,
 	userIsLoggedIn: false,
 };
 InverseSimpleHeader.parameters = {
-	origamiBackground: "slate",
+	origamiBackground: 'slate',
 	controls: {
 		exclude: [
-			"data",
-			"currentPath",
-			"variant",
-			"showAskButton",
-			"showMegaNav",
-			"showSubNavigation",
-			"showLogoLink",
-			"showStickyHeader",
-			"userIsSubscribed",
-			"userIsAnonymous",
-			"extraHeaderProps",
+			'data',
+			'currentPath',
+			'variant',
+			'showAskButton',
+			'showMegaNav',
+			'showSubNavigation',
+			'showLogoLink',
+			'showStickyHeader',
+			'userIsSubscribed',
+			'userIsAnonymous',
+			'extraHeaderProps',
 		],
 	},
 };

--- a/components/o-header/stories/jsdoc.stories.mdx
+++ b/components/o-header/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-header/JSDoc"
+title="Maintained/o-header/JSDoc"
 />
 
 <Markdown>

--- a/components/o-header/stories/readme.stories.mdx
+++ b/components/o-header/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-header/Readme"
+	title="Maintained/o-header/Readme"
 />
 
 

--- a/components/o-header/stories/sassdoc.stories.mdx
+++ b/components/o-header/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-header/SassDoc"
+title="Maintained/o-header/SassDoc"
 />
 
 <Markdown>

--- a/components/o-icons/stories/icons.stories.tsx
+++ b/components/o-icons/stories/icons.stories.tsx
@@ -4,7 +4,7 @@ import {Icon} from '../src/tsx/icon';
 import './icons.scss';
 
 export default {
-	title: 'Components/o-icons',
+	title: 'Deprecated/o-icons',
 	component: Icon,
 	argTypes: {
 		icon: {

--- a/components/o-icons/stories/readme.stories.mdx
+++ b/components/o-icons/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-icons/Readme"
+	title="Deprecated/o-icons/Readme"
 />
 
 

--- a/components/o-icons/stories/sassdoc.stories.mdx
+++ b/components/o-icons/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-icons/SassDoc"
+title="Deprecated/o-icons/SassDoc"
 />
 
 <Markdown>

--- a/components/o-labels/stories/core/content.stories.tsx
+++ b/components/o-labels/stories/core/content.stories.tsx
@@ -2,33 +2,33 @@ import {ContentLabel as ContentLabelTsx} from '../../src/tsx/label';
 import '../labels.scss';
 
 const ComponentDescription = {
-    title: 'Components/o-labels',
-    component: ContentLabelTsx,
-    argTypes: {
-        state: { defaultValue: 'content-premium' },
-        size: {
-            options: ['small', 'default', 'big'],
-            defaultValue: 'default'
-        },
-        text: {
-            name: 'text',
-            type: { name: 'string', required: false },
-            control: {
-                type: 'text'
-            }
-        }
-    }
+	title: 'Maintained/o-labels',
+	component: ContentLabelTsx,
+	argTypes: {
+		state: {defaultValue: 'content-premium'},
+		size: {
+			options: ['small', 'default', 'big'],
+			defaultValue: 'default',
+		},
+		text: {
+			name: 'text',
+			type: {name: 'string', required: false},
+			control: {
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const ContentLabel = args => {
-    const copy = args.text || args.state.replace('content-', '');
-    if(args.size === 'default') {
-        delete args.size;
-    }
-    return <ContentLabelTsx {...args}>{copy}</ContentLabelTsx>;
-}
+	const copy = args.text || args.state.replace('content-', '');
+	if (args.size === 'default') {
+		delete args.size;
+	}
+	return <ContentLabelTsx {...args}>{copy}</ContentLabelTsx>;
+};
 ContentLabel.args = {
 	text: 'Premium',
-}
+};

--- a/components/o-labels/stories/core/indicators.stories.tsx
+++ b/components/o-labels/stories/core/indicators.stories.tsx
@@ -2,29 +2,32 @@ import ODate from '@financial-times/o-date/main';
 import {Date as DateTSX} from '@financial-times/o-date/src/tsx/date';
 import type {Meta, Story} from '@storybook/react';
 import {useEffect} from 'react';
-import {IndicatorLabel as OIndicatorLabel, IndicatorLabelProps} from '../../src/tsx/label';
+import {
+	IndicatorLabel as OIndicatorLabel,
+	IndicatorLabelProps,
+} from '../../src/tsx/label';
 import '../labels.scss';
 
 export default {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: OIndicatorLabel,
 	argTypes: {
 		inverse: {control: 'boolean', defaultValue: false},
 		dateTime: {control: 'date'},
 		timestamp: {
 			table: {
-				disable: true
-			}
+				disable: true,
+			},
 		},
 		indicator: {
 			table: {
-				disable: true
-			}
-		}
+				disable: true,
+			},
+		},
 	},
 } as Meta<IndicatorLabelProps>;
 
-type IndicatorStory =  Story<IndicatorLabelProps & {dateTime: Date | number}>
+type IndicatorStory = Story<IndicatorLabelProps & {dateTime: Date | number}>;
 const Template: IndicatorStory = args => {
 	useEffect(() => {
 		let dates = ODate.init();
@@ -33,15 +36,14 @@ const Template: IndicatorStory = args => {
 			dates.forEach(date => date.destroy());
 		};
 	});
-	const dateString = args.dateTime && new Date(args.dateTime).toISOString()
-	if(dateString) {
-		args.timestamp =  <DateTSX dateTime={dateString} />;
+	const dateString = args.dateTime && new Date(args.dateTime).toISOString();
+	if (dateString) {
+		args.timestamp = <DateTSX dateTime={dateString} />;
 	}
 	return <OIndicatorLabel {...args} />;
 };
 
-export const LiveIndicatorLabel: IndicatorStory =
-	Template.bind({});
+export const LiveIndicatorLabel: IndicatorStory = Template.bind({});
 LiveIndicatorLabel.args = {
 	indicator: 'live',
 	status: 'live',
@@ -51,13 +53,12 @@ LiveIndicatorLabel.args = {
 LiveIndicatorLabel.argTypes = {
 	dateTime: {
 		table: {
-			disable: true
-		}
-	}
-}
+			disable: true,
+		},
+	},
+};
 
-export const ClosedIndicatorLabel: IndicatorStory =
-	Template.bind({});
+export const ClosedIndicatorLabel: IndicatorStory = Template.bind({});
 ClosedIndicatorLabel.args = {
 	indicator: 'closed',
 	status: 'closed',
@@ -66,13 +67,12 @@ ClosedIndicatorLabel.args = {
 ClosedIndicatorLabel.argTypes = {
 	dateTime: {
 		table: {
-			disable: true
-		}
-	}
-}
+			disable: true,
+		},
+	},
+};
 
-export const NewIndicatorLabel: IndicatorStory =
-	Template.bind({});
+export const NewIndicatorLabel: IndicatorStory = Template.bind({});
 NewIndicatorLabel.args = {
 	indicator: 'new',
 	status: 'new',
@@ -83,13 +83,12 @@ NewIndicatorLabel.args = {
 NewIndicatorLabel.argTypes = {
 	badge: {
 		table: {
-			disable: true
-		}
-	}
-}
+			disable: true,
+		},
+	},
+};
 
-export const UpdatedIndicatorLabel: IndicatorStory =
-	Template.bind({});
+export const UpdatedIndicatorLabel: IndicatorStory = Template.bind({});
 UpdatedIndicatorLabel.args = {
 	indicator: 'updated',
 	status: 'updated',
@@ -99,7 +98,7 @@ UpdatedIndicatorLabel.args = {
 UpdatedIndicatorLabel.argTypes = {
 	badge: {
 		table: {
-			disable: true
-		}
-	}
-}
+			disable: true,
+		},
+	},
+};

--- a/components/o-labels/stories/core/life-cycle.stories.tsx
+++ b/components/o-labels/stories/core/life-cycle.stories.tsx
@@ -2,38 +2,38 @@ import {LifeCycleLabel as LifeCycleLabelTsx} from '../../src/tsx/label';
 import '../labels.scss';
 
 const ComponentDescription = {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: LifeCycleLabelTsx,
 	argTypes: {
 		state: {
-            defaultValue: 'lifecycle-beta',
-            table: {
-                disable: true
-            }
-        },
+			defaultValue: 'lifecycle-beta',
+			table: {
+				disable: true,
+			},
+		},
 		size: {
 			options: ['small', 'default', 'big'],
-			defaultValue: 'default'
+			defaultValue: 'default',
 		},
 		text: {
 			name: 'text',
-			type: { name: 'string', required: false },
+			type: {name: 'string', required: false},
 			control: {
-			  type: 'text'
-			}
-		  }
-	}
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const LifeCycleLabel = args => {
 	const copy = args.text || args.state.replace('lifecycle-', '');
-	if(args.size === 'default') {
+	if (args.size === 'default') {
 		delete args.size;
 	}
 	return <LifeCycleLabelTsx {...args}>{copy}</LifeCycleLabelTsx>;
-}
+};
 LifeCycleLabel.args = {
 	text: 'Beta',
-}
+};

--- a/components/o-labels/stories/core/timestamps.stories.tsx
+++ b/components/o-labels/stories/core/timestamps.stories.tsx
@@ -2,11 +2,14 @@ import ODate from '@financial-times/o-date/main';
 import {Date as DateTSX} from '@financial-times/o-date/src/tsx/date';
 import type {Meta, Story} from '@storybook/react';
 import {useEffect} from 'react';
-import {TimestampLabel as OTimestampLabel, TimestampLabelProps} from '../../src/tsx/label';
+import {
+	TimestampLabel as OTimestampLabel,
+	TimestampLabelProps,
+} from '../../src/tsx/label';
 import '../labels.scss';
 
 export default {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: OTimestampLabel,
 	argTypes: {
 		inverse: {control: 'boolean', defaultValue: false},
@@ -14,7 +17,9 @@ export default {
 	},
 } as Meta<TimestampLabelProps>;
 
-export const TimestampLabel: Story<TimestampLabelProps & {dateTime: Date}> = args => {
+export const TimestampLabel: Story<
+	TimestampLabelProps & {dateTime: Date}
+> = args => {
 	useEffect(() => {
 		let dates = ODate.init();
 		return function cleanup() {
@@ -23,10 +28,12 @@ export const TimestampLabel: Story<TimestampLabelProps & {dateTime: Date}> = arg
 		};
 	});
 
-	const dateString = new Date(args.dateTime).toISOString()
-	return <OTimestampLabel {...args} >
-		<DateTSX dateTime={dateString} />
-	</OTimestampLabel>;
+	const dateString = new Date(args.dateTime).toISOString();
+	return (
+		<OTimestampLabel {...args}>
+			<DateTSX dateTime={dateString} />
+		</OTimestampLabel>
+	);
 };
 
 TimestampLabel.args = {

--- a/components/o-labels/stories/internal/colour-pallet.stories.tsx
+++ b/components/o-labels/stories/internal/colour-pallet.stories.tsx
@@ -2,30 +2,30 @@ import {ColourLabel} from '../../src/tsx/label';
 import '../labels.scss';
 
 const ComponentDescription = {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: ColourLabel,
 	argTypes: {
-		state: { defaultValue: 'oxford' },
+		state: {defaultValue: 'oxford'},
 		size: {
 			options: ['small', 'default', 'big'],
-			defaultValue: 'default'
+			defaultValue: 'default',
 		},
 		text: {
 			name: 'text',
-			type: { name: 'string', required: false },
+			type: {name: 'string', required: false},
 			control: {
-			  type: 'text'
-			}
-		  }
-	}
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const ColourPalletLabel = args => {
 	const copy = args.text || args.state;
-	if(args.size === 'default') {
+	if (args.size === 'default') {
 		delete args.size;
 	}
 	return <ColourLabel {...args}>{copy}</ColourLabel>;
-}
+};

--- a/components/o-labels/stories/internal/content.stories.tsx
+++ b/components/o-labels/stories/internal/content.stories.tsx
@@ -3,33 +3,33 @@ import '../labels.scss';
 
 const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
-    title: 'Components/o-labels',
-    component: ContentLabelTsx,
-    argTypes: {
-        state: { defaultValue: 'content-premium' },
-        size: {
-            options: ['small', 'default', 'big'],
-            defaultValue: 'default'
-        },
-        text: {
-            name: 'text',
-            type: { name: 'string', required: false },
-            control: {
-                type: 'text'
-            }
-        }
-    }
+	title: 'Maintained/o-labels',
+	component: ContentLabelTsx,
+	argTypes: {
+		state: {defaultValue: 'content-premium'},
+		size: {
+			options: ['small', 'default', 'big'],
+			defaultValue: 'default',
+		},
+		text: {
+			name: 'text',
+			type: {name: 'string', required: false},
+			control: {
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const ContentLabel = args => {
-    const copy = args.text || args.state.replace('content-', '');
-    if(args.size === 'default') {
-        delete args.size;
-    }
-    return <ContentLabelTsx {...args}>{copy}</ContentLabelTsx>;
-}
+	const copy = args.text || args.state.replace('content-', '');
+	if (args.size === 'default') {
+		delete args.size;
+	}
+	return <ContentLabelTsx {...args}>{copy}</ContentLabelTsx>;
+};
 ContentLabel.args = {
-	text: 'Premium'
-}
+	text: 'Premium',
+};

--- a/components/o-labels/stories/internal/service-tier.stories.tsx
+++ b/components/o-labels/stories/internal/service-tier.stories.tsx
@@ -2,33 +2,33 @@ import {ServiceLabel} from '../../src/tsx/label';
 import '../labels.scss';
 
 const ComponentDescription = {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: ServiceLabel,
 	argTypes: {
-		state: { defaultValue: 'tier-bronze' },
+		state: {defaultValue: 'tier-bronze'},
 		size: {
 			options: ['small', 'default', 'big'],
-			defaultValue: 'default'
+			defaultValue: 'default',
 		},
 		text: {
 			name: 'text',
-			type: { name: 'string', required: false },
+			type: {name: 'string', required: false},
 			control: {
-			  type: 'text'
-			}
-		  }
-	}
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const ServiceTierLabel = args => {
 	const copy = args.text || args.state.replace('tier-', '');
-	if(args.size === 'default') {
+	if (args.size === 'default') {
 		delete args.size;
 	}
 	return <ServiceLabel {...args}>{copy}</ServiceLabel>;
-}
+};
 ServiceTierLabel.args = {
-	text: 'Bronze'
-}
+	text: 'Bronze',
+};

--- a/components/o-labels/stories/internal/support.stories.tsx
+++ b/components/o-labels/stories/internal/support.stories.tsx
@@ -2,33 +2,33 @@ import {SupportLabel} from '../../src/tsx/label';
 import '../labels.scss';
 
 const ComponentDescription = {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: SupportLabel,
 	argTypes: {
 		state: {defaultValue: 'support-active'},
 		size: {
 			options: ['small', 'default', 'big'],
-			defaultValue: 'default'
+			defaultValue: 'default',
 		},
 		text: {
 			name: 'text',
-			type: { name: 'string', required: false },
+			type: {name: 'string', required: false},
 			control: {
-			  type: 'text'
-			}
-		  }
-	}
+				type: 'text',
+			},
+		},
+	},
 };
 
 export default ComponentDescription;
 
 export const SupportStatusLabel = args => {
 	const copy = args.text || args.state.replace('support-', '');
-	if(args.size === 'default') {
+	if (args.size === 'default') {
 		delete args.size;
 	}
 	return <SupportLabel {...args}>{copy}</SupportLabel>;
-}
+};
 SupportStatusLabel.args = {
-	text: 'Active'
-}
+	text: 'Active',
+};

--- a/components/o-labels/stories/labels.stories.tsx
+++ b/components/o-labels/stories/labels.stories.tsx
@@ -2,28 +2,28 @@ import {BaseLabel as BaseLabelTsx} from '../src/tsx/label';
 import './labels.scss';
 
 export default {
-	title: 'Components/o-labels',
+	title: 'Maintained/o-labels',
 	component: BaseLabelTsx,
 	argTypes: {
 		size: {
 			options: ['small', 'default', 'big'],
-			defaultValue: 'default'
+			defaultValue: 'default',
 		},
 		text: {
 			name: 'text',
-			type: { name: 'string', required: true },
+			type: {name: 'string', required: true},
 			defaultValue: 'example label',
 			control: {
-			  type: 'text'
-			}
-		  }
-	}
+				type: 'text',
+			},
+		},
+	},
 };
 
 export const BaseLabel = args => {
 	const copy = args.text;
-	if(args.size === 'default') {
+	if (args.size === 'default') {
 		delete args.size;
 	}
 	return <BaseLabelTsx {...args}>{copy}</BaseLabelTsx>;
-}
+};

--- a/components/o-labels/stories/readme.stories.mdx
+++ b/components/o-labels/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-labels/Readme"
+	title="Maintained/o-labels/Readme"
 />
 
 

--- a/components/o-labels/stories/sassdoc.stories.mdx
+++ b/components/o-labels/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-labels/SassDoc"
+title="Maintained/o-labels/SassDoc"
 />
 
 <Markdown>

--- a/components/o-layout/stories/internal/internalLayout.stories.tsx
+++ b/components/o-layout/stories/internal/internalLayout.stories.tsx
@@ -1,34 +1,34 @@
-import { ComponentMeta, Story } from "@storybook/react";
+import {ComponentMeta, Story} from '@storybook/react';
 import {
 	DefaultLayout as Layout,
 	LandingLayout,
 	QueryLayout,
-} from "../../src/tsx/layout";
-import { HeaderWithTitleSection } from "@financial-times/o-header-services/stories/header-services.stories";
-import { OverviewSections, ArticleList } from "../../src/tsx/landingPartials";
-import "../layout.scss";
-import javascript from "../../main.js";
-import Table from "@financial-times/o-table/main";
-import SyntaxHighlight from "@financial-times/o-syntax-highlight/main";
-import Tabs from "@financial-times/o-tabs/main";
-import Forms from "@financial-times/o-forms/main";
-import { useEffect, ComponentProps } from "react";
+} from '../../src/tsx/layout';
+import {HeaderWithTitleSection} from '@financial-times/o-header-services/stories/header-services.stories';
+import {OverviewSections, ArticleList} from '../../src/tsx/landingPartials';
+import '../layout.scss';
+import javascript from '../../main.js';
+import Table from '@financial-times/o-table/main';
+import SyntaxHighlight from '@financial-times/o-syntax-highlight/main';
+import Tabs from '@financial-times/o-tabs/main';
+import Forms from '@financial-times/o-forms/main';
+import {useEffect, ComponentProps} from 'react';
 import {
 	overviewActionElements,
 	overviewElements,
 	articleList,
 	DemoHero,
 	QueryLayout as QueryLayoutData,
-} from "./fixtures";
-import { DemoFooter } from "../fixtures";
-import { AdditionalSbProps, defaultControlsToProps } from "../layout.stories";
+} from './fixtures';
+import {DemoFooter} from '../fixtures';
+import {AdditionalSbProps, defaultControlsToProps} from '../layout.stories';
 
 type LandingStoryProps = ComponentProps<typeof LandingLayout> &
 	AdditionalSbProps;
 type QueryStoryProps = ComponentProps<typeof QueryLayout> & AdditionalSbProps;
 
 export default {
-	title: "Components/o-layout",
+	title: 'Maintained/o-layout',
 	component: Layout,
 	parameters: {},
 	args: {
@@ -36,13 +36,13 @@ export default {
 		headerControls: HeaderWithTitleSection.args,
 	},
 	argTypes: {
-		mainContent: { control: { disable: true } },
-		footer: { control: { disable: true } },
-		header: { control: { disable: true } },
-		bleed: { control: { disable: true } },
-		queryHeading: { control: { disable: true } },
-		querySideBar: { control: { disable: true } },
-		asideSideBar: { control: { disable: true } },
+		mainContent: {control: {disable: true}},
+		footer: {control: {disable: true}},
+		header: {control: {disable: true}},
+		bleed: {control: {disable: true}},
+		queryHeading: {control: {disable: true}},
+		querySideBar: {control: {disable: true}},
+		asideSideBar: {control: {disable: true}},
 	},
 } as ComponentMeta<typeof Layout>;
 
@@ -96,10 +96,10 @@ LandingLayoutWithHero.args = {
 
 LandingLayoutWithHero.parameters = {
 	controls: {
-		include: ['headerControls']
+		include: ['headerControls'],
 	},
 	layout: 'fullscreen',
-}
+};
 
 export const LandingLayoutWithArticleList: Story<LandingStoryProps> =
 	LandingLayoutStory.bind({});
@@ -120,10 +120,10 @@ LandingLayoutWithArticleList.args = {
 
 LandingLayoutWithArticleList.parameters = {
 	controls: {
-		include: ['headerControls']
+		include: ['headerControls'],
 	},
 	layout: 'fullscreen',
-}
+};
 
 export const QueryLayoutDemo: Story<QueryStoryProps> = args => {
 	useEffect(() => {
@@ -141,7 +141,7 @@ export const QueryLayoutDemo: Story<QueryStoryProps> = args => {
 	return <QueryLayout {...args} />;
 };
 
-QueryLayoutDemo.storyName = "Query Layout";
+QueryLayoutDemo.storyName = 'Query Layout';
 QueryLayoutDemo.args = {
 	...QueryLayoutData,
 	constructNav: false,
@@ -149,7 +149,6 @@ QueryLayoutDemo.args = {
 
 QueryLayoutDemo.parameters = {
 	controls: {
-		include: ['headerControls', 'constructNav']
-	}
-}
-
+		include: ['headerControls', 'constructNav'],
+	},
+};

--- a/components/o-layout/stories/jsdoc.stories.mdx
+++ b/components/o-layout/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-layout/JSDoc"
+title="Maintained/o-layout/JSDoc"
 />
 
 <Markdown>

--- a/components/o-layout/stories/layout.stories.tsx
+++ b/components/o-layout/stories/layout.stories.tsx
@@ -1,19 +1,19 @@
-import { ComponentMeta, Story } from "@storybook/react";
-import { useEffect, ComponentProps } from "react";
+import {ComponentMeta, Story} from '@storybook/react';
+import {useEffect, ComponentProps} from 'react';
 
-import { HeaderWithTitleSection } from "@financial-times/o-header-services/stories/header-services.stories";
-import Table from "@financial-times/o-table/main";
-import SyntaxHighlight from "@financial-times/o-syntax-highlight/main";
-import Tabs from "@financial-times/o-tabs/main";
-import Forms from "@financial-times/o-forms/main";
+import {HeaderWithTitleSection} from '@financial-times/o-header-services/stories/header-services.stories';
+import Table from '@financial-times/o-table/main';
+import SyntaxHighlight from '@financial-times/o-syntax-highlight/main';
+import Tabs from '@financial-times/o-tabs/main';
+import Forms from '@financial-times/o-forms/main';
 
-import { DefaultLayout as Layout, DocsLayout } from "../src/tsx/layout";
-import javascript from "../main.js";
-import "./layout.scss";
-import { DemoFooter, DemoMainContent } from "./fixtures";
+import {DefaultLayout as Layout, DocsLayout} from '../src/tsx/layout';
+import javascript from '../main.js';
+import './layout.scss';
+import {DemoFooter, DemoMainContent} from './fixtures';
 
 export type AdditionalSbProps = {
-	headerControls: { title: string };
+	headerControls: {title: string};
 	mainControls: string;
 	footerControls: string;
 	heroMuted?: boolean;
@@ -26,7 +26,7 @@ type DocsLayoutStoryProps = ComponentProps<typeof DocsLayout> &
 	AdditionalSbProps;
 
 export default {
-	title: "Components/o-layout",
+	title: 'Maintained/o-layout',
 	component: Layout,
 	parameters: {},
 	args: {
@@ -35,11 +35,11 @@ export default {
 		headerControls: HeaderWithTitleSection.args,
 	},
 	argTypes: {
-		mainContent: { control: { disable: true } },
-		footer: { control: { disable: true } },
-		header: { control: { disable: true } },
+		mainContent: {control: {disable: true}},
+		footer: {control: {disable: true}},
+		header: {control: {disable: true}},
 	},
-	excludeStories: ["defaultControlsToProps"],
+	excludeStories: ['defaultControlsToProps'],
 } as ComponentMeta<typeof Layout>;
 
 export function defaultControlsToProps(args) {
@@ -65,9 +65,9 @@ DefaultLayout.args = {
 
 DefaultLayout.parameters = {
 	controls: {
-		include: ['headerControls', 'bleed']
-	}
-}
+		include: ['headerControls', 'bleed'],
+	},
+};
 
 export const DocumentationLayout: Story<DocsLayoutStoryProps> = args => {
 	useEffect(() => {
@@ -96,11 +96,11 @@ export const DocumentationLayout: Story<DocsLayoutStoryProps> = args => {
 };
 DocumentationLayout.args = {
 	constructNav: true,
-	customNavHeadingSelector: "",
+	customNavHeadingSelector: '',
 };
 
 DocumentationLayout.parameters = {
 	controls: {
-		include: ['headerControls', 'constructNav']
-	}
-}
+		include: ['headerControls', 'constructNav'],
+	},
+};

--- a/components/o-layout/stories/readme.stories.mdx
+++ b/components/o-layout/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-layout/Readme"
+	title="Maintained/o-layout/Readme"
 />
 
 

--- a/components/o-layout/stories/sassdoc.stories.mdx
+++ b/components/o-layout/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-layout/SassDoc"
+title="Maintained/o-layout/SassDoc"
 />
 
 <Markdown>

--- a/components/o-lazy-load/stories/core/class-name-toggle.stories.tsx
+++ b/components/o-lazy-load/stories/core/class-name-toggle.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-lazy-load/Class name toggle',
+	title: 'Maintained/o-lazy-load/Class name toggle',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Classnametoggle = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=toggle&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=toggle&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-lazy-load/stories/core/content-placeholders.stories.tsx
+++ b/components/o-lazy-load/stories/core/content-placeholders.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-lazy-load/Content Placeholders',
+	title: 'Maintained/o-lazy-load/Content Placeholders',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ContentPlaceholders = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=placeholders&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=placeholders&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-lazy-load/stories/core/declarative-configuration.stories.tsx
+++ b/components/o-lazy-load/stories/core/declarative-configuration.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-lazy-load/Declarative configuration',
+	title: 'Maintained/o-lazy-load/Declarative configuration',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Declarativeconfiguration = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=scrollable&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=scrollable&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-lazy-load/stories/core/lazy-loading-images.stories.tsx
+++ b/components/o-lazy-load/stories/core/lazy-loading-images.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-lazy-load/Lazy loading images',
+	title: 'Maintained/o-lazy-load/Lazy loading images',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Lazyloadingimages = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=images&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=images&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-lazy-load/stories/core/lazy-loading-picture-elements.stories.tsx
+++ b/components/o-lazy-load/stories/core/lazy-loading-picture-elements.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-lazy-load/Lazy loading picture elements',
+	title: 'Maintained/o-lazy-load/Lazy loading picture elements',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Lazyloadingpictureelements = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=pictures&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-lazy-load%403.1.2&demo=pictures&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-lazy-load/stories/jsdoc.stories.mdx
+++ b/components/o-lazy-load/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-lazy-load/JSDoc"
+title="Maintained/o-lazy-load/JSDoc"
 />
 
 <Markdown>

--- a/components/o-lazy-load/stories/readme.stories.mdx
+++ b/components/o-lazy-load/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-lazy-load/Readme"
+	title="Maintained/o-lazy-load/Readme"
 />
 
 

--- a/components/o-loading/stories/core/sassdoc.stories.mdx
+++ b/components/o-loading/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-loading/SassDoc"
+title="Maintained/o-loading/SassDoc"
 />
 
 <Markdown>

--- a/components/o-loading/stories/internal/sassdoc.stories.mdx
+++ b/components/o-loading/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-loading/SassDoc"
+title="Maintained/o-loading/SassDoc"
 />
 
 <Markdown>

--- a/components/o-loading/stories/loading.stories.mdx
+++ b/components/o-loading/stories/loading.stories.mdx
@@ -1,9 +1,9 @@
-import {Canvas, Meta, Story} from '@storybook/addon-docs';
-import {Loading} from '../src/tsx/loading';
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Loading } from '../src/tsx/loading';
 import './loading.scss';
 
 <Meta
-	title="components/o-loading"
+	title="Maintained/o-loading"
 	component={Loading}
 	parameters={{design: {}, guidelines: {}, html: {}}}
 />

--- a/components/o-loading/stories/readme.stories.mdx
+++ b/components/o-loading/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-loading/Readme"
+	title="Maintained/o-loading/Readme"
 />
 
 

--- a/components/o-loading/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-loading/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-loading/SassDoc"
+title="Maintained/o-loading/SassDoc"
 />
 
 <Markdown>

--- a/components/o-message/stories/core/message-notice.stories.tsx
+++ b/components/o-message/stories/core/message-notice.stories.tsx
@@ -4,24 +4,19 @@ import {
 	NoticeInform,
 	NoticeInnerInform,
 	NoticeFeedback,
-	NoticeInnerFeedback
+	NoticeInnerFeedback,
 } from '../shared/message-notice';
 import '../message.scss';
 
 export default {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: NoticeMessage,
 	argTypes: {
 		state: {
 			options: ['inform', 'feedback'],
 		},
 	},
-	...ComponentDescription
+	...ComponentDescription,
 };
 
-export {
-	NoticeInform,
-	NoticeInnerInform,
-	NoticeFeedback,
-	NoticeInnerFeedback
-}
+export {NoticeInform, NoticeInnerInform, NoticeFeedback, NoticeInnerFeedback};

--- a/components/o-message/stories/internal/message-action.stories.tsx
+++ b/components/o-message/stories/internal/message-action.stories.tsx
@@ -5,7 +5,7 @@ import javascript from '../../main';
 import '../message.scss';
 
 export default {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: ActionMessage,
 	parameters: {},
 	args: {

--- a/components/o-message/stories/internal/message-notice.stories.tsx
+++ b/components/o-message/stories/internal/message-notice.stories.tsx
@@ -13,14 +13,14 @@ import {
 import '../message.scss';
 
 export default {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: NoticeMessage,
 	argTypes: {
 		state: {
 			options: ['inform', 'feedback', 'warning', 'warning-light'],
 		},
 	},
-	...ComponentDescription
+	...ComponentDescription,
 };
 
 export {
@@ -32,4 +32,4 @@ export {
 	NoticeInnerWarning,
 	NoticeFeedback,
 	NoticeInnerFeedback,
-}
+};

--- a/components/o-message/stories/jsdoc.stories.mdx
+++ b/components/o-message/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-message/JSDoc"
+title="Maintained/o-message/JSDoc"
 />
 
 <Markdown>

--- a/components/o-message/stories/message-alert.stories.tsx
+++ b/components/o-message/stories/message-alert.stories.tsx
@@ -5,7 +5,7 @@ import javascript from '../main';
 import './message.scss';
 
 export default {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: AlertMessage,
 	parameters: {},
 	args: {
@@ -25,7 +25,7 @@ export default {
 } as ComponentMeta<typeof AlertMessage>;
 
 const innerDecorator = Story => (
-	<div className='demo-inner-message'>{Story()}</div>
+	<div className="demo-inner-message">{Story()}</div>
 );
 
 const AlertStory = args => {

--- a/components/o-message/stories/readme.stories.mdx
+++ b/components/o-message/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-message/Readme"
+	title="Maintained/o-message/Readme"
 />
 
 

--- a/components/o-message/stories/sassdoc.stories.mdx
+++ b/components/o-message/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-message/SassDoc"
+title="Maintained/o-message/SassDoc"
 />
 
 <Markdown>

--- a/components/o-message/stories/shared/message-notice.tsx
+++ b/components/o-message/stories/shared/message-notice.tsx
@@ -5,7 +5,7 @@ import javascript from '../../main';
 import '../message.scss';
 
 export const ComponentDescription = {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: NoticeMessage,
 	parameters: {},
 	args: {
@@ -25,7 +25,7 @@ export const ComponentDescription = {
 };
 
 const innerDecorator = Story => (
-	<div className='demo-inner-message'>{Story()}</div>
+	<div className="demo-inner-message">{Story()}</div>
 );
 
 const NoticeStory = args => {

--- a/components/o-message/stories/whitelabel/message-notice.stories.tsx
+++ b/components/o-message/stories/whitelabel/message-notice.stories.tsx
@@ -2,22 +2,19 @@ import {NoticeMessage} from '../../src/tsx/message';
 import {
 	ComponentDescription,
 	NoticeInform,
-	NoticeInnerInform
+	NoticeInnerInform,
 } from '../shared/message-notice';
 import '../message.scss';
 
 export default {
-	title: 'Components/o-message',
+	title: 'Maintained/o-message',
 	component: NoticeMessage,
 	argTypes: {
 		state: {
 			options: ['inform'],
 		},
 	},
-	...ComponentDescription
+	...ComponentDescription,
 };
 
-export {
-	NoticeInform,
-	NoticeInnerInform
-}
+export {NoticeInform, NoticeInnerInform};

--- a/components/o-meter/stories/meter.stories.tsx
+++ b/components/o-meter/stories/meter.stories.tsx
@@ -6,7 +6,7 @@ import './meter.scss';
 import {higherIsBetterDemoData, lowerIsBetterDemoData} from './meterData';
 
 export default {
-	title: 'Components/o-meter',
+	title: 'Maintained/o-meter',
 	component: Meter,
 	args: {
 		min: 0,

--- a/components/o-meter/stories/readme.stories.mdx
+++ b/components/o-meter/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-meter/Readme"
+	title="Maintained/o-meter/Readme"
 />
 
 

--- a/components/o-multi-select/stories/jsdoc.stories.mdx
+++ b/components/o-multi-select/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-multi-select/JSDoc"
+title="Maintained/o-multi-select/JSDoc"
 />
 
 <Markdown>

--- a/components/o-multi-select/stories/multi-select.stories.tsx
+++ b/components/o-multi-select/stories/multi-select.stories.tsx
@@ -6,7 +6,7 @@ import javascript from '../main.js';
 import {Form, GenericInput} from '@financial-times/o-forms/src/tsx/Form';
 
 export default {
-	title: 'Components/o-multi-select',
+	title: 'Maintained/o-multi-select',
 	component: MultiSelect,
 	parameters: {},
 	args: {},

--- a/components/o-multi-select/stories/readme.stories.mdx
+++ b/components/o-multi-select/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-multi-select/Readme"
+	title="Maintained/o-multi-select/Readme"
 />
 
 

--- a/components/o-normalise/stories/readme.stories.mdx
+++ b/components/o-normalise/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="Brandless/o-normalise/Readme"
+	title="Deprecated/o-normalise/Readme"
 />
 
 

--- a/components/o-normalise/stories/sassdoc.stories.mdx
+++ b/components/o-normalise/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-normalise/SassDoc"
+title="Deprecated/o-normalise/SassDoc"
 />
 
 <Markdown>

--- a/components/o-overlay/stories/core/an-overlay-that-is-nested-in-the-page.stories.tsx
+++ b/components/o-overlay/stories/core/an-overlay-that-is-nested-in-the-page.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/An overlay that is nested in the page',
+	title: 'Maintained/o-overlay/An overlay that is nested in the page',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Anoverlaythatisnestedinthepage = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/core/modal-fullscreen-overlay.stories.tsx
+++ b/components/o-overlay/stories/core/modal-fullscreen-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal fullscreen overlay',
+	title: 'Maintained/o-overlay/Modal fullscreen overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalfullscreenoverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/core/modal-overlay.stories.tsx
+++ b/components/o-overlay/stories/core/modal-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal overlay',
+	title: 'Maintained/o-overlay/Modal overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modaloverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/core/modal-without-close-button.stories.tsx
+++ b/components/o-overlay/stories/core/modal-without-close-button.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal without close button',
+	title: 'Maintained/o-overlay/Modal without close button',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalwithoutclosebutton = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/internal/an-overlay-that-is-nested-in-the-page.stories.tsx
+++ b/components/o-overlay/stories/internal/an-overlay-that-is-nested-in-the-page.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/An overlay that is nested in the page',
+	title: 'Maintained/o-overlay/An overlay that is nested in the page',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Anoverlaythatisnestedinthepage = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/internal/modal-fullscreen-overlay.stories.tsx
+++ b/components/o-overlay/stories/internal/modal-fullscreen-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal fullscreen overlay',
+	title: 'Maintained/o-overlay/Modal fullscreen overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalfullscreenoverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/internal/modal-overlay.stories.tsx
+++ b/components/o-overlay/stories/internal/modal-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal overlay',
+	title: 'Maintained/o-overlay/Modal overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modaloverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/internal/modal-without-close-button.stories.tsx
+++ b/components/o-overlay/stories/internal/modal-without-close-button.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal without close button',
+	title: 'Maintained/o-overlay/Modal without close button',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalwithoutclosebutton = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/jsdoc.stories.mdx
+++ b/components/o-overlay/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-overlay/JSDoc"
+title="Maintained/o-overlay/JSDoc"
 />
 
 <Markdown>

--- a/components/o-overlay/stories/readme.stories.mdx
+++ b/components/o-overlay/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-overlay/Readme"
+	title="Maintained/o-overlay/Readme"
 />
 
 

--- a/components/o-overlay/stories/whitelabel/an-overlay-that-is-nested-in-the-page.stories.tsx
+++ b/components/o-overlay/stories/whitelabel/an-overlay-that-is-nested-in-the-page.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/An overlay that is nested in the page',
+	title: 'Maintained/o-overlay/An overlay that is nested in the page',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Anoverlaythatisnestedinthepage = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=sliding-notification&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/whitelabel/modal-fullscreen-overlay.stories.tsx
+++ b/components/o-overlay/stories/whitelabel/modal-fullscreen-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal fullscreen overlay',
+	title: 'Maintained/o-overlay/Modal fullscreen overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalfullscreenoverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-fullscreen&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/whitelabel/modal-overlay.stories.tsx
+++ b/components/o-overlay/stories/whitelabel/modal-overlay.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal overlay',
+	title: 'Maintained/o-overlay/Modal overlay',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modaloverlay = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-overlay/stories/whitelabel/modal-without-close-button.stories.tsx
+++ b/components/o-overlay/stories/whitelabel/modal-without-close-button.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-overlay/Modal without close button',
+	title: 'Maintained/o-overlay/Modal without close button',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Modalwithoutclosebutton = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-overlay%404.2.10&demo=modal-prevent-closure&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-quote/stories/core/sassdoc.stories.mdx
+++ b/components/o-quote/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-quote/SassDoc"
+title="Deprecated/o-quote/SassDoc"
 />
 
 <Markdown>

--- a/components/o-quote/stories/internal/sassdoc.stories.mdx
+++ b/components/o-quote/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-quote/SassDoc"
+title="Deprecated/o-quote/SassDoc"
 />
 
 <Markdown>

--- a/components/o-quote/stories/quote.stories.tsx
+++ b/components/o-quote/stories/quote.stories.tsx
@@ -2,7 +2,7 @@ import {Quote} from '../src/tsx/quote';
 import './quote.scss';
 
 export default {
-	title: 'Components/o-quote',
+	title: 'Deprecated/o-quote',
 	component: Quote,
 	args: {
 		iconOnly: false,
@@ -19,16 +19,16 @@ const Story = args => <Quote {...args} />;
 // @todo - show editorial quote only when the core brand is selected https://github.com/Financial-Times/origami/issues/617
 export const EditorialQuote = Story.bind({});
 EditorialQuote.args = {
-    type: 'editorial',
-    copy: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente placeat ducimus blanditiis, deleniti necessitatibus quo vel itaque omnis ipsum voluptas. Debitis omnis nobis optio minus vero quaerat quasi perspiciatis aliquid?',
-    author: 'Lorem ipsum',
-    source: 'Lorem, ipsum dolor.',
+	type: 'editorial',
+	copy: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente placeat ducimus blanditiis, deleniti necessitatibus quo vel itaque omnis ipsum voluptas. Debitis omnis nobis optio minus vero quaerat quasi perspiciatis aliquid?',
+	author: 'Lorem ipsum',
+	source: 'Lorem, ipsum dolor.',
 };
 
 export const StandardQuote = Story.bind({});
 StandardQuote.args = {
-    type: 'standard',
-    copy: 'Origami is about empowering developers of all levels to build robust, on-brand products ranging from simple static sites through to rich, dynamic web applications, to do it faster, to do it cheaper, and leave them more supportable and more maintainable.',
-    author: 'Financial Times',
-    source: 'The Origami Specification',
+	type: 'standard',
+	copy: 'Origami is about empowering developers of all levels to build robust, on-brand products ranging from simple static sites through to rich, dynamic web applications, to do it faster, to do it cheaper, and leave them more supportable and more maintainable.',
+	author: 'Financial Times',
+	source: 'The Origami Specification',
 };

--- a/components/o-quote/stories/readme.stories.mdx
+++ b/components/o-quote/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-quote/Readme"
+	title="Deprecated/o-quote/Readme"
 />
 
 

--- a/components/o-quote/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-quote/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-quote/SassDoc"
+title="Deprecated/o-quote/SassDoc"
 />
 
 <Markdown>

--- a/components/o-share/stories/jsdoc.stories.mdx
+++ b/components/o-share/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-share/JSDoc"
+title="Maintained/o-share/JSDoc"
 />
 
 <Markdown>

--- a/components/o-share/stories/readme.stories.mdx
+++ b/components/o-share/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-share/Readme"
+	title="Maintained/o-share/Readme"
 />
 
 

--- a/components/o-share/stories/sassdoc.stories.mdx
+++ b/components/o-share/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-share/SassDoc"
+title="Maintained/o-share/SassDoc"
 />
 
 <Markdown>

--- a/components/o-share/stories/share.stories.tsx
+++ b/components/o-share/stories/share.stories.tsx
@@ -1,20 +1,20 @@
-import { Story, ComponentMeta } from "@storybook/react";
+import {Story, ComponentMeta} from '@storybook/react';
 
-import { Share } from "../src/tsx/share";
-import { ShareIcon, UrlProps } from "../src/tsx/shareIcon";
-import { useEffect, ComponentProps } from "react";
-import javascript from "../main";
-import "./share.scss";
+import {Share} from '../src/tsx/share';
+import {ShareIcon, UrlProps} from '../src/tsx/shareIcon';
+import {useEffect, ComponentProps} from 'react';
+import javascript from '../main';
+import './share.scss';
 
 export default {
-	title: "Components/o-share",
+	title: 'Maintained/o-share',
 	component: Share,
 	args: {
-		title: "US drugs",
-		url: "http://on.ft.com/1mUdgA2",
-		titleExtra: "FT.com | Pharmaceuticals",
-		summary: "US drugs group vows to maintain big British presence",
-		relatedXAccounts: "ftcompanies",
+		title: 'US drugs',
+		url: 'http://on.ft.com/1mUdgA2',
+		titleExtra: 'FT.com | Pharmaceuticals',
+		summary: 'US drugs group vows to maintain big British presence',
+		relatedXAccounts: 'ftcompanies',
 		small: false,
 		inverse: false,
 		vertical: false,
@@ -58,7 +58,7 @@ Inverse.args = {
 	inverse: true,
 };
 Inverse.parameters = {
-	origamiBackground: "slate",
+	origamiBackground: 'slate',
 };
 export const Vertical: Story<ShareProps> = StoryTemplate.bind({});
 Vertical.args = {

--- a/components/o-social-follow/stories/readme.stories.mdx
+++ b/components/o-social-follow/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-social-follow/Readme"
+	title="Maintained/o-social-follow/Readme"
 />
 
 

--- a/components/o-social-follow/stories/sassdoc.stories.mdx
+++ b/components/o-social-follow/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-social-follow/SassDoc"
+title="Maintained/o-social-follow/SassDoc"
 />
 
 <Markdown>

--- a/components/o-social-follow/stories/social-follow.stories.tsx
+++ b/components/o-social-follow/stories/social-follow.stories.tsx
@@ -2,20 +2,20 @@ import {SocialFollow} from '../src/tsx/social-follow';
 import './social-follow.scss';
 
 export default {
-	title: 'Components/o-social-follow',
+	title: 'Maintained/o-social-follow',
 	component: SocialFollow,
 	args: {
 		icons: ['twitter', 'facebook', 'linkedin', 'youtube', 'instagram'],
 		standalone: false,
-		theme: ''
+		theme: '',
 	},
 	parameters: {
 		design: {
 			type: 'figma',
-			url: 'https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/?node-id=2606%3A2409'
+			url: 'https://www.figma.com/file/MyHQ1qdwYyek5IBdhEEaND/?node-id=2606%3A2409',
 		},
 		guidelines: {
-			notion: '072c8d4797ad47d39142b4396592070a'
+			notion: '072c8d4797ad47d39142b4396592070a',
 		},
 		html: {},
 	},
@@ -27,7 +27,7 @@ export const SocialFollowContainer = Story.bind({});
 
 export const SocialFollowInverse = Story.bind({});
 SocialFollowInverse.args = {
-	'theme': 'inverse'
+	theme: 'inverse',
 };
 SocialFollowInverse.parameters = {
 	origamiBackground: 'slate',
@@ -35,5 +35,5 @@ SocialFollowInverse.parameters = {
 
 export const SocialFollowStandAlone = Story.bind({});
 SocialFollowStandAlone.args = {
-	'standalone': true
+	standalone: true,
 };

--- a/components/o-spacing/stories/readme.stories.mdx
+++ b/components/o-spacing/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-spacing/Readme"
+	title="Deprecated/o-spacing/Readme"
 />
 
 

--- a/components/o-spacing/stories/sassdoc.stories.mdx
+++ b/components/o-spacing/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-spacing/SassDoc"
+title="Deprecated/o-spacing/SassDoc"
 />
 
 <Markdown>

--- a/components/o-spacing/stories/spacing.stories.tsx
+++ b/components/o-spacing/stories/spacing.stories.tsx
@@ -1,10 +1,9 @@
 import './spacing.scss';
 import {SpacingDemo} from './spacing-demo';
 
-
 export default {
-	title: 'Components/o-spacing',
-    component: SpacingDemo,
+	title: 'Deprecated/o-spacing',
+	component: SpacingDemo,
 	parameters: {
 		guidelines: {},
 		html: {},
@@ -13,5 +12,5 @@ export default {
 
 export const Spacing = SpacingDemo.bind({});
 Spacing.args = {
-    name: 'm12'
+	name: 'm12',
 };

--- a/components/o-stepped-progress/stories/jsdoc.stories.mdx
+++ b/components/o-stepped-progress/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-stepped-progress/JSDoc"
+title="Maintained/o-stepped-progress/JSDoc"
 />
 
 <Markdown>

--- a/components/o-stepped-progress/stories/readme.stories.mdx
+++ b/components/o-stepped-progress/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-stepped-progress/Readme"
+	title="Maintained/o-stepped-progress/Readme"
 />
 
 

--- a/components/o-stepped-progress/stories/sassdoc.stories.mdx
+++ b/components/o-stepped-progress/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-stepped-progress/SassDoc"
+title="Maintained/o-stepped-progress/SassDoc"
 />
 
 <Markdown>

--- a/components/o-stepped-progress/stories/stepped-progress.stories.tsx
+++ b/components/o-stepped-progress/stories/stepped-progress.stories.tsx
@@ -4,7 +4,7 @@ import './stepped-progress.scss';
 import javascript from '@financial-times/o-stepped-progress';
 
 export default {
-	title: 'Components/o-stepped-progress',
+	title: 'Maintained/o-stepped-progress',
 	component: SteppedProgress,
 	parameters: {
 		design: {

--- a/components/o-subs-card/stories/core/demo.stories.tsx
+++ b/components/o-subs-card/stories/core/demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-subs-card/Demo',
+	title: "Maintained/o-subs-card/Demo",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Demo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-subs-card%406.2.5&demo=demo&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-subs-card%406.2.5&demo=demo&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-subs-card/stories/jsdoc.stories.mdx
+++ b/components/o-subs-card/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-subs-card/JSDoc"
+title="Maintained/o-subs-card/JSDoc"
 />
 
 <Markdown>

--- a/components/o-subs-card/stories/readme.stories.mdx
+++ b/components/o-subs-card/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-subs-card/Readme"
+	title="Maintained/o-subs-card/Readme"
 />
 
 

--- a/components/o-subs-card/stories/sassdoc.stories.mdx
+++ b/components/o-subs-card/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-subs-card/SassDoc"
+title="Maintained/o-subs-card/SassDoc"
 />
 
 <Markdown>

--- a/components/o-syntax-highlight/stories/jsdoc.stories.mdx
+++ b/components/o-syntax-highlight/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-syntax-highlight/JSDoc"
+title="Maintained/o-syntax-highlight/JSDoc"
 />
 
 <Markdown>

--- a/components/o-syntax-highlight/stories/readme.stories.mdx
+++ b/components/o-syntax-highlight/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-syntax-highlight/Readme"
+	title="Maintained/o-syntax-highlight/Readme"
 />
 
 

--- a/components/o-syntax-highlight/stories/syntax-highlight.stories.tsx
+++ b/components/o-syntax-highlight/stories/syntax-highlight.stories.tsx
@@ -21,7 +21,7 @@ const LanguageMapping = {
 };
 
 export default {
-	title: 'Components/o-syntax-highlight',
+	title: 'Maintained/o-syntax-highlight',
 	component: SyntaxHighlightBlock,
 	parameters: {},
 	args: {},

--- a/components/o-table/stories/core/basic.stories.tsx
+++ b/components/o-table/stories/core/basic.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Basic',
+	title: 'Maintained/o-table/Basic',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Basic = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/caption-and-footnote.stories.tsx
+++ b/components/o-table/stories/core/caption-and-footnote.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Caption and footnote',
+	title: 'Maintained/o-table/Caption and footnote',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Captionandfootnote = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/compact.stories.tsx
+++ b/components/o-table/stories/core/compact.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Compact',
+	title: 'Maintained/o-table/Compact',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Compact = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/expanding-table-with-arrow-dock.stories.tsx
+++ b/components/o-table/stories/core/expanding-table-with-arrow-dock.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table With Arrow Dock',
+	title: 'Maintained/o-table/Expanding Table With Arrow Dock',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTableWithArrowDock = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/expanding-table.stories.tsx
+++ b/components/o-table/stories/core/expanding-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table',
+	title: 'Maintained/o-table/Expanding Table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/filter-with-a-select-box.stories.tsx
+++ b/components/o-table/stories/core/filter-with-a-select-box.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a select box',
+	title: 'Maintained/o-table/Filter with a select box',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithaselectbox = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/filter-with-a-text-input.stories.tsx
+++ b/components/o-table/stories/core/filter-with-a-text-input.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a text input',
+	title: 'Maintained/o-table/Filter with a text input',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithatextinput = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/huge-sortable-table.stories.tsx
+++ b/components/o-table/stories/core/huge-sortable-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Huge sortable table',
+	title: 'Maintained/o-table/Huge sortable table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hugesortabletable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/multiple-columns.stories.tsx
+++ b/components/o-table/stories/core/multiple-columns.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Multiple Columns',
+	title: 'Maintained/o-table/Multiple Columns',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const MultipleColumns = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/pa11y.stories.tsx
+++ b/components/o-table/stories/core/pa11y.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Pa11y',
+	title: 'Maintained/o-table/Pa11y',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Pa11y = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/responsive-flat.stories.tsx
+++ b/components/o-table/stories/core/responsive-flat.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Flat',
+	title: 'Maintained/o-table/Responsive Flat',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveFlat = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/responsive-overflow.stories.tsx
+++ b/components/o-table/stories/core/responsive-overflow.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Overflow',
+	title: 'Maintained/o-table/Responsive Overflow',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveOverflow = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/responsive-scroll.stories.tsx
+++ b/components/o-table/stories/core/responsive-scroll.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Scroll',
+	title: 'Maintained/o-table/Responsive Scroll',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveScroll = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/row-headings.stories.tsx
+++ b/components/o-table/stories/core/row-headings.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row headings',
+	title: 'Maintained/o-table/Row headings',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Rowheadings = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/row-stripes.stories.tsx
+++ b/components/o-table/stories/core/row-stripes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row Stripes',
+	title: 'Maintained/o-table/Row Stripes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const RowStripes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/sassdoc.stories.mdx
+++ b/components/o-table/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-table/SassDoc"
+title="Maintained/o-table/SassDoc"
 />
 
 <Markdown>

--- a/components/o-table/stories/core/sorting-disabled.stories.tsx
+++ b/components/o-table/stories/core/sorting-disabled.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting Disabled',
+	title: 'Maintained/o-table/Sorting Disabled',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SortingDisabled = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/sorting.stories.tsx
+++ b/components/o-table/stories/core/sorting.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting',
+	title: 'Maintained/o-table/Sorting',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Sorting = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/core/vertically-centre.stories.tsx
+++ b/components/o-table/stories/core/vertically-centre.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Vertically centre',
+	title: 'Maintained/o-table/Vertically centre',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Verticallycentre = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/basic.stories.tsx
+++ b/components/o-table/stories/internal/basic.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Basic',
+	title: 'Maintained/o-table/Basic',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Basic = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/caption-and-footnote.stories.tsx
+++ b/components/o-table/stories/internal/caption-and-footnote.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Caption and footnote',
+	title: 'Maintained/o-table/Caption and footnote',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Captionandfootnote = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/compact.stories.tsx
+++ b/components/o-table/stories/internal/compact.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Compact',
+	title: 'Maintained/o-table/Compact',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Compact = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/expanding-table-with-arrow-dock.stories.tsx
+++ b/components/o-table/stories/internal/expanding-table-with-arrow-dock.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table With Arrow Dock',
+	title: 'Maintained/o-table/Expanding Table With Arrow Dock',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTableWithArrowDock = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/expanding-table.stories.tsx
+++ b/components/o-table/stories/internal/expanding-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table',
+	title: 'Maintained/o-table/Expanding Table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/filter-with-a-select-box.stories.tsx
+++ b/components/o-table/stories/internal/filter-with-a-select-box.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a select box',
+	title: 'Maintained/o-table/Filter with a select box',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithaselectbox = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/filter-with-a-text-input.stories.tsx
+++ b/components/o-table/stories/internal/filter-with-a-text-input.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a text input',
+	title: 'Maintained/o-table/Filter with a text input',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithatextinput = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/huge-sortable-table.stories.tsx
+++ b/components/o-table/stories/internal/huge-sortable-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Huge sortable table',
+	title: 'Maintained/o-table/Huge sortable table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hugesortabletable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/multiple-columns.stories.tsx
+++ b/components/o-table/stories/internal/multiple-columns.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Multiple Columns',
+	title: 'Maintained/o-table/Multiple Columns',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const MultipleColumns = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/pa11y.stories.tsx
+++ b/components/o-table/stories/internal/pa11y.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Pa11y',
+	title: 'Maintained/o-table/Pa11y',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Pa11y = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/responsive-flat.stories.tsx
+++ b/components/o-table/stories/internal/responsive-flat.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Flat',
+	title: 'Maintained/o-table/Responsive Flat',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveFlat = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/responsive-overflow.stories.tsx
+++ b/components/o-table/stories/internal/responsive-overflow.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Overflow',
+	title: 'Maintained/o-table/Responsive Overflow',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveOverflow = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/responsive-scroll.stories.tsx
+++ b/components/o-table/stories/internal/responsive-scroll.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Scroll',
+	title: 'Maintained/o-table/Responsive Scroll',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveScroll = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/row-headings.stories.tsx
+++ b/components/o-table/stories/internal/row-headings.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row headings',
+	title: 'Maintained/o-table/Row headings',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Rowheadings = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/row-stripes.stories.tsx
+++ b/components/o-table/stories/internal/row-stripes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row Stripes',
+	title: 'Maintained/o-table/Row Stripes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const RowStripes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/sassdoc.stories.mdx
+++ b/components/o-table/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-table/SassDoc"
+title="Maintained/o-table/SassDoc"
 />
 
 <Markdown>

--- a/components/o-table/stories/internal/sorting-disabled.stories.tsx
+++ b/components/o-table/stories/internal/sorting-disabled.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting Disabled',
+	title: 'Maintained/o-table/Sorting Disabled',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SortingDisabled = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/sorting.stories.tsx
+++ b/components/o-table/stories/internal/sorting.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting',
+	title: 'Maintained/o-table/Sorting',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Sorting = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/internal/vertically-centre.stories.tsx
+++ b/components/o-table/stories/internal/vertically-centre.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Vertically centre',
+	title: 'Maintained/o-table/Vertically centre',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Verticallycentre = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/jsdoc.stories.mdx
+++ b/components/o-table/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-table/JSDoc"
+title="Maintained/o-table/JSDoc"
 />
 
 <Markdown>

--- a/components/o-table/stories/readme.stories.mdx
+++ b/components/o-table/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-table/Readme"
+	title="Maintained/o-table/Readme"
 />
 
 

--- a/components/o-table/stories/whitelabel/basic.stories.tsx
+++ b/components/o-table/stories/whitelabel/basic.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Basic',
+	title: 'Maintained/o-table/Basic',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Basic = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=basic&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/caption-and-footnote.stories.tsx
+++ b/components/o-table/stories/whitelabel/caption-and-footnote.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Caption and footnote',
+	title: 'Maintained/o-table/Caption and footnote',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Captionandfootnote = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=captions&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/compact.stories.tsx
+++ b/components/o-table/stories/whitelabel/compact.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Compact',
+	title: 'Maintained/o-table/Compact',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Compact = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=compact&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/expanding-table-with-arrow-dock.stories.tsx
+++ b/components/o-table/stories/whitelabel/expanding-table-with-arrow-dock.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table With Arrow Dock',
+	title: 'Maintained/o-table/Expanding Table With Arrow Dock',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTableWithArrowDock = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding-dock&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/expanding-table.stories.tsx
+++ b/components/o-table/stories/whitelabel/expanding-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Expanding Table',
+	title: 'Maintained/o-table/Expanding Table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ExpandingTable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=expanding&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/filter-with-a-select-box.stories.tsx
+++ b/components/o-table/stories/whitelabel/filter-with-a-select-box.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a select box',
+	title: 'Maintained/o-table/Filter with a select box',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithaselectbox = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-select&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/filter-with-a-text-input.stories.tsx
+++ b/components/o-table/stories/whitelabel/filter-with-a-text-input.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Filter with a text input',
+	title: 'Maintained/o-table/Filter with a text input',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Filterwithatextinput = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=filter-input&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/huge-sortable-table.stories.tsx
+++ b/components/o-table/stories/whitelabel/huge-sortable-table.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Huge sortable table',
+	title: 'Maintained/o-table/Huge sortable table',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hugesortabletable = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=huge&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/multiple-columns.stories.tsx
+++ b/components/o-table/stories/whitelabel/multiple-columns.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Multiple Columns',
+	title: 'Maintained/o-table/Multiple Columns',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const MultipleColumns = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=multiple-columns-responsive-overflow&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/pa11y.stories.tsx
+++ b/components/o-table/stories/whitelabel/pa11y.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Pa11y',
+	title: 'Maintained/o-table/Pa11y',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Pa11y = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=pa11y&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/responsive-flat.stories.tsx
+++ b/components/o-table/stories/whitelabel/responsive-flat.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Flat',
+	title: 'Maintained/o-table/Responsive Flat',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveFlat = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-flat&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/responsive-overflow.stories.tsx
+++ b/components/o-table/stories/whitelabel/responsive-overflow.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Overflow',
+	title: 'Maintained/o-table/Responsive Overflow',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveOverflow = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-overflow&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/responsive-scroll.stories.tsx
+++ b/components/o-table/stories/whitelabel/responsive-scroll.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Responsive Scroll',
+	title: 'Maintained/o-table/Responsive Scroll',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsiveScroll = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=responsive-scroll&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/row-headings.stories.tsx
+++ b/components/o-table/stories/whitelabel/row-headings.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row headings',
+	title: 'Maintained/o-table/Row headings',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Rowheadings = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-headings&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/row-stripes.stories.tsx
+++ b/components/o-table/stories/whitelabel/row-stripes.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Row Stripes',
+	title: 'Maintained/o-table/Row Stripes',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const RowStripes = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=row-stripes&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-table/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-table/SassDoc"
+title="Maintained/o-table/SassDoc"
 />
 
 <Markdown>

--- a/components/o-table/stories/whitelabel/sorting-disabled.stories.tsx
+++ b/components/o-table/stories/whitelabel/sorting-disabled.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting Disabled',
+	title: 'Maintained/o-table/Sorting Disabled',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SortingDisabled = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting-disabled&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/sorting.stories.tsx
+++ b/components/o-table/stories/whitelabel/sorting.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Sorting',
+	title: 'Maintained/o-table/Sorting',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Sorting = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=sorting&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-table/stories/whitelabel/vertically-centre.stories.tsx
+++ b/components/o-table/stories/whitelabel/vertically-centre.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-table/Vertically centre',
+	title: 'Maintained/o-table/Vertically centre',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Verticallycentre = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-table%409.1.0&demo=cell-styles&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tabs/stories/jsdoc.stories.mdx
+++ b/components/o-tabs/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-tabs/JSDoc"
+title="Maintained/o-tabs/JSDoc"
 />
 
 <Markdown>

--- a/components/o-tabs/stories/readme.stories.mdx
+++ b/components/o-tabs/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-tabs/Readme"
+	title="Maintained/o-tabs/Readme"
 />
 
 

--- a/components/o-tabs/stories/sassdoc.stories.mdx
+++ b/components/o-tabs/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-tabs/SassDoc"
+title="Maintained/o-tabs/SassDoc"
 />
 
 <Markdown>

--- a/components/o-tabs/stories/tabs.stories.tsx
+++ b/components/o-tabs/stories/tabs.stories.tsx
@@ -4,10 +4,9 @@ import javascript from '../main';
 import './tabs.scss';
 
 export default {
-	title: 'Components/o-tabs',
+	title: 'Maintained/o-tabs',
 	component: Tabs,
-	args: {
-	},
+	args: {},
 	parameters: {
 		guidelines: {},
 		html: {},
@@ -20,7 +19,7 @@ const Story = args => {
 		return function cleanup() {
 			tabs = Array.isArray(tabs) ? tabs : [tabs];
 			tabs.forEach(tab => tab.destroy());
-		}
+		};
 	}, [args.updateUrlHash]);
 	return <Tabs {...args} />;
 };
@@ -31,51 +30,51 @@ Default.args = {
 		{
 			heading: 'Tab 1',
 			content: 'Tab content 1',
-			id: 'demo-tab-1'
+			id: 'demo-tab-1',
 		},
 		{
 			heading: 'Tab 2',
 			content: 'Tab content 2',
-			id: 'demo-tab-2'
+			id: 'demo-tab-2',
 		},
 		{
 			heading: 'Tab 3',
 			content: 'Tab content 3',
-			id: 'demo-tab-3'
-		}
+			id: 'demo-tab-3',
+		},
 	],
 	type: 'secondary',
 	theme: '',
 	size: '',
-	updateUrlHash: true
+	updateUrlHash: true,
 };
 
 export const Inverse = Story.bind({});
 Inverse.parameters = {
-	origamiBackground: 'slate'
+	origamiBackground: 'slate',
 };
 Inverse.args = {
 	tabs: [
 		{
 			heading: 'Tab 1',
 			content: 'Tab content 1',
-			id: 'demo-tab-1'
+			id: 'demo-tab-1',
 		},
 		{
 			heading: 'Tab 2',
 			content: 'Tab content 2',
-			id: 'demo-tab-2'
+			id: 'demo-tab-2',
 		},
 		{
 			heading: 'Tab 3',
 			content: 'Tab content 3',
-			id: 'demo-tab-3'
-		}
+			id: 'demo-tab-3',
+		},
 	],
 	type: 'secondary',
 	theme: 'inverse',
 	size: '',
-	updateUrlHash: true
+	updateUrlHash: true,
 };
 
 export const Big = Story.bind({});
@@ -84,21 +83,21 @@ Big.args = {
 		{
 			heading: 'Tab 1',
 			content: 'Tab content 1',
-			id: 'demo-tab-1'
+			id: 'demo-tab-1',
 		},
 		{
 			heading: 'Tab 2',
 			content: 'Tab content 2',
-			id: 'demo-tab-2'
+			id: 'demo-tab-2',
 		},
 		{
 			heading: 'Tab 3',
 			content: 'Tab content 3',
-			id: 'demo-tab-3'
-		}
+			id: 'demo-tab-3',
+		},
 	],
 	type: 'secondary',
 	theme: '',
 	size: 'big',
-	updateUrlHash: true
+	updateUrlHash: true,
 };

--- a/components/o-teaser-collection/stories/core/basic.stories.tsx
+++ b/components/o-teaser-collection/stories/core/basic.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-teaser-collection/Basic',
+	title: 'Maintained/o-teaser-collection/Basic',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Basic = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=standard&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=standard&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-teaser-collection/stories/core/collection--horizontal.stories.tsx
+++ b/components/o-teaser-collection/stories/core/collection--horizontal.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-teaser-collection/Collection horizontal',
+	title: 'Maintained/o-teaser-collection/Collection horizontal',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-teaser-collection/stories/core/collection--mid-slice.stories.tsx
+++ b/components/o-teaser-collection/stories/core/collection--mid-slice.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-teaser-collection/Collection mid slice',
+	title: 'Maintained/o-teaser-collection/Collection mid slice',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-teaser-collection/stories/core/collection--numbered-and-special.stories.tsx
+++ b/components/o-teaser-collection/stories/core/collection--numbered-and-special.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-teaser-collection/Collection numbered and special',
+	title: 'Maintained/o-teaser-collection/Collection numbered and special',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-teaser-collection/stories/core/collection--special.stories.tsx
+++ b/components/o-teaser-collection/stories/core/collection--special.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-teaser-collection/Collection special',
+	title: 'Maintained/o-teaser-collection/Collection special',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-teaser-collection/stories/core/inverse-heading.stories.tsx
+++ b/components/o-teaser-collection/stories/core/inverse-heading.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-teaser-collection/Inverse Heading',
+	title: 'Maintained/o-teaser-collection/Inverse Heading',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const InverseHeading = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=inverse&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=inverse&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-teaser-collection/stories/core/linked-heading.stories.tsx
+++ b/components/o-teaser-collection/stories/core/linked-heading.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-teaser-collection/Linked Heading',
+	title: 'Maintained/o-teaser-collection/Linked Heading',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const LinkedHeading = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=linked&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-teaser-collection%404.2.4&demo=linked&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-teaser-collection/stories/core/responsive-heading--full-width-on-desktop-.stories.tsx
+++ b/components/o-teaser-collection/stories/core/responsive-heading--full-width-on-desktop-.stories.tsx
@@ -1,6 +1,6 @@
 export default {
 	title:
-		'Components/o-teaser-collection/Responsive Heading full width on desktop ',
+		'Maintained/o-teaser-collection/Responsive Heading full width on desktop ',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-teaser-collection/stories/readme.stories.mdx
+++ b/components/o-teaser-collection/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-teaser-collection/Readme"
+	title="Maintained/o-teaser-collection/Readme"
 />
 
 

--- a/components/o-teaser-collection/stories/sassdoc.stories.mdx
+++ b/components/o-teaser-collection/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-teaser-collection/SassDoc"
+title="Maintained/o-teaser-collection/SassDoc"
 />
 
 <Markdown>

--- a/components/o-teaser/stories/readme.stories.mdx
+++ b/components/o-teaser/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-teaser/Readme"
+	title="Maintained/o-teaser/Readme"
 />
 
 

--- a/components/o-teaser/stories/teaser.stories.tsx
+++ b/components/o-teaser/stories/teaser.stories.tsx
@@ -21,7 +21,7 @@ argTypes.customSlot = {
 };
 
 export default {
-	title: 'Components/o-teaser',
+	title: 'Maintained/o-teaser',
 	component: Teaser,
 	parameters: {},
 } as ComponentMeta<typeof Teaser>;

--- a/components/o-toggle/stories/core/toggle-display-on-off-.stories.tsx
+++ b/components/o-toggle/stories/core/toggle-display-on-off-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle display on off ',
+	title: 'Maintained/o-toggle/Toggle display on off ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggledisplayonoff = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-toggle/stories/core/toggle-visibility-.stories.tsx
+++ b/components/o-toggle/stories/core/toggle-visibility-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle visibility ',
+	title: 'Maintained/o-toggle/Toggle visibility ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Togglevisibility = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-toggle/stories/internal/toggle-display-on-off-.stories.tsx
+++ b/components/o-toggle/stories/internal/toggle-display-on-off-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle display on off ',
+	title: 'Maintained/o-toggle/Toggle display on off ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggledisplayonoff = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-toggle/stories/internal/toggle-visibility-.stories.tsx
+++ b/components/o-toggle/stories/internal/toggle-visibility-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle visibility ',
+	title: 'Maintained/o-toggle/Toggle visibility ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Togglevisibility = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-toggle/stories/jsdoc.stories.mdx
+++ b/components/o-toggle/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-toggle/JSDoc"
+title="Maintained/o-toggle/JSDoc"
 />
 
 <Markdown>

--- a/components/o-toggle/stories/readme.stories.mdx
+++ b/components/o-toggle/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-toggle/Readme"
+	title="Maintained/o-toggle/Readme"
 />
 
 

--- a/components/o-toggle/stories/sassdoc.stories.mdx
+++ b/components/o-toggle/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-toggle/SassDoc"
+title="Maintained/o-toggle/SassDoc"
 />
 
 <Markdown>

--- a/components/o-toggle/stories/whitelabel/toggle-display-on-off-.stories.tsx
+++ b/components/o-toggle/stories/whitelabel/toggle-display-on-off-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle display on off ',
+	title: 'Maintained/o-toggle/Toggle display on off ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggledisplayonoff = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=display-toggle&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-toggle/stories/whitelabel/toggle-visibility-.stories.tsx
+++ b/components/o-toggle/stories/whitelabel/toggle-visibility-.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-toggle/Toggle visibility ',
+	title: 'Maintained/o-toggle/Toggle visibility ',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Togglevisibility = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-toggle%403.2.5&demo=visibility-toggle&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/click.stories.tsx
+++ b/components/o-tooltip/stories/core/click.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Click',
+	title: 'Maintained/o-tooltip/Click',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Click = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/custom-tooltip-theme.stories.tsx
+++ b/components/o-tooltip/stories/core/custom-tooltip-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Custom Tooltip Theme',
+	title: 'Maintained/o-tooltip/Custom Tooltip Theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CustomTooltipTheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/demo.stories.tsx
+++ b/components/o-tooltip/stories/core/demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Demo',
+	title: 'Maintained/o-tooltip/Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Demo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/focus.stories.tsx
+++ b/components/o-tooltip/stories/core/focus.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Focus',
+	title: 'Maintained/o-tooltip/Focus',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Focus = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/hover.stories.tsx
+++ b/components/o-tooltip/stories/core/hover.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Hover',
+	title: 'Maintained/o-tooltip/Hover',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hover = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/no-markup.stories.tsx
+++ b/components/o-tooltip/stories/core/no-markup.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/No Markup',
+	title: 'Maintained/o-tooltip/No Markup',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const NoMarkup = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/professional-demo.stories.tsx
+++ b/components/o-tooltip/stories/core/professional-demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Professional Demo',
+	title: 'Maintained/o-tooltip/Professional Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ProfessionalDemo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/responsive-positioning.stories.tsx
+++ b/components/o-tooltip/stories/core/responsive-positioning.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Responsive Positioning',
+	title: 'Maintained/o-tooltip/Responsive Positioning',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsivePositioning = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/timeout.stories.tsx
+++ b/components/o-tooltip/stories/core/timeout.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Timeout',
+	title: 'Maintained/o-tooltip/Timeout',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Timeout = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/core/toggle.stories.tsx
+++ b/components/o-tooltip/stories/core/toggle.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Toggle',
+	title: 'Maintained/o-tooltip/Toggle',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggle = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/click.stories.tsx
+++ b/components/o-tooltip/stories/internal/click.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Click',
+	title: 'Maintained/o-tooltip/Click',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Click = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/custom-tooltip-theme.stories.tsx
+++ b/components/o-tooltip/stories/internal/custom-tooltip-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Custom Tooltip Theme',
+	title: 'Maintained/o-tooltip/Custom Tooltip Theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CustomTooltipTheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/demo.stories.tsx
+++ b/components/o-tooltip/stories/internal/demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Demo',
+	title: 'Maintained/o-tooltip/Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Demo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/focus.stories.tsx
+++ b/components/o-tooltip/stories/internal/focus.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Focus',
+	title: 'Maintained/o-tooltip/Focus',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Focus = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/hover.stories.tsx
+++ b/components/o-tooltip/stories/internal/hover.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Hover',
+	title: 'Maintained/o-tooltip/Hover',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hover = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/no-markup.stories.tsx
+++ b/components/o-tooltip/stories/internal/no-markup.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/No Markup',
+	title: 'Maintained/o-tooltip/No Markup',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const NoMarkup = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/professional-demo.stories.tsx
+++ b/components/o-tooltip/stories/internal/professional-demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Professional Demo',
+	title: 'Maintained/o-tooltip/Professional Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ProfessionalDemo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/responsive-positioning.stories.tsx
+++ b/components/o-tooltip/stories/internal/responsive-positioning.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Responsive Positioning',
+	title: 'Maintained/o-tooltip/Responsive Positioning',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsivePositioning = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/timeout.stories.tsx
+++ b/components/o-tooltip/stories/internal/timeout.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Timeout',
+	title: 'Maintained/o-tooltip/Timeout',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Timeout = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/internal/toggle.stories.tsx
+++ b/components/o-tooltip/stories/internal/toggle.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Toggle',
+	title: 'Maintained/o-tooltip/Toggle',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggle = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=internal"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=internal"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/jsdoc.stories.mdx
+++ b/components/o-tooltip/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-tooltip/JSDoc"
+title="Maintained/o-tooltip/JSDoc"
 />
 
 <Markdown>

--- a/components/o-tooltip/stories/readme.stories.mdx
+++ b/components/o-tooltip/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-tooltip/Readme"
+	title="Maintained/o-tooltip/Readme"
 />
 
 

--- a/components/o-tooltip/stories/sassdoc.stories.mdx
+++ b/components/o-tooltip/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-tooltip/SassDoc"
+title="Maintained/o-tooltip/SassDoc"
 />
 
 <Markdown>

--- a/components/o-tooltip/stories/whitelabel/click.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/click.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Click',
+	title: 'Maintained/o-tooltip/Click',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Click = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=click&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/custom-tooltip-theme.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/custom-tooltip-theme.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Custom Tooltip Theme',
+	title: 'Maintained/o-tooltip/Custom Tooltip Theme',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CustomTooltipTheme = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=custom&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/demo.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Demo',
+	title: 'Maintained/o-tooltip/Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Demo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=demo&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/focus.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/focus.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Focus',
+	title: 'Maintained/o-tooltip/Focus',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Focus = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=focus&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/hover.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/hover.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Hover',
+	title: 'Maintained/o-tooltip/Hover',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Hover = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=hover&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/no-markup.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/no-markup.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/No Markup',
+	title: 'Maintained/o-tooltip/No Markup',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const NoMarkup = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=no-markup&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/professional-demo.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/professional-demo.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Professional Demo',
+	title: 'Maintained/o-tooltip/Professional Demo',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ProfessionalDemo = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=professional-demo&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/responsive-positioning.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/responsive-positioning.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Responsive Positioning',
+	title: 'Maintained/o-tooltip/Responsive Positioning',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const ResponsivePositioning = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=responsive-positioning&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/timeout.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/timeout.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Timeout',
+	title: 'Maintained/o-tooltip/Timeout',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Timeout = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=timeout&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-tooltip/stories/whitelabel/toggle.stories.tsx
+++ b/components/o-tooltip/stories/whitelabel/toggle.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-tooltip/Toggle',
+	title: 'Maintained/o-tooltip/Toggle',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const Toggle = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=whitelabel"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-tooltip%405.3.1&demo=toggle&system_code=origami&brand=whitelabel"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-top-banner/stories/readme.stories.mdx
+++ b/components/o-top-banner/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-top-banner/Readme"
+	title="Maintained/o-top-banner/Readme"
 />
 
 

--- a/components/o-top-banner/stories/sassdoc.stories.mdx
+++ b/components/o-top-banner/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-top-banner/SassDoc"
+title="Maintained/o-top-banner/SassDoc"
 />
 
 <Markdown>

--- a/components/o-top-banner/stories/top-banner.stories.tsx
+++ b/components/o-top-banner/stories/top-banner.stories.tsx
@@ -3,7 +3,7 @@ import {TopBanner} from '../src/tsx/top-banner';
 import './top-banner.scss';
 
 export default {
-	title: 'Components/o-top-banner',
+	title: 'Maintained/o-top-banner',
 	component: TopBanner,
 	parameters: {},
 	args: {},
@@ -11,24 +11,26 @@ export default {
 
 const TopBannerStory = args => <TopBanner {...args} />;
 
-export const NewWorldTopBanner: ComponentStory<typeof TopBanner> = TopBannerStory.bind({});
+export const NewWorldTopBanner: ComponentStory<typeof TopBanner> =
+	TopBannerStory.bind({});
 NewWorldTopBanner.args = {
 	heading: 'Make sense of it all.',
 	content: 'Become an FT subscriber. Pay annually and save 20%',
-	primaryAction:  {
+	primaryAction: {
 		copy: 'Subscribe now',
 		url: '#',
 	},
-	theme:'new-world'
+	theme: 'new-world',
 };
 
-export const InverseProfessionalTopBanner: ComponentStory<typeof TopBanner> = TopBannerStory.bind({});
+export const InverseProfessionalTopBanner: ComponentStory<typeof TopBanner> =
+	TopBannerStory.bind({});
 InverseProfessionalTopBanner.args = {
 	heading: 'You can now access Workspace',
 	content: 'Only available with your FT Professional subscription',
-	primaryAction:  {
+	primaryAction: {
 		copy: 'Visit Workspace',
 		url: '#',
 	},
-	theme:'professional-inverse'
+	theme: 'professional-inverse',
 };

--- a/components/o-topper/stories/core/basic-article-topper.stories.tsx
+++ b/components/o-topper/stories/core/basic-article-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Basic Article Topper',
+	title: 'Maintained/o-topper/Basic Article Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BasicArticleTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Basic&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Basic&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/branded-article-topper.stories.tsx
+++ b/components/o-topper/stories/core/branded-article-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Branded Article Topper',
+	title: 'Maintained/o-topper/Branded Article Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const BrandedArticleTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Branded&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Branded&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/center-aligned-full-bleed-image-topper.stories.tsx
+++ b/components/o-topper/stories/core/center-aligned-full-bleed-image-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Center Aligned Full Bleed Image Topper',
+	title: 'Maintained/o-topper/Center Aligned Full Bleed Image Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CenterAlignedFullBleedImageTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Image+Center&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Image+Center&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/center-aligned-split-text-topper.stories.tsx
+++ b/components/o-topper/stories/core/center-aligned-split-text-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Center Aligned Split Text Topper',
+	title: 'Maintained/o-topper/Center Aligned Split Text Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CenterAlignedSplitTextTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Split+Text+Center&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Split+Text+Center&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/centered-topper.stories.tsx
+++ b/components/o-topper/stories/core/centered-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Centered Topper',
+	title: 'Maintained/o-topper/Centered Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const CenteredTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Centered&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Centered&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/deep-landscape.stories.tsx
+++ b/components/o-topper/stories/core/deep-landscape.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Deep Landscape',
+	title: 'Maintained/o-topper/Deep Landscape',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const DeepLandscape = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Deep+Landscape&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Deep+Landscape&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/deep-portrait.stories.tsx
+++ b/components/o-topper/stories/core/deep-portrait.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Deep Portrait',
+	title: 'Maintained/o-topper/Deep Portrait',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const DeepPortrait = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Deep+Portrait&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Deep+Portrait&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/featured-package-landing-page-topper.stories.tsx
+++ b/components/o-topper/stories/core/featured-package-landing-page-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Featured Package Landing Page Topper',
+	title: 'Maintained/o-topper/Featured Package Landing Page Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const FeaturedPackageLandingPageTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Package+Extra&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Package+Extra&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/left-aligned-full-bleed-image-topper.stories.tsx
+++ b/components/o-topper/stories/core/left-aligned-full-bleed-image-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Left Aligned Full Bleed Image Topper',
+	title: 'Maintained/o-topper/Left Aligned Full Bleed Image Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const LeftAlignedFullBleedImageTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Image+Left&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Image+Left&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/left-aligned-split-text-topper.stories.tsx
+++ b/components/o-topper/stories/core/left-aligned-split-text-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Left Aligned Split Text Topper',
+	title: 'Maintained/o-topper/Left Aligned Split Text Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const LeftAlignedSplitTextTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Split+Text+Left&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Split+Text+Left&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/offset-full-bleed-image-topper.stories.tsx
+++ b/components/o-topper/stories/core/offset-full-bleed-image-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Offset Full Bleed Image Topper',
+	title: 'Maintained/o-topper/Offset Full Bleed Image Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const OffsetFullBleedImageTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Offset+Right+Rail&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Full+Bleed+Offset+Right+Rail&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/opinion-article-topper.stories.tsx
+++ b/components/o-topper/stories/core/opinion-article-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Opinion Article Topper',
+	title: 'Maintained/o-topper/Opinion Article Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const OpinionArticleTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Opinion&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Opinion&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/package--series--landing-page-topper.stories.tsx
+++ b/components/o-topper/stories/core/package--series--landing-page-topper.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-	title: 'Components/o-topper/Package Series Landing Page Topper',
+	title: 'Maintained/o-topper/Package Series Landing Page Topper',
 	args: {},
 	parameters: {
 		html: {},

--- a/components/o-topper/stories/core/right-hand-rail-topper.stories.tsx
+++ b/components/o-topper/stories/core/right-hand-rail-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Right hand rail Topper',
+	title: 'Maintained/o-topper/Right hand rail Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const RighthandrailTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Right+hand+rail&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Right+hand+rail&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/core/special-report-package-landing-page-topper.stories.tsx
+++ b/components/o-topper/stories/core/special-report-package-landing-page-topper.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-topper/Special Report Package Landing Page Topper',
+	title: 'Maintained/o-topper/Special Report Package Landing Page Topper',
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,20 @@ export default {
 };
 
 export const SpecialReportPackageLandingPageTopper = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Package+Special+Report&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-topper%406.0.7&demo=Package+Special+Report&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: 'calc(100vh - 3rem)',
+					'box-sizing': 'border-box',
+					border: '0',
+					width: '100%',
+				}}></iframe>
+		</>
+	);
+};

--- a/components/o-topper/stories/readme.stories.mdx
+++ b/components/o-topper/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-topper/Readme"
+	title="Maintained/o-topper/Readme"
 />
 
 

--- a/components/o-topper/stories/sassdoc.stories.mdx
+++ b/components/o-topper/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-topper/SassDoc"
+title="Maintained/o-topper/SassDoc"
 />
 
 <Markdown>

--- a/components/o-typography/stories/core/sassdoc.stories.mdx
+++ b/components/o-typography/stories/core/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-typography/SassDoc"
+title="Deprecated/o-typography/SassDoc"
 />
 
 <Markdown>

--- a/components/o-typography/stories/internal/sassdoc.stories.mdx
+++ b/components/o-typography/stories/internal/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-typography/SassDoc"
+title="Deprecated/o-typography/SassDoc"
 />
 
 <Markdown>

--- a/components/o-typography/stories/jsdoc.stories.mdx
+++ b/components/o-typography/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-typography/JSDoc"
+title="Deprecated/o-typography/JSDoc"
 />
 
 <Markdown>

--- a/components/o-typography/stories/readme.stories.mdx
+++ b/components/o-typography/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-typography/Readme"
+	title="Deprecated/o-typography/Readme"
 />
 
 

--- a/components/o-typography/stories/typography-body.stories.tsx
+++ b/components/o-typography/stories/typography-body.stories.tsx
@@ -2,9 +2,9 @@ import {P, Span, Sup, Sub, Strong, Em, Link} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: P,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -17,13 +17,20 @@ export default {
 	},
 };
 
-const Story = args => <>
-    <P {...args}>
-        <Span weight='bold'>Body</Span> - Lorem ipsum dolor sit amet, consectetur adipisicing elit. <Link href="#">Link</Link> a rem <Strong>excepturi</Strong> consequuntur commodi dolores ad <Em>laboriosam</Em> qui odit ipsum distinctio quos laborum dolore magnam iure rerum, enim deleniti saepe sunt.
-    </P>
-    <P {...args}>
-        Lorem ipsum dolor sit amet<Sup>Sup</Sup>, consectetur adipisicing elit<Sub>Sub</Sub>. <Link href="#">Link Necessitatibus asperiores</Link>.
-    </P>
-</>;
+const Story = args => (
+	<>
+		<P {...args}>
+			<Span weight="bold">Body</Span> - Lorem ipsum dolor sit amet, consectetur
+			adipisicing elit. <Link href="#">Link</Link> a rem{' '}
+			<Strong>excepturi</Strong> consequuntur commodi dolores ad{' '}
+			<Em>laboriosam</Em> qui odit ipsum distinctio quos laborum dolore magnam
+			iure rerum, enim deleniti saepe sunt.
+		</P>
+		<P {...args}>
+			Lorem ipsum dolor sit amet<Sup>Sup</Sup>, consectetur adipisicing elit
+			<Sub>Sub</Sub>. <Link href="#">Link Necessitatibus asperiores</Link>.
+		</P>
+	</>
+);
 
 export const Body = Story.bind({});

--- a/components/o-typography/stories/typography-caption.stories.tsx
+++ b/components/o-typography/stories/typography-caption.stories.tsx
@@ -1,9 +1,9 @@
 import {FigCaption, Link} from '../src/tsx/typography';
 import './typography.scss';
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: FigCaption,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -16,20 +16,21 @@ export default {
 	},
 };
 
-export const FigureCaption = args => <figure>
-<img alt="illustration of people at a picnic bench, used as a demo image" src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=origami-build-tools" />
-<FigCaption {...args}>
-    {args.children ? args.children : <><Link href="#">&#xA9;Lorem</Link> John Doe</>}
-</FigCaption>
-</figure>;
-FigureCaption.args = {children: '' };
-
-
-
-
-
-
-
-
-
-
+export const FigureCaption = args => (
+	<figure>
+		<img
+			alt="illustration of people at a picnic bench, used as a demo image"
+			src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=origami-build-tools"
+		/>
+		<FigCaption {...args}>
+			{args.children ? (
+				args.children
+			) : (
+				<>
+					<Link href="#">&#xA9;Lorem</Link> John Doe
+				</>
+			)}
+		</FigCaption>
+	</figure>
+);
+FigureCaption.args = {children: ''};

--- a/components/o-typography/stories/typography-footer.stories.tsx
+++ b/components/o-typography/stories/typography-footer.stories.tsx
@@ -2,9 +2,9 @@ import {Footer as FooterComponent} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: FooterComponent,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -17,4 +17,6 @@ export default {
 	},
 };
 
-export const Footer = args => <FooterComponent {...args}>Footer such as copyright notice.</FooterComponent>;
+export const Footer = args => (
+	<FooterComponent {...args}>Footer such as copyright notice.</FooterComponent>
+);

--- a/components/o-typography/stories/typography-headings.stories.tsx
+++ b/components/o-typography/stories/typography-headings.stories.tsx
@@ -2,9 +2,9 @@ import {Heading} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: Heading,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -17,12 +17,14 @@ export default {
 	},
 };
 
-export const UIHeadings = args => <>
-	<Heading level={1} copy={args.copy || 'Heading level 1'} />
-	<Heading level={2} copy={args.copy || 'Heading level 2'} />
-	<Heading level={3} copy={args.copy || 'Heading level 3'} />
-	<Heading level={4} copy={args.copy || 'Heading level 4'} />
-	<Heading level={5} copy={args.copy || 'Heading level 5'} />
-	<Heading level={6} copy={args.copy || 'Heading level 6'} />
-</>;
-UIHeadings.args = {copy: '' };
+export const UIHeadings = args => (
+	<>
+		<Heading level={1} copy={args.copy || 'Heading level 1'} />
+		<Heading level={2} copy={args.copy || 'Heading level 2'} />
+		<Heading level={3} copy={args.copy || 'Heading level 3'} />
+		<Heading level={4} copy={args.copy || 'Heading level 4'} />
+		<Heading level={5} copy={args.copy || 'Heading level 5'} />
+		<Heading level={6} copy={args.copy || 'Heading level 6'} />
+	</>
+);
+UIHeadings.args = {copy: ''};

--- a/components/o-typography/stories/typography-links.stories.tsx
+++ b/components/o-typography/stories/typography-links.stories.tsx
@@ -2,9 +2,9 @@ import {Link} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: Link,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -22,5 +22,5 @@ const Story = args => <Link {...args} />;
 export const StandardLink = Story.bind({});
 StandardLink.args = {
 	children: 'link to another page',
-	href: '#'
+	href: '#',
 };

--- a/components/o-typography/stories/typography-list.stories.tsx
+++ b/components/o-typography/stories/typography-list.stories.tsx
@@ -2,9 +2,9 @@ import {Body, List, ListItem} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: List,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -18,18 +18,25 @@ export default {
 };
 
 const items = ['Apples', 'Bananas', 'Oranges', 'Pears', 'Tangelos'];
-const Story = args => <Body>
-    <List {...args} children={args.items.map(item => <ListItem key={item}>{item}</ListItem>)} />
-</Body>;
+const Story = args => (
+	<Body>
+		<List
+			{...args}
+			children={args.items.map(item => (
+				<ListItem key={item}>{item}</ListItem>
+			))}
+		/>
+	</Body>
+);
 
 export const UnorderedList = Story.bind({});
 UnorderedList.args = {
 	items,
-	ordered: false
+	ordered: false,
 };
 
 export const OrderedList = Story.bind({});
 OrderedList.args = {
 	items,
-    ordered: true
+	ordered: true,
 };

--- a/components/o-typography/stories/typography-wrapper.stories.tsx
+++ b/components/o-typography/stories/typography-wrapper.stories.tsx
@@ -2,9 +2,9 @@ import {Wrapper} from '../src/tsx/typography';
 import './typography.scss';
 
 export default {
-	title: 'Components/o-typography',
+	title: 'Deprecated/o-typography',
 	component: Wrapper,
-    args: {},
+	args: {},
 	parameters: {
 		design: {
 			type: 'figma',
@@ -17,29 +17,44 @@ export default {
 	},
 };
 
+export const TypographyWrapper = args => (
+	<Wrapper {...args}>
+		<h1>Heading level 1</h1>
+		<h2>Heading level 2</h2>
+		<h3>Heading level 3</h3>
+		<h4>Heading level 4</h4>
+		<h5>Heading level 5</h5>
+		<h6>Heading level 6</h6>
 
-export const TypographyWrapper = args => <Wrapper {...args}>
-	<h1>Heading level 1</h1>
-	<h2>Heading level 2</h2>
-	<h3>Heading level 3</h3>
-	<h4>Heading level 4</h4>
-	<h5>Heading level 5</h5>
-	<h6>Heading level 6</h6>
+		<p>
+			Body - Lorem ipsum dolor sit amet, consectetur adipisicing elit.{' '}
+			<a href="#">Link</a> a rem <strong>excepturi</strong> consequuntur commodi
+			dolores ad <em>laboriosam</em> qui odit ipsum distinctio quos laborum
+			dolore magnam iure rerum, enim deleniti saepe sunt.
+		</p>
+		<p>
+			Lorem ipsum dolor sit amet<sup>Sup</sup>, consectetur adipisicing elit
+			<sub>Sub</sub> reiciendis neque et facilis quidem quasi autem tenetur
+			adipisci eum aut magni atque cupiditate laboriosam.{' '}
+			<a href="#">Link Necessitatibus asperiores</a>
+		</p>
 
-	<p>Body - Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Link</a> a rem <strong>excepturi</strong> consequuntur commodi dolores ad <em>laboriosam</em> qui odit ipsum distinctio quos laborum dolore magnam iure rerum, enim deleniti saepe sunt.</p>
-	<p>Lorem ipsum dolor sit amet<sup>Sup</sup>, consectetur adipisicing elit<sub>Sub</sub> reiciendis neque et facilis quidem quasi autem tenetur adipisci eum aut magni atque cupiditate laboriosam. <a href="#">Link Necessitatibus asperiores</a></p>
+		<p>
+			Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt
+			aspernatur aut corporis eius. Neque consequuntur commodi consectetur ullam
+			laudantium saepe.
+		</p>
 
-	<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt aspernatur aut corporis eius. Neque consequuntur commodi consectetur ullam laudantium saepe.</p>
+		<ul>
+			<li>List</li>
+			<li>List</li>
+		</ul>
 
-	<ul>
-		<li>List</li>
-		<li>List</li>
-	</ul>
+		<ol>
+			<li>List ordered</li>
+			<li>List ordered</li>
+		</ol>
 
-	<ol>
-		<li>List ordered</li>
-		<li>List ordered</li>
-	</ol>
-
-	<footer>Footer such as copyright notice.</footer>
-</Wrapper>;
+		<footer>Footer such as copyright notice.</footer>
+	</Wrapper>
+);

--- a/components/o-typography/stories/whitelabel/sassdoc.stories.mdx
+++ b/components/o-typography/stories/whitelabel/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './sassdoc.md';
 
 <Meta
-title="components/o-typography/SassDoc"
+title="Deprecated/o-typography/SassDoc"
 />
 
 <Markdown>

--- a/components/o-video/stories/core/captions.stories.tsx
+++ b/components/o-video/stories/core/captions.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Captions',
+	title: "Maintained/o-video/Captions",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Captions = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=captions&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=captions&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/core/native.stories.tsx
+++ b/components/o-video/stories/core/native.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Native',
+	title: "Maintained/o-video/Native",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Native = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=native&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=native&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/core/placeholder-with-hint.stories.tsx
+++ b/components/o-video/stories/core/placeholder-with-hint.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Placeholder With Hint',
+	title: "Maintained/o-video/Placeholder With Hint",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const PlaceholderWithHint = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=placeholder+with+hint&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=placeholder+with+hint&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/core/placeholder.stories.tsx
+++ b/components/o-video/stories/core/placeholder.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Placeholder',
+	title: "Maintained/o-video/Placeholder",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Placeholder = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=placeholder&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=placeholder&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/core/playlist.stories.tsx
+++ b/components/o-video/stories/core/playlist.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Playlist',
+	title: "Maintained/o-video/Playlist",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const Playlist = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=playlist&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=playlist&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/core/size-variations.stories.tsx
+++ b/components/o-video/stories/core/size-variations.stories.tsx
@@ -1,6 +1,5 @@
-
 export default {
-	title: 'Components/o-video/Size Variations',
+	title: "Maintained/o-video/Size Variations",
 	args: {},
 	parameters: {
 		html: {},
@@ -8,19 +7,21 @@ export default {
 };
 
 export const SizeVariations = args => {
-
-	return (<>
-		<iframe
-			loading="lazy"
-			scrolling="yes"
-			allowTransparency="true"
-			src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=size+variations&system_code=origami&brand=core"
-			title="Inline Live Demo"
-			style={{
-				height: 'calc(100vh - 3rem)',
-				'box-sizing': 'border-box',
-				border: '0',
-				width: '100%',
-			}}></iframe>
-	</>);
-}
+	return (
+		<>
+			<iframe
+				loading="lazy"
+				scrolling="yes"
+				allowTransparency="true"
+				src="https://www.ft.com/__origami/service/build/v3/demo?component=o-video%407.2.10&demo=size+variations&system_code=origami&brand=core"
+				title="Inline Live Demo"
+				style={{
+					height: "calc(100vh - 3rem)",
+					"box-sizing": "border-box",
+					border: "0",
+					width: "100%",
+				}}
+			></iframe>
+		</>
+	);
+};

--- a/components/o-video/stories/jsdoc.stories.mdx
+++ b/components/o-video/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="components/o-video/JSDoc"
+title="Maintained/o-video/JSDoc"
 />
 
 <Markdown>

--- a/components/o-video/stories/readme.stories.mdx
+++ b/components/o-video/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-video/Readme"
+	title="Maintained/o-video/Readme"
 />
 
 

--- a/components/o-video/stories/sassdoc.stories.mdx
+++ b/components/o-video/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-video/SassDoc"
+title="Maintained/o-video/SassDoc"
 />
 
 <Markdown>

--- a/components/o-viewport/stories/jsdoc.stories.mdx
+++ b/components/o-viewport/stories/jsdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import JSDOC from './docs/jsdoc.md';
 
 <Meta
-title="Brandless/o-viewport/JSDoc"
+title="Maintained/o-viewport/JSDoc"
 />
 
 <Markdown>

--- a/components/o-viewport/stories/readme.stories.mdx
+++ b/components/o-viewport/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="Brandless/o-viewport/Readme"
+	title="Maintained/o-viewport/Readme"
 />
 
 

--- a/components/o-visual-effects/stories/readme.stories.mdx
+++ b/components/o-visual-effects/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="components/o-visual-effects/Readme"
+	title="Maintained/o-visual-effects/Readme"
 />
 
 

--- a/components/o-visual-effects/stories/sassdoc.stories.mdx
+++ b/components/o-visual-effects/stories/sassdoc.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import SASSDOC from './docs/sassdoc.md';
 
 <Meta
-title="components/o-visual-effects/SassDoc"
+title="Maintained/o-visual-effects/SassDoc"
 />
 
 <Markdown>

--- a/components/o-visual-effects/stories/shadows.stories.tsx
+++ b/components/o-visual-effects/stories/shadows.stories.tsx
@@ -2,8 +2,8 @@ import './visual-effects.scss';
 import {ShadowDemo} from './shadows-demo';
 
 export default {
-	title: 'Components/o-visual-effects',
-    component: ShadowDemo,
+	title: 'Maintained/o-visual-effects',
+	component: ShadowDemo,
 	parameters: {
 		guidelines: {},
 		html: {},
@@ -12,5 +12,5 @@ export default {
 
 export const Shadows = ShadowDemo.bind({});
 Shadows.args = {
-    depth: 'mid'
+	depth: 'mid',
 };

--- a/components/o-visual-effects/stories/transitions.stories.tsx
+++ b/components/o-visual-effects/stories/transitions.stories.tsx
@@ -2,8 +2,8 @@ import './visual-effects.scss';
 import {TransitionDemo} from './transition-demo';
 
 export default {
-	title: 'Components/o-visual-effects',
-    component: TransitionDemo,
+	title: 'Maintained/o-visual-effects',
+	component: TransitionDemo,
 	parameters: {
 		guidelines: {},
 		html: {},
@@ -12,18 +12,18 @@ export default {
 
 export const Expand = TransitionDemo.bind({});
 Expand.args = {
-    transition: 'expand',
-    timing: 0.3
+	transition: 'expand',
+	timing: 0.3,
 };
 
 export const Slide = TransitionDemo.bind({});
 Slide.args = {
-    transition: 'slide',
-    timing: 0.3
+	transition: 'slide',
+	timing: 0.3,
 };
 
 export const Fade = TransitionDemo.bind({});
 Fade.args = {
-    transition: 'fade',
-    timing: 0.3
+	transition: 'fade',
+	timing: 0.3,
 };

--- a/libraries/o-autoinit/stories/readme.stories.mdx
+++ b/libraries/o-autoinit/stories/readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta, Markdown} from "@storybook/blocks";
+import { Meta, Markdown } from "@storybook/blocks";
 import Readme from '../README.md';
 
 <Meta
-	title="Brandless/o-autoinit/Readme"
+	title="Maintained/o-autoinit/Readme"
 />
 
 

--- a/libraries/o-tracking/stories/o-tracking.readme.stories.mdx
+++ b/libraries/o-tracking/stories/o-tracking.readme.stories.mdx
@@ -1,8 +1,8 @@
-import {Meta} from "@storybook/addon-docs";
+import { Meta } from "@storybook/addon-docs";
 import Readme from "../README.md";
-import {Markdown} from "@storybook/blocks";
+import { Markdown } from "@storybook/blocks";
 
-<Meta title = "Brandless/o-tracking/Readme" / >
+<Meta title = "Maintained/o-tracking/Readme" / >
 
 <Markdown>
 	{Readme}

--- a/libraries/o-tracking/stories/o-tracking.stories.jsx
+++ b/libraries/o-tracking/stories/o-tracking.stories.jsx
@@ -1,5 +1,5 @@
 export default {
-	title: "Brandless/o-tracking"
+	title: "Maintained/o-tracking"
 };
 
 export const NoJavascript = () => {


### PR DESCRIPTION
- Update index page of composite storybook to reflect changes in o3 and our adoption schedule. We shouldn't refer to "o2" components as "legacy" when many are actively maintained, and will be used for the foreseeable future.
- Remove "Brandless" grouping. This is repeated with "Brandless/o-tracking" at a top level and other "Brandless" packages nested within each brand's storybook, including o-tracking repeated again. Instead, keep each component under each brand it supports. This also means it is visible when viewing a single brand's storybook in isolation.
- Group stories by support status. This makes it clear which components are supported and which have been deprecated for o3 alternatives. When we upgrade to storybook 8 [tags](https://storybook.js.org/docs/writing-stories/tags) would be a better option. This would allow component story titles to stay the same when support status changes (maintaining links) and allow components to be filtered by support status (as with the old Origami registry)

Before:
![Screenshot 2025-02-27 at 15 28 22](https://github.com/user-attachments/assets/56d947ff-b9ef-41cf-861d-b8cd299c8cb8)

After:
![Screenshot 2025-02-27 at 15 28 04](https://github.com/user-attachments/assets/5251ab6d-2592-4f82-a6b8-34f1c4c9ec37)
