### PR TITLE
fix: exclude anchor tags from type color selectors

### DIFF
--- a/components/o3-foundation/src/css/components/typography/usecases.css
+++ b/components/o3-foundation/src/css/components/typography/usecases.css
@@ -132,7 +132,7 @@
 
 /* Default body colours */
 
-:where(
+:where(:not(a)):where(
 		[class^='o3-type-body'],
 		.o3-type-detail,
 		.o3-type-label,
@@ -140,7 +140,8 @@
 		.o3-typography-wrapper > :is(p, figcaption)
 	) {
 	color: var(--o3-color-use-case-body-text);
-	[data-o3-theme='inverse']&,
+
+	[data-o3-theme='inverse'] &,
 	:where([data-o3-theme='inverse']) & {
 		color: var(--o3-color-use-case-body-inverse-text);
 	}
@@ -148,14 +149,14 @@
 
 /* Default heading colours */
 
-:where(
+:where(:not(a)):where(
 		[class^='o3-type-headline'],
 		[class^='o3-type-display'],
-		[class^='o3-type-title'],
-		.o3-typography-wrapper > :where(h1, h2, h3, h4, h5, h6)
+		[class^='o3-type-title']
 	) {
 	color: var(--o3-color-use-case-heading-text);
-	[data-o3-theme=inverse]&,
+
+	[data-o3-theme=inverse] &,
 	:where([data-o3-theme=inverse]) & {
 		color: var(--o3-color-use-case-heading-inverse-text);
 	}
@@ -173,6 +174,7 @@
 	display: inline-block;
 	margin-bottom: -1em;
 }
+
 .o3-typography-wrapper > sup,
 .o3-typography-wrapper > p sup,
 .o3-type-body-base > sup,

--- a/components/o3-foundation/stories/story-templates.tsx
+++ b/components/o3-foundation/stories/story-templates.tsx
@@ -129,6 +129,10 @@ export const WrapperStory = {
 					<a href="#">Link Necessitatibus asperiores</a>
 				</p>
 
+				<a className="o3-type-body-base" href="#">
+					Link by itself.
+				</a>
+
 				<p>
 					Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt
 					aspernatur aut corporis eius. Neque consequuntur commodi consectetur


### PR DESCRIPTION
## Describe your changes

Anchor tags in wrappers need to have an `o3-typography-body-base` class somewhere in the cascade to receive text styles. 

When an anchor tag is outside another typographic tag, such as `p`, it may be necessary to apply `o3-typography-body-base` directly to the anchor tag. This class provides colour which may have precedence over any anchor styles from `o3-typography-wrapper`.

This PR adds additional selectors to typography-base classes so that anchor tags do not receive its colour styles.

## Issue ticket number and link

## Link to Figma designs

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
