### PR TITLE
docs: use correct o3 editorial typography classes in migration guide

### DIFF
--- a/components/o-editorial-typography/MIGRATION.md
+++ b/components/o-editorial-typography/MIGRATION.md
@@ -15,7 +15,7 @@ e.g. Core brand with inverse theme will have following markup:
 ```html
 
 <div data-o3-brand="core" data-o3-theme="inverse">
-	<h1 class="o3-editorial-typography__headline">Heading</h1>
+	<h1 class="o3-editorial-typography-headline">Heading</h1>
 </div>
 ```
 
@@ -25,7 +25,7 @@ e.g Sustainable Views brand with inverse theme specifically applied on the eleme
 
 <div data-o3-brand="sustainable-views">
 	<!-- OTHER HTML -->
-	<h1 class="o3-editorial-typography__headline" data-o3-theme="inverse">
+	<h1 class="o3-editorial-typography-headline" data-o3-theme="inverse">
 		Heading
 	</h1>
 	<!-- OTHER HTML -->
@@ -55,7 +55,7 @@ To migrate each mixin first import `o3-editorial-typography` css. For example:
 `oEditorialTypography` mixin was used to include all o-editorial-typography CSS. `o3-editorial-typography` includes all
 o-editorial-typography CSS by default and can be used by applying correct class names.
 
-There is no need to include `oEditorialTypography` mixin in your Sass files any more. Using new class names replaced
+There is no need to include `oEditorialTypography` mixin in your Sass files anymore. Using new class names replaced
 mixins that output css.
 
 class name replacements are as follows:


### PR DESCRIPTION
## Describe your changes

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
