### PR TITLE
feat: ci-2617 export auth library for login without comments stream

### DIFF
--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -88,6 +88,21 @@ If you need the count as a value, use the `getCount` method which returns an int
 Comments.getCount("article-id").then(count => console.log(count));
 ```
 
+#### auth
+
+If you just want to log someone into Coral but don't want to render the whole stream, the authorisation step is exported as `auth`
+
+```js
+import { auth } from '@financial-times/o-comments';
+
+export default async ({ useStaging = true }: { useStaging: boolean }) =>
+  auth.fetchJsonWebToken({
+    useStagingEnvironment: useStaging,
+    onlySubscribers: true,
+  });
+
+```
+
 ### Use staging environment
 
 Add the following attribute to the markup to use Coral staging environment:

--- a/components/o-comments/src/js/comments.js
+++ b/components/o-comments/src/js/comments.js
@@ -1,5 +1,6 @@
 import Stream from './stream.js';
 import Count from './count.js';
+import auth from './utils/auth.js';
 
 class Comments {
 	constructor (rootEl, opts) {
@@ -90,3 +91,4 @@ class Comments {
 }
 
 export default Comments;
+export { auth };


### PR DESCRIPTION
## Describe your changes

Export auth so users can be logged into Coral without also rendering the stream (to be used in Live Q&A)

## Issue ticket number and link
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2617

## Link to Figma designs
N/A

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
