### PR TITLE
backstage: use pixel values for sizing and typography in tooling

### DIFF
--- a/apps/dictionary/src/config/platforms/css.js
+++ b/apps/dictionary/src/config/platforms/css.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import {sharedTransformers} from '../transformers.js';
+import {webTransformers} from '../transformers.js';
 import components from '../components.js';
 import {outputReferencesTransformed} from 'style-dictionary/utils';
 
@@ -8,7 +8,7 @@ function cssConfigForBrand(brand) {
 	return {
 		transformGroup: 'css',
 		transforms: [
-			...sharedTransformers,
+			...webTransformers,
 			'value/figma-shadow-shorthand',
 			'value/transformSVG',
 		],

--- a/apps/dictionary/src/config/platforms/sass.js
+++ b/apps/dictionary/src/config/platforms/sass.js
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import {sharedTransformers} from '../transformers.js';
+import {webTransformers} from '../transformers.js';
 
 function sassConfigForBrand(brand) {
 	const parentBrand = brand.split('/').slice(-1);
 	return {
 		transformGroup: 'scss',
 		transforms: [
-			...sharedTransformers,
+			...webTransformers,
 			'value/figma-shadow-shorthand',
 			'value/transformSVG',
 		],

--- a/apps/dictionary/src/config/platforms/tooling.js
+++ b/apps/dictionary/src/config/platforms/tooling.js
@@ -5,7 +5,7 @@ function toolingConfigForBrand(brand) {
 	const parentBrand = brand.split('/').slice(-1);
 	return {
 		transformGroup: 'js',
-		transforms: [...toolingTransformers, 'Origami/tintGroup'],
+		transforms: toolingTransformers,
 		buildPath: path.join(
 			process.cwd(),
 			'../../libraries/o3-tooling-token/build/'

--- a/apps/dictionary/src/config/platforms/tooling.js
+++ b/apps/dictionary/src/config/platforms/tooling.js
@@ -1,11 +1,11 @@
 import path from 'node:path';
-import {sharedTransformers} from '../transformers.js';
+import {toolingTransformers} from '../transformers.js';
 
 function toolingConfigForBrand(brand) {
 	const parentBrand = brand.split('/').slice(-1);
 	return {
 		transformGroup: 'js',
-		transforms: [...sharedTransformers, 'Origami/tintGroup'],
+		transforms: [...toolingTransformers, 'Origami/tintGroup'],
 		buildPath: path.join(
 			process.cwd(),
 			'../../libraries/o3-tooling-token/build/'

--- a/apps/dictionary/src/config/transformers.js
+++ b/apps/dictionary/src/config/transformers.js
@@ -13,11 +13,11 @@ const transformers = [
 
 const toolingTransformers = [
 	'size/px',
-	// 'size/remToPx',
+	'Origami/tintGroup',
 	...baseTransformers,
 ]
 
 export {
-	transformers as sharedTransformers,
+	transformers as webTransformers,
 	toolingTransformers,
 };

--- a/apps/dictionary/src/config/transformers.js
+++ b/apps/dictionary/src/config/transformers.js
@@ -1,5 +1,4 @@
-const transformers = [
-	'size/pxToRem',
+const baseTransformers = [
 	'ts/descriptionToComment',
 	'color/css',
 	'ts/color/modifiers',
@@ -7,4 +6,18 @@ const transformers = [
 	'name/origamiPrivatePrefix',
 ];
 
-export {transformers as sharedTransformers};
+const transformers = [
+	...baseTransformers,
+	'size/pxToRem',
+];
+
+const toolingTransformers = [
+	'size/px',
+	// 'size/remToPx',
+	...baseTransformers,
+]
+
+export {
+	transformers as sharedTransformers,
+	toolingTransformers,
+};

--- a/libraries/o3-tooling-token/build/core/_variables.js
+++ b/libraries/o3-tooling-token/build/core/_variables.js
@@ -1991,7 +1991,7 @@ export default {
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4px",
 		"type": "dimension",
 		"attributes": {
@@ -2007,7 +2007,7 @@ export default {
 },
 	"o3-spacing-4xs": {
 		"shortName": "4xs",
-		"value": "0.5rem",
+		"value": "8px",
 		"originalValue": "8px",
 		"type": "dimension",
 		"attributes": {
@@ -2023,7 +2023,7 @@ export default {
 },
 	"o3-spacing-3xs": {
 		"shortName": "3xs",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12px",
 		"type": "dimension",
 		"attributes": {
@@ -2039,7 +2039,7 @@ export default {
 },
 	"o3-spacing-2xs": {
 		"shortName": "2xs",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16px",
 		"type": "dimension",
 		"attributes": {
@@ -2055,7 +2055,7 @@ export default {
 },
 	"o3-spacing-xs": {
 		"shortName": "xs",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20px",
 		"type": "dimension",
 		"attributes": {
@@ -2071,7 +2071,7 @@ export default {
 },
 	"o3-spacing-s": {
 		"shortName": "s",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24px",
 		"type": "dimension",
 		"attributes": {
@@ -2087,7 +2087,7 @@ export default {
 },
 	"o3-spacing-m": {
 		"shortName": "m",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32px",
 		"type": "dimension",
 		"attributes": {
@@ -2103,7 +2103,7 @@ export default {
 },
 	"o3-spacing-l": {
 		"shortName": "l",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40px",
 		"type": "dimension",
 		"attributes": {
@@ -2119,7 +2119,7 @@ export default {
 },
 	"o3-spacing-xl": {
 		"shortName": "xl",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48px",
 		"type": "dimension",
 		"attributes": {
@@ -2135,7 +2135,7 @@ export default {
 },
 	"o3-spacing-2xl": {
 		"shortName": "2xl",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64px",
 		"type": "dimension",
 		"attributes": {
@@ -2151,7 +2151,7 @@ export default {
 },
 	"o3-spacing-3xl": {
 		"shortName": "3xl",
-		"value": "5rem",
+		"value": "80px",
 		"originalValue": "80px",
 		"type": "dimension",
 		"attributes": {
@@ -2167,7 +2167,7 @@ export default {
 },
 	"o3-spacing-4xl": {
 		"shortName": "4xl",
-		"value": "6rem",
+		"value": "96px",
 		"originalValue": "96px",
 		"type": "dimension",
 		"attributes": {
@@ -2221,7 +2221,7 @@ export default {
 },
 	"o3-type-display-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.size.7}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2240,7 +2240,7 @@ export default {
 },
 	"o3-type-display-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight.7}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2297,7 +2297,7 @@ export default {
 },
 	"o3-type-display-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2316,7 +2316,7 @@ export default {
 },
 	"o3-type-display-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2373,7 +2373,7 @@ export default {
 },
 	"o3-type-display-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2392,7 +2392,7 @@ export default {
 },
 	"o3-type-display-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2449,7 +2449,7 @@ export default {
 },
 	"o3-type-headline-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2468,7 +2468,7 @@ export default {
 },
 	"o3-type-headline-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2525,7 +2525,7 @@ export default {
 },
 	"o3-type-headline-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2544,7 +2544,7 @@ export default {
 },
 	"o3-type-headline-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2601,7 +2601,7 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2620,7 +2620,7 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight.3}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2677,7 +2677,7 @@ export default {
 },
 	"o3-type-title-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.size-metric2.4}",
 		"type": "dimension",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2696,7 +2696,7 @@ export default {
 },
 	"o3-type-title-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2753,7 +2753,7 @@ export default {
 },
 	"o3-type-title-md-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -2772,7 +2772,7 @@ export default {
 },
 	"o3-type-title-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -2829,7 +2829,7 @@ export default {
 },
 	"o3-type-title-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -2848,7 +2848,7 @@ export default {
 },
 	"o3-type-title-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -2905,7 +2905,7 @@ export default {
 },
 	"o3-type-body-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "{o3.font.size-metric2.1}",
 		"type": "dimension",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -2924,7 +2924,7 @@ export default {
 },
 	"o3-type-body-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.1}",
 		"type": "number",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -2981,7 +2981,7 @@ export default {
 },
 	"o3-type-body-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3000,7 +3000,7 @@ export default {
 },
 	"o3-type-body-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3057,7 +3057,7 @@ export default {
 },
 	"o3-type-body-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3076,7 +3076,7 @@ export default {
 },
 	"o3-type-body-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3133,7 +3133,7 @@ export default {
 },
 	"o3-type-detail-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3152,7 +3152,7 @@ export default {
 },
 	"o3-type-detail-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3209,7 +3209,7 @@ export default {
 },
 	"o3-type-label-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3228,7 +3228,7 @@ export default {
 },
 	"o3-type-label-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3304,7 +3304,7 @@ export default {
 },
 	"o3-type-body-content-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3323,7 +3323,7 @@ export default {
 },
 	"o3-type-body-content-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3380,7 +3380,7 @@ export default {
 },
 	"o3-type-body-content-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3399,7 +3399,7 @@ export default {
 },
 	"o3-type-body-content-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3456,7 +3456,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3475,7 +3475,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3513,7 +3513,7 @@ export default {
 },
 	"o3-border-radius-1": {
 		"shortName": "1",
-		"value": "0.125rem",
+		"value": "2px",
 		"originalValue": "2",
 		"type": "dimension",
 		"description": "for default radius on interactive elements",
@@ -3530,7 +3530,7 @@ export default {
 },
 	"o3-border-radius-2": {
 		"shortName": "2",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4",
 		"type": "dimension",
 		"description": "for the outer radius of interactive elements that have both inner and outer boundaries as in box radio button ",
@@ -3691,7 +3691,7 @@ export default {
 },
 	"o3-font-lineheight-0": {
 		"shortName": "0",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3709,7 +3709,7 @@ export default {
 },
 	"o3-font-lineheight-1": {
 		"shortName": "1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3727,7 +3727,7 @@ export default {
 },
 	"o3-font-lineheight-2": {
 		"shortName": "2",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -3745,7 +3745,7 @@ export default {
 },
 	"o3-font-lineheight-3": {
 		"shortName": "3",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -3763,7 +3763,7 @@ export default {
 },
 	"o3-font-lineheight-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3781,7 +3781,7 @@ export default {
 },
 	"o3-font-lineheight-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3799,7 +3799,7 @@ export default {
 },
 	"o3-font-lineheight-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -3817,7 +3817,7 @@ export default {
 },
 	"o3-font-lineheight-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -3835,7 +3835,7 @@ export default {
 },
 	"o3-font-lineheight-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -3853,7 +3853,7 @@ export default {
 },
 	"o3-font-lineheight-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -3871,7 +3871,7 @@ export default {
 },
 	"o3-font-lineheight-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -3889,7 +3889,7 @@ export default {
 },
 	"o3-font-lineheight-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -3907,7 +3907,7 @@ export default {
 },
 	"o3-font-lineheight-negative-1": {
 		"shortName": "negative-1",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -3925,7 +3925,7 @@ export default {
 },
 	"o3-font-size-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -3943,7 +3943,7 @@ export default {
 },
 	"o3-font-size-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -3961,7 +3961,7 @@ export default {
 },
 	"o3-font-size-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -3979,7 +3979,7 @@ export default {
 },
 	"o3-font-size-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -3997,7 +3997,7 @@ export default {
 },
 	"o3-font-size-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -4015,7 +4015,7 @@ export default {
 },
 	"o3-font-size-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -4033,7 +4033,7 @@ export default {
 },
 	"o3-font-size-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -4051,7 +4051,7 @@ export default {
 },
 	"o3-font-size-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -4069,7 +4069,7 @@ export default {
 },
 	"o3-font-size-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "fontSize",
 		"attributes": {
@@ -4087,7 +4087,7 @@ export default {
 },
 	"o3-font-size-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -4105,7 +4105,7 @@ export default {
 },
 	"o3-font-size-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "fontSize",
 		"attributes": {
@@ -4123,7 +4123,7 @@ export default {
 },
 	"o3-font-size-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -4141,7 +4141,7 @@ export default {
 },
 	"o3-font-size-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -4159,7 +4159,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-0": {
 		"shortName": "0",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -4177,7 +4177,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-1": {
 		"shortName": "1",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -4195,7 +4195,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-2": {
 		"shortName": "2",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -4213,7 +4213,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-3": {
 		"shortName": "3",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -4231,7 +4231,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -4249,7 +4249,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-5": {
 		"shortName": "5",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -4267,7 +4267,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-6": {
 		"shortName": "6",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -4285,7 +4285,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-7": {
 		"shortName": "7",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -4303,7 +4303,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-8": {
 		"shortName": "8",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -4321,7 +4321,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-9": {
 		"shortName": "9",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -4339,7 +4339,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -4357,7 +4357,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -4375,7 +4375,7 @@ export default {
 },
 	"o3-font-size-metric2-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -4393,7 +4393,7 @@ export default {
 },
 	"o3-font-size-metric2-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -4411,7 +4411,7 @@ export default {
 },
 	"o3-font-size-metric2-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -4429,7 +4429,7 @@ export default {
 },
 	"o3-font-size-metric2-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -4447,7 +4447,7 @@ export default {
 },
 	"o3-font-size-metric2-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -4465,7 +4465,7 @@ export default {
 },
 	"o3-font-size-metric2-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -4483,7 +4483,7 @@ export default {
 },
 	"o3-font-size-metric2-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -4501,7 +4501,7 @@ export default {
 },
 	"o3-font-size-metric2-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -4519,7 +4519,7 @@ export default {
 },
 	"o3-font-size-metric2-8": {
 		"shortName": "8",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64",
 		"type": "fontSize",
 		"attributes": {
@@ -4537,7 +4537,7 @@ export default {
 },
 	"o3-font-size-metric2-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -4555,7 +4555,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -4573,7 +4573,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/core/professional/_variables.js
+++ b/libraries/o3-tooling-token/build/core/professional/_variables.js
@@ -2229,7 +2229,7 @@ export default {
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4px",
 		"type": "dimension",
 		"attributes": {
@@ -2245,7 +2245,7 @@ export default {
 },
 	"o3-spacing-4xs": {
 		"shortName": "4xs",
-		"value": "0.5rem",
+		"value": "8px",
 		"originalValue": "8px",
 		"type": "dimension",
 		"attributes": {
@@ -2261,7 +2261,7 @@ export default {
 },
 	"o3-spacing-3xs": {
 		"shortName": "3xs",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12px",
 		"type": "dimension",
 		"attributes": {
@@ -2277,7 +2277,7 @@ export default {
 },
 	"o3-spacing-2xs": {
 		"shortName": "2xs",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16px",
 		"type": "dimension",
 		"attributes": {
@@ -2293,7 +2293,7 @@ export default {
 },
 	"o3-spacing-xs": {
 		"shortName": "xs",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20px",
 		"type": "dimension",
 		"attributes": {
@@ -2309,7 +2309,7 @@ export default {
 },
 	"o3-spacing-s": {
 		"shortName": "s",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24px",
 		"type": "dimension",
 		"attributes": {
@@ -2325,7 +2325,7 @@ export default {
 },
 	"o3-spacing-m": {
 		"shortName": "m",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32px",
 		"type": "dimension",
 		"attributes": {
@@ -2341,7 +2341,7 @@ export default {
 },
 	"o3-spacing-l": {
 		"shortName": "l",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40px",
 		"type": "dimension",
 		"attributes": {
@@ -2357,7 +2357,7 @@ export default {
 },
 	"o3-spacing-xl": {
 		"shortName": "xl",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48px",
 		"type": "dimension",
 		"attributes": {
@@ -2373,7 +2373,7 @@ export default {
 },
 	"o3-spacing-2xl": {
 		"shortName": "2xl",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64px",
 		"type": "dimension",
 		"attributes": {
@@ -2389,7 +2389,7 @@ export default {
 },
 	"o3-spacing-3xl": {
 		"shortName": "3xl",
-		"value": "5rem",
+		"value": "80px",
 		"originalValue": "80px",
 		"type": "dimension",
 		"attributes": {
@@ -2405,7 +2405,7 @@ export default {
 },
 	"o3-spacing-4xl": {
 		"shortName": "4xl",
-		"value": "6rem",
+		"value": "96px",
 		"originalValue": "96px",
 		"type": "dimension",
 		"attributes": {
@@ -2459,7 +2459,7 @@ export default {
 },
 	"o3-type-display-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.size.7}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2478,7 +2478,7 @@ export default {
 },
 	"o3-type-display-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight.7}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2535,7 +2535,7 @@ export default {
 },
 	"o3-type-display-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2554,7 +2554,7 @@ export default {
 },
 	"o3-type-display-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2611,7 +2611,7 @@ export default {
 },
 	"o3-type-display-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2630,7 +2630,7 @@ export default {
 },
 	"o3-type-display-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2687,7 +2687,7 @@ export default {
 },
 	"o3-type-headline-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2706,7 +2706,7 @@ export default {
 },
 	"o3-type-headline-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2763,7 +2763,7 @@ export default {
 },
 	"o3-type-headline-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2782,7 +2782,7 @@ export default {
 },
 	"o3-type-headline-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2839,7 +2839,7 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2858,7 +2858,7 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight.3}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2915,7 +2915,7 @@ export default {
 },
 	"o3-type-title-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.size-metric2.4}",
 		"type": "dimension",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2934,7 +2934,7 @@ export default {
 },
 	"o3-type-title-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2991,7 +2991,7 @@ export default {
 },
 	"o3-type-title-md-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -3010,7 +3010,7 @@ export default {
 },
 	"o3-type-title-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -3067,7 +3067,7 @@ export default {
 },
 	"o3-type-title-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -3086,7 +3086,7 @@ export default {
 },
 	"o3-type-title-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -3143,7 +3143,7 @@ export default {
 },
 	"o3-type-body-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "{o3.font.size-metric2.1}",
 		"type": "dimension",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -3162,7 +3162,7 @@ export default {
 },
 	"o3-type-body-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.1}",
 		"type": "number",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -3219,7 +3219,7 @@ export default {
 },
 	"o3-type-body-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3238,7 +3238,7 @@ export default {
 },
 	"o3-type-body-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3295,7 +3295,7 @@ export default {
 },
 	"o3-type-body-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3314,7 +3314,7 @@ export default {
 },
 	"o3-type-body-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3371,7 +3371,7 @@ export default {
 },
 	"o3-type-detail-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3390,7 +3390,7 @@ export default {
 },
 	"o3-type-detail-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3447,7 +3447,7 @@ export default {
 },
 	"o3-type-label-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3466,7 +3466,7 @@ export default {
 },
 	"o3-type-label-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3542,7 +3542,7 @@ export default {
 },
 	"o3-type-body-content-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3561,7 +3561,7 @@ export default {
 },
 	"o3-type-body-content-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3618,7 +3618,7 @@ export default {
 },
 	"o3-type-body-content-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3637,7 +3637,7 @@ export default {
 },
 	"o3-type-body-content-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3694,7 +3694,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3713,7 +3713,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3895,7 +3895,7 @@ export default {
 },
 	"o3-font-lineheight-0": {
 		"shortName": "0",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3913,7 +3913,7 @@ export default {
 },
 	"o3-font-lineheight-1": {
 		"shortName": "1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3931,7 +3931,7 @@ export default {
 },
 	"o3-font-lineheight-2": {
 		"shortName": "2",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -3949,7 +3949,7 @@ export default {
 },
 	"o3-font-lineheight-3": {
 		"shortName": "3",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -3967,7 +3967,7 @@ export default {
 },
 	"o3-font-lineheight-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3985,7 +3985,7 @@ export default {
 },
 	"o3-font-lineheight-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -4003,7 +4003,7 @@ export default {
 },
 	"o3-font-lineheight-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -4021,7 +4021,7 @@ export default {
 },
 	"o3-font-lineheight-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -4039,7 +4039,7 @@ export default {
 },
 	"o3-font-lineheight-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -4057,7 +4057,7 @@ export default {
 },
 	"o3-font-lineheight-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -4075,7 +4075,7 @@ export default {
 },
 	"o3-font-lineheight-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -4093,7 +4093,7 @@ export default {
 },
 	"o3-font-lineheight-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -4111,7 +4111,7 @@ export default {
 },
 	"o3-font-lineheight-negative-1": {
 		"shortName": "negative-1",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -4129,7 +4129,7 @@ export default {
 },
 	"o3-font-size-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -4147,7 +4147,7 @@ export default {
 },
 	"o3-font-size-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -4165,7 +4165,7 @@ export default {
 },
 	"o3-font-size-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -4183,7 +4183,7 @@ export default {
 },
 	"o3-font-size-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -4201,7 +4201,7 @@ export default {
 },
 	"o3-font-size-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -4219,7 +4219,7 @@ export default {
 },
 	"o3-font-size-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -4237,7 +4237,7 @@ export default {
 },
 	"o3-font-size-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -4255,7 +4255,7 @@ export default {
 },
 	"o3-font-size-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -4273,7 +4273,7 @@ export default {
 },
 	"o3-font-size-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "fontSize",
 		"attributes": {
@@ -4291,7 +4291,7 @@ export default {
 },
 	"o3-font-size-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -4309,7 +4309,7 @@ export default {
 },
 	"o3-font-size-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "fontSize",
 		"attributes": {
@@ -4327,7 +4327,7 @@ export default {
 },
 	"o3-font-size-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -4345,7 +4345,7 @@ export default {
 },
 	"o3-font-size-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -4363,7 +4363,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-0": {
 		"shortName": "0",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -4381,7 +4381,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-1": {
 		"shortName": "1",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -4399,7 +4399,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-2": {
 		"shortName": "2",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -4417,7 +4417,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-3": {
 		"shortName": "3",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -4435,7 +4435,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -4453,7 +4453,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-5": {
 		"shortName": "5",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -4471,7 +4471,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-6": {
 		"shortName": "6",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -4489,7 +4489,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-7": {
 		"shortName": "7",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -4507,7 +4507,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-8": {
 		"shortName": "8",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -4525,7 +4525,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-9": {
 		"shortName": "9",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -4543,7 +4543,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -4561,7 +4561,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -4579,7 +4579,7 @@ export default {
 },
 	"o3-font-size-metric2-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -4597,7 +4597,7 @@ export default {
 },
 	"o3-font-size-metric2-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -4615,7 +4615,7 @@ export default {
 },
 	"o3-font-size-metric2-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -4633,7 +4633,7 @@ export default {
 },
 	"o3-font-size-metric2-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -4651,7 +4651,7 @@ export default {
 },
 	"o3-font-size-metric2-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -4669,7 +4669,7 @@ export default {
 },
 	"o3-font-size-metric2-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -4687,7 +4687,7 @@ export default {
 },
 	"o3-font-size-metric2-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -4705,7 +4705,7 @@ export default {
 },
 	"o3-font-size-metric2-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -4723,7 +4723,7 @@ export default {
 },
 	"o3-font-size-metric2-8": {
 		"shortName": "8",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64",
 		"type": "fontSize",
 		"attributes": {
@@ -4741,7 +4741,7 @@ export default {
 },
 	"o3-font-size-metric2-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -4759,7 +4759,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -4777,7 +4777,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -5002,7 +5002,7 @@ export default {
 },
 	"o3-border-radius-1": {
 		"shortName": "1",
-		"value": "0.125rem",
+		"value": "2px",
 		"originalValue": "2",
 		"type": "dimension",
 		"description": "for default radius on interactive elements",
@@ -5019,7 +5019,7 @@ export default {
 },
 	"o3-border-radius-2": {
 		"shortName": "2",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4",
 		"type": "dimension",
 		"description": "for the outer radius of interactive elements that have both inner and outer boundaries as in box radio button ",

--- a/libraries/o3-tooling-token/build/internal/_variables.js
+++ b/libraries/o3-tooling-token/build/internal/_variables.js
@@ -1362,7 +1362,7 @@ export default {
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4px",
 		"type": "dimension",
 		"attributes": {
@@ -1378,7 +1378,7 @@ export default {
 },
 	"o3-spacing-4xs": {
 		"shortName": "4xs",
-		"value": "0.5rem",
+		"value": "8px",
 		"originalValue": "8px",
 		"type": "dimension",
 		"attributes": {
@@ -1394,7 +1394,7 @@ export default {
 },
 	"o3-spacing-3xs": {
 		"shortName": "3xs",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12px",
 		"type": "dimension",
 		"attributes": {
@@ -1410,7 +1410,7 @@ export default {
 },
 	"o3-spacing-2xs": {
 		"shortName": "2xs",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16px",
 		"type": "dimension",
 		"attributes": {
@@ -1426,7 +1426,7 @@ export default {
 },
 	"o3-spacing-xs": {
 		"shortName": "xs",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20px",
 		"type": "dimension",
 		"attributes": {
@@ -1442,7 +1442,7 @@ export default {
 },
 	"o3-spacing-s": {
 		"shortName": "s",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24px",
 		"type": "dimension",
 		"attributes": {
@@ -1458,7 +1458,7 @@ export default {
 },
 	"o3-spacing-m": {
 		"shortName": "m",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32px",
 		"type": "dimension",
 		"attributes": {
@@ -1474,7 +1474,7 @@ export default {
 },
 	"o3-spacing-l": {
 		"shortName": "l",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40px",
 		"type": "dimension",
 		"attributes": {
@@ -1490,7 +1490,7 @@ export default {
 },
 	"o3-spacing-xl": {
 		"shortName": "xl",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48px",
 		"type": "dimension",
 		"attributes": {
@@ -1506,7 +1506,7 @@ export default {
 },
 	"o3-spacing-2xl": {
 		"shortName": "2xl",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64px",
 		"type": "dimension",
 		"attributes": {
@@ -1522,7 +1522,7 @@ export default {
 },
 	"o3-spacing-3xl": {
 		"shortName": "3xl",
-		"value": "5rem",
+		"value": "80px",
 		"originalValue": "80px",
 		"type": "dimension",
 		"attributes": {
@@ -1538,7 +1538,7 @@ export default {
 },
 	"o3-spacing-4xl": {
 		"shortName": "4xl",
-		"value": "6rem",
+		"value": "96px",
 		"originalValue": "96px",
 		"type": "dimension",
 		"attributes": {
@@ -1592,7 +1592,7 @@ export default {
 },
 	"o3-type-display-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.size.7}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1611,7 +1611,7 @@ export default {
 },
 	"o3-type-display-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight.7}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1668,7 +1668,7 @@ export default {
 },
 	"o3-type-display-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1687,7 +1687,7 @@ export default {
 },
 	"o3-type-display-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1744,7 +1744,7 @@ export default {
 },
 	"o3-type-display-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1763,7 +1763,7 @@ export default {
 },
 	"o3-type-display-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1820,7 +1820,7 @@ export default {
 },
 	"o3-type-title-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.size-metric2.4}",
 		"type": "dimension",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -1839,7 +1839,7 @@ export default {
 },
 	"o3-type-title-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -1896,7 +1896,7 @@ export default {
 },
 	"o3-type-title-md-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -1915,7 +1915,7 @@ export default {
 },
 	"o3-type-title-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -1972,7 +1972,7 @@ export default {
 },
 	"o3-type-title-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -1991,7 +1991,7 @@ export default {
 },
 	"o3-type-title-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -2048,7 +2048,7 @@ export default {
 },
 	"o3-type-body-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "{o3.font.size-metric2.1}",
 		"type": "dimension",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -2067,7 +2067,7 @@ export default {
 },
 	"o3-type-body-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.1}",
 		"type": "number",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -2124,7 +2124,7 @@ export default {
 },
 	"o3-type-body-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -2143,7 +2143,7 @@ export default {
 },
 	"o3-type-body-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -2200,7 +2200,7 @@ export default {
 },
 	"o3-type-body-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -2219,7 +2219,7 @@ export default {
 },
 	"o3-type-body-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -2276,7 +2276,7 @@ export default {
 },
 	"o3-type-detail-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -2295,7 +2295,7 @@ export default {
 },
 	"o3-type-detail-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -2352,7 +2352,7 @@ export default {
 },
 	"o3-type-label-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -2371,7 +2371,7 @@ export default {
 },
 	"o3-type-label-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -2553,7 +2553,7 @@ export default {
 },
 	"o3-font-lineheight-0": {
 		"shortName": "0",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -2571,7 +2571,7 @@ export default {
 },
 	"o3-font-lineheight-1": {
 		"shortName": "1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -2589,7 +2589,7 @@ export default {
 },
 	"o3-font-lineheight-2": {
 		"shortName": "2",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -2607,7 +2607,7 @@ export default {
 },
 	"o3-font-lineheight-3": {
 		"shortName": "3",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -2625,7 +2625,7 @@ export default {
 },
 	"o3-font-lineheight-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -2643,7 +2643,7 @@ export default {
 },
 	"o3-font-lineheight-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -2661,7 +2661,7 @@ export default {
 },
 	"o3-font-lineheight-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -2679,7 +2679,7 @@ export default {
 },
 	"o3-font-lineheight-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -2697,7 +2697,7 @@ export default {
 },
 	"o3-font-lineheight-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -2715,7 +2715,7 @@ export default {
 },
 	"o3-font-lineheight-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -2733,7 +2733,7 @@ export default {
 },
 	"o3-font-lineheight-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -2751,7 +2751,7 @@ export default {
 },
 	"o3-font-lineheight-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -2769,7 +2769,7 @@ export default {
 },
 	"o3-font-lineheight-negative-1": {
 		"shortName": "negative-1",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -2787,7 +2787,7 @@ export default {
 },
 	"o3-font-size-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -2805,7 +2805,7 @@ export default {
 },
 	"o3-font-size-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -2823,7 +2823,7 @@ export default {
 },
 	"o3-font-size-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -2841,7 +2841,7 @@ export default {
 },
 	"o3-font-size-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -2859,7 +2859,7 @@ export default {
 },
 	"o3-font-size-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -2877,7 +2877,7 @@ export default {
 },
 	"o3-font-size-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -2895,7 +2895,7 @@ export default {
 },
 	"o3-font-size-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -2913,7 +2913,7 @@ export default {
 },
 	"o3-font-size-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -2931,7 +2931,7 @@ export default {
 },
 	"o3-font-size-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "fontSize",
 		"attributes": {
@@ -2949,7 +2949,7 @@ export default {
 },
 	"o3-font-size-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -2967,7 +2967,7 @@ export default {
 },
 	"o3-font-size-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "fontSize",
 		"attributes": {
@@ -2985,7 +2985,7 @@ export default {
 },
 	"o3-font-size-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -3003,7 +3003,7 @@ export default {
 },
 	"o3-font-size-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -3021,7 +3021,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-0": {
 		"shortName": "0",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -3039,7 +3039,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-1": {
 		"shortName": "1",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -3057,7 +3057,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-2": {
 		"shortName": "2",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -3075,7 +3075,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-3": {
 		"shortName": "3",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3093,7 +3093,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3111,7 +3111,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-5": {
 		"shortName": "5",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -3129,7 +3129,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-6": {
 		"shortName": "6",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -3147,7 +3147,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-7": {
 		"shortName": "7",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -3165,7 +3165,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-8": {
 		"shortName": "8",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -3183,7 +3183,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-9": {
 		"shortName": "9",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -3201,7 +3201,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -3219,7 +3219,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3237,7 +3237,7 @@ export default {
 },
 	"o3-font-size-metric2-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -3255,7 +3255,7 @@ export default {
 },
 	"o3-font-size-metric2-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -3273,7 +3273,7 @@ export default {
 },
 	"o3-font-size-metric2-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -3291,7 +3291,7 @@ export default {
 },
 	"o3-font-size-metric2-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -3309,7 +3309,7 @@ export default {
 },
 	"o3-font-size-metric2-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -3327,7 +3327,7 @@ export default {
 },
 	"o3-font-size-metric2-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -3345,7 +3345,7 @@ export default {
 },
 	"o3-font-size-metric2-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -3363,7 +3363,7 @@ export default {
 },
 	"o3-font-size-metric2-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -3381,7 +3381,7 @@ export default {
 },
 	"o3-font-size-metric2-8": {
 		"shortName": "8",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64",
 		"type": "fontSize",
 		"attributes": {
@@ -3399,7 +3399,7 @@ export default {
 },
 	"o3-font-size-metric2-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -3417,7 +3417,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -3435,7 +3435,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -3660,7 +3660,7 @@ export default {
 },
 	"o3-border-radius-1": {
 		"shortName": "1",
-		"value": "0.125rem",
+		"value": "2px",
 		"originalValue": "2",
 		"type": "dimension",
 		"description": "for default radius on interactive elements",
@@ -3677,7 +3677,7 @@ export default {
 },
 	"o3-border-radius-2": {
 		"shortName": "2",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4",
 		"type": "dimension",
 		"description": "for the outer radius of interactive elements that have both inner and outer boundaries as in box radio button ",

--- a/libraries/o3-tooling-token/build/sustainable-views/_variables.js
+++ b/libraries/o3-tooling-token/build/sustainable-views/_variables.js
@@ -1,7 +1,7 @@
 export default {
 	"o3-spacing-5xs": {
 		"shortName": "5xs",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4px",
 		"type": "dimension",
 		"attributes": {
@@ -17,7 +17,7 @@ export default {
 },
 	"o3-spacing-4xs": {
 		"shortName": "4xs",
-		"value": "0.5rem",
+		"value": "8px",
 		"originalValue": "8px",
 		"type": "dimension",
 		"attributes": {
@@ -33,7 +33,7 @@ export default {
 },
 	"o3-spacing-3xs": {
 		"shortName": "3xs",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12px",
 		"type": "dimension",
 		"attributes": {
@@ -49,7 +49,7 @@ export default {
 },
 	"o3-spacing-2xs": {
 		"shortName": "2xs",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16px",
 		"type": "dimension",
 		"attributes": {
@@ -65,7 +65,7 @@ export default {
 },
 	"o3-spacing-xs": {
 		"shortName": "xs",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20px",
 		"type": "dimension",
 		"attributes": {
@@ -81,7 +81,7 @@ export default {
 },
 	"o3-spacing-s": {
 		"shortName": "s",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24px",
 		"type": "dimension",
 		"attributes": {
@@ -97,7 +97,7 @@ export default {
 },
 	"o3-spacing-m": {
 		"shortName": "m",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32px",
 		"type": "dimension",
 		"attributes": {
@@ -113,7 +113,7 @@ export default {
 },
 	"o3-spacing-l": {
 		"shortName": "l",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40px",
 		"type": "dimension",
 		"attributes": {
@@ -129,7 +129,7 @@ export default {
 },
 	"o3-spacing-xl": {
 		"shortName": "xl",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48px",
 		"type": "dimension",
 		"attributes": {
@@ -145,7 +145,7 @@ export default {
 },
 	"o3-spacing-2xl": {
 		"shortName": "2xl",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64px",
 		"type": "dimension",
 		"attributes": {
@@ -161,7 +161,7 @@ export default {
 },
 	"o3-spacing-3xl": {
 		"shortName": "3xl",
-		"value": "5rem",
+		"value": "80px",
 		"originalValue": "80px",
 		"type": "dimension",
 		"attributes": {
@@ -177,7 +177,7 @@ export default {
 },
 	"o3-spacing-4xl": {
 		"shortName": "4xl",
-		"value": "6rem",
+		"value": "96px",
 		"originalValue": "96px",
 		"type": "dimension",
 		"attributes": {
@@ -1024,7 +1024,7 @@ export default {
 },
 	"o3-type-display-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.size-metric2.7}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1043,7 +1043,7 @@ export default {
 },
 	"o3-type-display-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "{o3.font.lineheight-metric2.7}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1100,7 +1100,7 @@ export default {
 },
 	"o3-type-display-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size-metric2.6}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1119,7 +1119,7 @@ export default {
 },
 	"o3-type-display-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight-metric2.6}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1176,7 +1176,7 @@ export default {
 },
 	"o3-type-display-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size-metric2.5}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1195,7 +1195,7 @@ export default {
 },
 	"o3-type-display-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight-metric2.5}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -1252,7 +1252,7 @@ export default {
 },
 	"o3-type-headline-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size-metric2.6}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -1271,7 +1271,7 @@ export default {
 },
 	"o3-type-headline-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight-metric2.6}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -1328,7 +1328,7 @@ export default {
 },
 	"o3-type-headline-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size-metric2.5}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -1347,7 +1347,7 @@ export default {
 },
 	"o3-type-headline-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight-metric2.5}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -1404,7 +1404,7 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -1423,7 +1423,7 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -1480,7 +1480,7 @@ export default {
 },
 	"o3-type-title-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.size-metric2.4}",
 		"type": "dimension",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -1499,7 +1499,7 @@ export default {
 },
 	"o3-type-title-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -1556,7 +1556,7 @@ export default {
 },
 	"o3-type-title-md-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -1575,7 +1575,7 @@ export default {
 },
 	"o3-type-title-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -1632,7 +1632,7 @@ export default {
 },
 	"o3-type-title-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -1651,7 +1651,7 @@ export default {
 },
 	"o3-type-title-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -1708,7 +1708,7 @@ export default {
 },
 	"o3-type-body-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "{o3.font.size-metric2.1}",
 		"type": "dimension",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -1727,7 +1727,7 @@ export default {
 },
 	"o3-type-body-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.1}",
 		"type": "number",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -1784,7 +1784,7 @@ export default {
 },
 	"o3-type-body-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -1803,7 +1803,7 @@ export default {
 },
 	"o3-type-body-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -1860,7 +1860,7 @@ export default {
 },
 	"o3-type-body-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -1879,7 +1879,7 @@ export default {
 },
 	"o3-type-body-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -1936,7 +1936,7 @@ export default {
 },
 	"o3-type-detail-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -1955,7 +1955,7 @@ export default {
 },
 	"o3-type-detail-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -2012,7 +2012,7 @@ export default {
 },
 	"o3-type-label-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -2031,7 +2031,7 @@ export default {
 },
 	"o3-type-label-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -2107,7 +2107,7 @@ export default {
 },
 	"o3-type-body-content-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2126,7 +2126,7 @@ export default {
 },
 	"o3-type-body-content-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2164,7 +2164,7 @@ export default {
 },
 	"o3-type-body-content-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2183,7 +2183,7 @@ export default {
 },
 	"o3-type-body-content-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2259,7 +2259,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2278,7 +2278,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -2459,7 +2459,7 @@ export default {
 },
 	"o3-font-lineheight-0": {
 		"shortName": "0",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -2477,7 +2477,7 @@ export default {
 },
 	"o3-font-lineheight-1": {
 		"shortName": "1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -2495,7 +2495,7 @@ export default {
 },
 	"o3-font-lineheight-2": {
 		"shortName": "2",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -2513,7 +2513,7 @@ export default {
 },
 	"o3-font-lineheight-3": {
 		"shortName": "3",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -2531,7 +2531,7 @@ export default {
 },
 	"o3-font-lineheight-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -2549,7 +2549,7 @@ export default {
 },
 	"o3-font-lineheight-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -2567,7 +2567,7 @@ export default {
 },
 	"o3-font-lineheight-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -2585,7 +2585,7 @@ export default {
 },
 	"o3-font-lineheight-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -2603,7 +2603,7 @@ export default {
 },
 	"o3-font-lineheight-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -2621,7 +2621,7 @@ export default {
 },
 	"o3-font-lineheight-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -2639,7 +2639,7 @@ export default {
 },
 	"o3-font-lineheight-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -2657,7 +2657,7 @@ export default {
 },
 	"o3-font-lineheight-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -2675,7 +2675,7 @@ export default {
 },
 	"o3-font-lineheight-negative-1": {
 		"shortName": "negative-1",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -2693,7 +2693,7 @@ export default {
 },
 	"o3-font-size-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -2711,7 +2711,7 @@ export default {
 },
 	"o3-font-size-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -2729,7 +2729,7 @@ export default {
 },
 	"o3-font-size-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -2747,7 +2747,7 @@ export default {
 },
 	"o3-font-size-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -2765,7 +2765,7 @@ export default {
 },
 	"o3-font-size-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -2783,7 +2783,7 @@ export default {
 },
 	"o3-font-size-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -2801,7 +2801,7 @@ export default {
 },
 	"o3-font-size-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -2819,7 +2819,7 @@ export default {
 },
 	"o3-font-size-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -2837,7 +2837,7 @@ export default {
 },
 	"o3-font-size-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "fontSize",
 		"attributes": {
@@ -2855,7 +2855,7 @@ export default {
 },
 	"o3-font-size-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -2873,7 +2873,7 @@ export default {
 },
 	"o3-font-size-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "fontSize",
 		"attributes": {
@@ -2891,7 +2891,7 @@ export default {
 },
 	"o3-font-size-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -2909,7 +2909,7 @@ export default {
 },
 	"o3-font-size-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -2927,7 +2927,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-0": {
 		"shortName": "0",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -2945,7 +2945,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-1": {
 		"shortName": "1",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -2963,7 +2963,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-2": {
 		"shortName": "2",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -2981,7 +2981,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-3": {
 		"shortName": "3",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -2999,7 +2999,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -3017,7 +3017,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-5": {
 		"shortName": "5",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -3035,7 +3035,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-6": {
 		"shortName": "6",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -3053,7 +3053,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-7": {
 		"shortName": "7",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -3071,7 +3071,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-8": {
 		"shortName": "8",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -3089,7 +3089,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-9": {
 		"shortName": "9",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -3107,7 +3107,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -3125,7 +3125,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -3143,7 +3143,7 @@ export default {
 },
 	"o3-font-size-metric2-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -3161,7 +3161,7 @@ export default {
 },
 	"o3-font-size-metric2-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -3179,7 +3179,7 @@ export default {
 },
 	"o3-font-size-metric2-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -3197,7 +3197,7 @@ export default {
 },
 	"o3-font-size-metric2-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -3215,7 +3215,7 @@ export default {
 },
 	"o3-font-size-metric2-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -3233,7 +3233,7 @@ export default {
 },
 	"o3-font-size-metric2-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -3251,7 +3251,7 @@ export default {
 },
 	"o3-font-size-metric2-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -3269,7 +3269,7 @@ export default {
 },
 	"o3-font-size-metric2-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -3287,7 +3287,7 @@ export default {
 },
 	"o3-font-size-metric2-8": {
 		"shortName": "8",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64",
 		"type": "fontSize",
 		"attributes": {
@@ -3305,7 +3305,7 @@ export default {
 },
 	"o3-font-size-metric2-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -3323,7 +3323,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -3341,7 +3341,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -3566,7 +3566,7 @@ export default {
 },
 	"o3-border-radius-1": {
 		"shortName": "1",
-		"value": "0.125rem",
+		"value": "2px",
 		"originalValue": "2",
 		"type": "dimension",
 		"description": "for default radius on interactive elements",
@@ -3583,7 +3583,7 @@ export default {
 },
 	"o3-border-radius-2": {
 		"shortName": "2",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4",
 		"type": "dimension",
 		"description": "for the outer radius of interactive elements that have both inner and outer boundaries as in box radio button ",

--- a/libraries/o3-tooling-token/build/whitelabel/_variables.js
+++ b/libraries/o3-tooling-token/build/whitelabel/_variables.js
@@ -145,7 +145,7 @@ export default {
 },
 	"o3-font-lineheight-0": {
 		"shortName": "0",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -163,7 +163,7 @@ export default {
 },
 	"o3-font-lineheight-1": {
 		"shortName": "1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -181,7 +181,7 @@ export default {
 },
 	"o3-font-lineheight-2": {
 		"shortName": "2",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -199,7 +199,7 @@ export default {
 },
 	"o3-font-lineheight-3": {
 		"shortName": "3",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -217,7 +217,7 @@ export default {
 },
 	"o3-font-lineheight-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -235,7 +235,7 @@ export default {
 },
 	"o3-font-lineheight-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -253,7 +253,7 @@ export default {
 },
 	"o3-font-lineheight-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -271,7 +271,7 @@ export default {
 },
 	"o3-font-lineheight-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -289,7 +289,7 @@ export default {
 },
 	"o3-font-lineheight-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -307,7 +307,7 @@ export default {
 },
 	"o3-font-lineheight-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -325,7 +325,7 @@ export default {
 },
 	"o3-font-lineheight-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -343,7 +343,7 @@ export default {
 },
 	"o3-font-lineheight-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -361,7 +361,7 @@ export default {
 },
 	"o3-font-lineheight-negative-1": {
 		"shortName": "negative-1",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -379,7 +379,7 @@ export default {
 },
 	"o3-font-size-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -397,7 +397,7 @@ export default {
 },
 	"o3-font-size-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -415,7 +415,7 @@ export default {
 },
 	"o3-font-size-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -433,7 +433,7 @@ export default {
 },
 	"o3-font-size-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -451,7 +451,7 @@ export default {
 },
 	"o3-font-size-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -469,7 +469,7 @@ export default {
 },
 	"o3-font-size-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -487,7 +487,7 @@ export default {
 },
 	"o3-font-size-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -505,7 +505,7 @@ export default {
 },
 	"o3-font-size-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -523,7 +523,7 @@ export default {
 },
 	"o3-font-size-8": {
 		"shortName": "8",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "fontSize",
 		"attributes": {
@@ -541,7 +541,7 @@ export default {
 },
 	"o3-font-size-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -559,7 +559,7 @@ export default {
 },
 	"o3-font-size-10": {
 		"shortName": "10",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "fontSize",
 		"attributes": {
@@ -577,7 +577,7 @@ export default {
 },
 	"o3-font-size-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -595,7 +595,7 @@ export default {
 },
 	"o3-font-size-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -613,7 +613,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-0": {
 		"shortName": "0",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -631,7 +631,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-1": {
 		"shortName": "1",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "lineHeights",
 		"attributes": {
@@ -649,7 +649,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-2": {
 		"shortName": "2",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "lineHeights",
 		"attributes": {
@@ -667,7 +667,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-3": {
 		"shortName": "3",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -685,7 +685,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-4": {
 		"shortName": "4",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "lineHeights",
 		"attributes": {
@@ -703,7 +703,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-5": {
 		"shortName": "5",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "lineHeights",
 		"attributes": {
@@ -721,7 +721,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-6": {
 		"shortName": "6",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "lineHeights",
 		"attributes": {
@@ -739,7 +739,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-7": {
 		"shortName": "7",
-		"value": "3.5rem",
+		"value": "56px",
 		"originalValue": "56",
 		"type": "lineHeights",
 		"attributes": {
@@ -757,7 +757,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-8": {
 		"shortName": "8",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "lineHeights",
 		"attributes": {
@@ -775,7 +775,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-9": {
 		"shortName": "9",
-		"value": "5.25rem",
+		"value": "84px",
 		"originalValue": "84",
 		"type": "lineHeights",
 		"attributes": {
@@ -793,7 +793,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "lineHeights",
 		"attributes": {
@@ -811,7 +811,7 @@ export default {
 },
 	"o3-font-lineheight-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "lineHeights",
 		"attributes": {
@@ -829,7 +829,7 @@ export default {
 },
 	"o3-font-size-metric2-0": {
 		"shortName": "0",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16",
 		"type": "fontSize",
 		"attributes": {
@@ -847,7 +847,7 @@ export default {
 },
 	"o3-font-size-metric2-1": {
 		"shortName": "1",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "18",
 		"type": "fontSize",
 		"attributes": {
@@ -865,7 +865,7 @@ export default {
 },
 	"o3-font-size-metric2-2": {
 		"shortName": "2",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20",
 		"type": "fontSize",
 		"attributes": {
@@ -883,7 +883,7 @@ export default {
 },
 	"o3-font-size-metric2-3": {
 		"shortName": "3",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24",
 		"type": "fontSize",
 		"attributes": {
@@ -901,7 +901,7 @@ export default {
 },
 	"o3-font-size-metric2-4": {
 		"shortName": "4",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "28",
 		"type": "fontSize",
 		"attributes": {
@@ -919,7 +919,7 @@ export default {
 },
 	"o3-font-size-metric2-5": {
 		"shortName": "5",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32",
 		"type": "fontSize",
 		"attributes": {
@@ -937,7 +937,7 @@ export default {
 },
 	"o3-font-size-metric2-6": {
 		"shortName": "6",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40",
 		"type": "fontSize",
 		"attributes": {
@@ -955,7 +955,7 @@ export default {
 },
 	"o3-font-size-metric2-7": {
 		"shortName": "7",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48",
 		"type": "fontSize",
 		"attributes": {
@@ -973,7 +973,7 @@ export default {
 },
 	"o3-font-size-metric2-8": {
 		"shortName": "8",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64",
 		"type": "fontSize",
 		"attributes": {
@@ -991,7 +991,7 @@ export default {
 },
 	"o3-font-size-metric2-9": {
 		"shortName": "9",
-		"value": "4.5rem",
+		"value": "72px",
 		"originalValue": "72",
 		"type": "fontSize",
 		"attributes": {
@@ -1009,7 +1009,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-2": {
 		"shortName": "negative-2",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12",
 		"type": "fontSize",
 		"attributes": {
@@ -1027,7 +1027,7 @@ export default {
 },
 	"o3-font-size-metric2-negative-1": {
 		"shortName": "negative-1",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "14",
 		"type": "fontSize",
 		"attributes": {
@@ -2068,7 +2068,7 @@ export default {
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4px",
 		"type": "dimension",
 		"attributes": {
@@ -2084,7 +2084,7 @@ export default {
 },
 	"o3-spacing-4xs": {
 		"shortName": "4xs",
-		"value": "0.5rem",
+		"value": "8px",
 		"originalValue": "8px",
 		"type": "dimension",
 		"attributes": {
@@ -2100,7 +2100,7 @@ export default {
 },
 	"o3-spacing-3xs": {
 		"shortName": "3xs",
-		"value": "0.75rem",
+		"value": "12px",
 		"originalValue": "12px",
 		"type": "dimension",
 		"attributes": {
@@ -2116,7 +2116,7 @@ export default {
 },
 	"o3-spacing-2xs": {
 		"shortName": "2xs",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "16px",
 		"type": "dimension",
 		"attributes": {
@@ -2132,7 +2132,7 @@ export default {
 },
 	"o3-spacing-xs": {
 		"shortName": "xs",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "20px",
 		"type": "dimension",
 		"attributes": {
@@ -2148,7 +2148,7 @@ export default {
 },
 	"o3-spacing-s": {
 		"shortName": "s",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "24px",
 		"type": "dimension",
 		"attributes": {
@@ -2164,7 +2164,7 @@ export default {
 },
 	"o3-spacing-m": {
 		"shortName": "m",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "32px",
 		"type": "dimension",
 		"attributes": {
@@ -2180,7 +2180,7 @@ export default {
 },
 	"o3-spacing-l": {
 		"shortName": "l",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "40px",
 		"type": "dimension",
 		"attributes": {
@@ -2196,7 +2196,7 @@ export default {
 },
 	"o3-spacing-xl": {
 		"shortName": "xl",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "48px",
 		"type": "dimension",
 		"attributes": {
@@ -2212,7 +2212,7 @@ export default {
 },
 	"o3-spacing-2xl": {
 		"shortName": "2xl",
-		"value": "4rem",
+		"value": "64px",
 		"originalValue": "64px",
 		"type": "dimension",
 		"attributes": {
@@ -2228,7 +2228,7 @@ export default {
 },
 	"o3-spacing-3xl": {
 		"shortName": "3xl",
-		"value": "5rem",
+		"value": "80px",
 		"originalValue": "80px",
 		"type": "dimension",
 		"attributes": {
@@ -2244,7 +2244,7 @@ export default {
 },
 	"o3-spacing-4xl": {
 		"shortName": "4xl",
-		"value": "6rem",
+		"value": "96px",
 		"originalValue": "96px",
 		"type": "dimension",
 		"attributes": {
@@ -2298,7 +2298,7 @@ export default {
 },
 	"o3-type-display-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.size.7}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2317,7 +2317,7 @@ export default {
 },
 	"o3-type-display-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "3rem",
+		"value": "48px",
 		"originalValue": "{o3.font.lineheight.7}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2374,7 +2374,7 @@ export default {
 },
 	"o3-type-display-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2393,7 +2393,7 @@ export default {
 },
 	"o3-type-display-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2450,7 +2450,7 @@ export default {
 },
 	"o3-type-display-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2469,7 +2469,7 @@ export default {
 },
 	"o3-type-display-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages.",
@@ -2526,7 +2526,7 @@ export default {
 },
 	"o3-type-headline-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.size.6}",
 		"type": "dimension",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2545,7 +2545,7 @@ export default {
 },
 	"o3-type-headline-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2.5rem",
+		"value": "40px",
 		"originalValue": "{o3.font.lineheight.6}",
 		"type": "number",
 		"description": "Use this style for large screens headlines in standard-sized teasers and text only toppers (eg. Opinion and News).",
@@ -2602,7 +2602,7 @@ export default {
 },
 	"o3-type-headline-md-font-size": {
 		"shortName": "fontSize",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.size.5}",
 		"type": "dimension",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2621,7 +2621,7 @@ export default {
 },
 	"o3-type-headline-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.5}",
 		"type": "number",
 		"description": "Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2678,7 +2678,7 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size.3}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2697,7 +2697,7 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight.3}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
@@ -2754,7 +2754,7 @@ export default {
 },
 	"o3-type-title-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.size-metric2.4}",
 		"type": "dimension",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2773,7 +2773,7 @@ export default {
 },
 	"o3-type-title-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.",
@@ -2830,7 +2830,7 @@ export default {
 },
 	"o3-type-title-md-font-size": {
 		"shortName": "fontSize",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.size-metric2.3}",
 		"type": "dimension",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -2849,7 +2849,7 @@ export default {
 },
 	"o3-type-title-md-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight-metric2.3}",
 		"type": "number",
 		"description": "Use this style as H3 or subtitles within the content body to break paragraphs, or for titles of components like forms, tables and cards across all breakpoints.",
@@ -2906,7 +2906,7 @@ export default {
 },
 	"o3-type-title-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.75rem",
+		"value": "28px",
 		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -2925,7 +2925,7 @@ export default {
 },
 	"o3-type-title-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use H6 for subtitles within the content body to break up paragraphs, and H2 for subheadings on stream pages or as subtitles for components such as forms, tables, and cards across all breakpoints.",
@@ -2982,7 +2982,7 @@ export default {
 },
 	"o3-type-body-lg-font-size": {
 		"shortName": "fontSize",
-		"value": "1.125rem",
+		"value": "18px",
 		"originalValue": "{o3.font.size-metric2.1}",
 		"type": "dimension",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -3001,7 +3001,7 @@ export default {
 },
 	"o3-type-body-lg-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.1}",
 		"type": "number",
 		"description": "Use primarily for the stand-first (introductory summary or highlight) in topper component, as larger body text in components, or section description.",
@@ -3058,7 +3058,7 @@ export default {
 },
 	"o3-type-body-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3077,7 +3077,7 @@ export default {
 },
 	"o3-type-body-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for the stand-first in teasers and as the default body copy style across components such as location in the byline.",
@@ -3134,7 +3134,7 @@ export default {
 },
 	"o3-type-body-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1rem",
+		"value": "16px",
 		"originalValue": "{o3.font.size-metric2.0}",
 		"type": "dimension",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3153,7 +3153,7 @@ export default {
 },
 	"o3-type-body-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.5rem",
+		"value": "24px",
 		"originalValue": "{o3.font.lineheight-metric2.0}",
 		"type": "number",
 		"description": "Use this style for bold formatting in body copy or for small interactive elements, such as Topic tags and Author names.",
@@ -3210,7 +3210,7 @@ export default {
 },
 	"o3-type-detail-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3229,7 +3229,7 @@ export default {
 },
 	"o3-type-detail-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for caption in visual assets such as image and video and for small text elements, such as secondary metadata, caveats, or footnotes.",
@@ -3286,7 +3286,7 @@ export default {
 },
 	"o3-type-label-font-size": {
 		"shortName": "fontSize",
-		"value": "0.875rem",
+		"value": "14px",
 		"originalValue": "{o3.font.size-metric2.negative-1}",
 		"type": "dimension",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3305,7 +3305,7 @@ export default {
 },
 	"o3-type-label-line-height": {
 		"shortName": "lineHeight",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.lineheight-metric2.negative-1}",
 		"type": "number",
 		"description": "Use this style for labels such as badges and metadata in teasers and toppers (e.g., \"Live,\" \"Premium,\" or the main timestamp). Avoid using full sentences.",
@@ -3381,7 +3381,7 @@ export default {
 },
 	"o3-type-body-content-base-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3400,7 +3400,7 @@ export default {
 },
 	"o3-type-body-content-base-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3457,7 +3457,7 @@ export default {
 },
 	"o3-type-body-content-highlight-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3476,7 +3476,7 @@ export default {
 },
 	"o3-type-body-content-highlight-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3533,7 +3533,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-font-size": {
 		"shortName": "fontSize",
-		"value": "1.25rem",
+		"value": "20px",
 		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3552,7 +3552,7 @@ export default {
 },
 	"o3-type-body-content-emphasis-line-height": {
 		"shortName": "lineHeight",
-		"value": "2rem",
+		"value": "32px",
 		"originalValue": "{o3.font.lineheight.4}",
 		"type": "number",
 		"description": "Use this style only for the body copy of content pages, such as articles, live news and other content experience page.",
@@ -3590,7 +3590,7 @@ export default {
 },
 	"o3-border-radius-1": {
 		"shortName": "1",
-		"value": "0.125rem",
+		"value": "2px",
 		"originalValue": "2",
 		"type": "dimension",
 		"description": "for default radius on interactive elements",
@@ -3607,7 +3607,7 @@ export default {
 },
 	"o3-border-radius-2": {
 		"shortName": "2",
-		"value": "0.25rem",
+		"value": "4px",
 		"originalValue": "4",
 		"type": "dimension",
 		"description": "for the outer radius of interactive elements that have both inner and outer boundaries as in box radio button ",


### PR DESCRIPTION
## Describe your changes
For our sizing and typography tokens, we want to use pixel values as these are easier understood by our docs users.

This has been achieved by varying the style dictionary config for tooling and production configs.

* Use `size/px` for tooling config in Style Dictionary

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
