### PR TITLE
feat: calendar as default icon

### DIFF
--- a/components/o3-button/README.md
+++ b/components/o3-button/README.md
@@ -131,6 +131,7 @@ A limited number of button icons are available. Limiting the number of icons kee
 - search
 - refresh
 - cross
+- calendar
 
 ```html
 <button

--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -499,3 +499,6 @@
 .o3-button-icon.o3-button-icon--refresh::before {
 	--o3-button-icon: var(--o3-icon-refresh);
 }
+.o3-button-icon.o3-button-icon--calendar::before {
+	--o3-button-icon: var(--o3-icon-calendar);
+}

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -17,7 +17,8 @@ export interface ButtonProps {
 		| 'download'
 		| 'search'
 		| 'refresh'
-		| 'cross';
+		| 'cross'
+		| 'calendar';
 	iconOnly?: boolean;
 	visuallyHideDisabled?: boolean;
 	attributes?: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2855,7 +2855,7 @@
 		},
 		"components/o-icons": {
 			"name": "@financial-times/o-icons",
-			"version": "7.8.0",
+			"version": "7.9.0",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3022,7 +3022,7 @@
 		},
 		"components/o-private-foundation": {
 			"name": "@financial-times/o-private-foundation",
-			"version": "1.0.4",
+			"version": "1.2.2",
 			"license": "MIT",
 			"devDependencies": {},
 			"engines": {
@@ -3374,7 +3374,7 @@
 		},
 		"components/o3-button": {
 			"name": "@financial-times/o3-button",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"
@@ -3388,7 +3388,7 @@
 		},
 		"components/o3-editorial-typography": {
 			"name": "@financial-times/o3-editorial-typography",
-			"version": "3.0.2",
+			"version": "3.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"
@@ -3402,7 +3402,7 @@
 		},
 		"components/o3-form": {
 			"name": "@financial-times/o3-form",
-			"version": "0.5.1",
+			"version": "0.5.2",
 			"license": "MIT",
 			"engines": {
 				"npm": ">7"
@@ -3415,7 +3415,7 @@
 		},
 		"components/o3-foundation": {
 			"name": "@financial-times/o3-foundation",
-			"version": "3.0.1",
+			"version": "3.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0"
@@ -3434,7 +3434,7 @@
 		},
 		"components/o3-tooltip": {
 			"name": "@financial-times/o3-tooltip",
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.8"


### PR DESCRIPTION
## Describe your changes
This PR adds the calendar icon as a default icon for buttons

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [CI-2665](https://financialtimes.atlassian.net/browse/CI-2665) | [Figma: Add to calendar](https://www.figma.com/design/m4B9Kn2WtXX5dz0a2pRcWa/Add-to-calendar?node-id=4019-14880&m=dev&t=RzYZ3OpIemvevsCp-1)

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[CI-2665]: https://financialtimes.atlassian.net/browse/CI-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ