### PR TITLE
fix: Ensure o-teaser__timestamp modifiers have higher specificity

### DIFF
--- a/components/o-teaser/src/scss/elements/_timestamp.scss
+++ b/components/o-teaser/src/scss/elements/_timestamp.scss
@@ -26,7 +26,7 @@
 		);
 	}
 
-	.o-teaser__timestamp--new {
+	.o-teaser__timestamp.o-teaser__timestamp--new {
 		@include oLabelsIndicatorContent(
 			$opts: (
 				'block': true,
@@ -35,7 +35,7 @@
 		);
 	}
 
-	.o-teaser__timestamp--updated {
+	.o-teaser__timestamp.o-teaser__timestamp--updated {
 		@include oLabelsIndicatorContent(
 			$opts: (
 				'block': true,
@@ -57,7 +57,7 @@
 		);
 	}
 
-	.o-teaser__timestamp--closed {
+	.o-teaser__timestamp.o-teaser__timestamp--closed {
 		@include oLabelsIndicatorContent(
 			$opts: (
 				'block': true,


### PR DESCRIPTION
Unreliable source order due to use of extends may be at fault