### PR TITLE
fix: Add explicit underline to links

### DIFF
--- a/components/o3-foundation/src/css/components/typography/link.css
+++ b/components/o3-foundation/src/css/components/typography/link.css
@@ -3,6 +3,7 @@
 	border-bottom-color: var(--o3-color-use-case-link-underline);
 	text-decoration-color: var(--o3-color-use-case-link-underline);
 	text-decoration-thickness: 2px;
+	text-decoration-line: underline;
 
 	&:focus-visible {
 		color: var(--o3-color-use-case-link-text-focus);


### PR DESCRIPTION
Rather than rely on the browser default.
https://financialtimes.slack.com/archives/C07PT7A1LNB/p1742815968838199?thread_ts=1742472155.845909&cid=C07PT7A1LNB