### PR TITLE
fix: use aria-disabled on LinkButton

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -37,13 +37,15 @@
 	appearance: none;
 }
 
-.o3-button[disabled] {
+.o3-button[disabled],
+.o3-button[aria-disabled=true] {
 	pointer-events: none;
 	opacity: 0.4;
 	cursor: default;
 }
 
-.o3-button[disabled].o3-button--hide-disabled {
+.o3-button[disabled].o3-button--hide-disabled,
+.o3-button[aria-disabled=true].o3-button--hide-disabled {
 	visibility: hidden;
 }
 

--- a/components/o3-button/stories/story-templates.tsx
+++ b/components/o3-button/stories/story-templates.tsx
@@ -8,8 +8,9 @@ import {TemplateSBConfig} from './sb-story-config';
 type ButtonStory = Omit<StoryObj, 'args'> & {
 	args: ButtonProps & {disabled: Boolean};
 };
+
 type LinkButtonStory = Omit<StoryObj, 'args'> & {
-	args: LinkButtonProps & {disabled: Boolean};
+	args: LinkButtonProps & {ariaDisabled: Boolean};
 };
 type ButtonGroupStory = Omit<StoryObj, 'args'> & {
 	args: {
@@ -17,9 +18,7 @@ type ButtonGroupStory = Omit<StoryObj, 'args'> & {
 	};
 };
 
-export type TemplateType = StoryObj & {
-	render: (args) => JSX.Element;
-};
+export type TemplateType = StoryObj;
 
 const ButtonTemplate: TemplateType = {
 	...TemplateSBConfig,
@@ -31,7 +30,7 @@ const ButtonTemplate: TemplateType = {
 const LinkButtonTemplate: TemplateType = {
 	...TemplateSBConfig,
 	render: args => {
-		return <LinkButton {...args} attributes={{disabled: args.disabled}} />;
+		return <LinkButton {...args} attributes={{'aria-disabled': args['aria-disabled']}} />;
 	},
 };
 
@@ -74,7 +73,7 @@ export const LinkAsButton: LinkButtonStory = {
 		label: 'Link button',
 		type: 'secondary',
 		href: '#',
-		disabled: false,
+		['aria-disabled']: false,
 	},
 };
 


### PR DESCRIPTION
## Describe your changes

Storybook was applying `disabled` attribute to LinkButton which uses an anchor tag, `disabled` is not a valid attribute on anchors, instead use `aria-disabled`

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
