### PR TITLE
chore: Add dummy Story to storybook composition

### DIFF
--- a/apps/o2-storybook-composition/stories/placeholder.stories.tsx
+++ b/apps/o2-storybook-composition/stories/placeholder.stories.tsx
@@ -1,0 +1,17 @@
+const Dummy = () => (
+	<>
+		Storybook{' '}
+		<a href="https://github.com/chromaui/chromatic-cli/issues/774">
+			composition requires a Story
+		</a>
+		, though we do not need any. Origami v2 (o2) has a seperate Storyboook for
+		each brand. This Storybook composes them all into one place.
+	</>
+);
+export default {
+	title: 'Placeholder',
+	component: Dummy,
+	tags: ['!autodocs', '!dev'], // Hide story in the sidebar
+};
+
+export const Story = {};


### PR DESCRIPTION
Fix deployment with a dummy story (hidden). Otherwise, the production build fails, assuming a mistake as no stories exist: https://github.com/chromaui/chromatic-cli/issues/774