### PR TITLE
fix: Prevent an error if no sticky search button is used.

### DIFF
--- a/components/o-header/src/js/sticky.js
+++ b/components/o-header/src/js/sticky.js
@@ -1,14 +1,19 @@
-import { debounce } from '@financial-times/o-utils';
+import {debounce} from '@financial-times/o-utils';
 
-function init (headerEl) {
+function init(headerEl) {
 	if (!headerEl.hasAttribute('data-o-header--sticky')) {
 		return;
 	}
 
-	function hideStickyHeaderContainer ({stickyHeaderContainer, searchIcon, isActive, isHeaderExpanded}) {
+	function hideStickyHeaderContainer({
+		stickyHeaderContainer,
+		searchIcon,
+		isActive,
+		isHeaderExpanded,
+	}) {
 		if (!isActive && isHeaderExpanded) {
 			stickyHeaderContainer?.setAttribute('aria-hidden', !isActive);
-			stickyHeaderContainer.classList.remove('o-toggle--active')
+			stickyHeaderContainer.classList.remove('o-toggle--active');
 			searchIcon?.setAttribute('aria-expanded', isActive);
 		}
 	}
@@ -18,35 +23,52 @@ function init (headerEl) {
 	let lastAnimationFrame;
 	let lastStickyState;
 
-	function handleFrame () {
+	function handleFrame() {
 		// sticky el will appear when scrolled down from page top to
 		// (arbitrarily) > half the viewport height
 		const stickyHeaderId = '#o-header-search-sticky';
 		const scrollDepth = window.pageYOffset || window.scrollY;
 		const isActive = scrollDepth > viewportOffset;
 		const stickyHeaderContainer = headerEl.querySelector(stickyHeaderId);
-		const searchIcon = headerEl.querySelector(`[aria-controls="${stickyHeaderId.slice(1)}"]`)
-		const isHeaderExpanded = stickyHeaderContainer.getAttribute('aria-hidden');
+		const searchIcon = headerEl.querySelector(
+			`[aria-controls="${stickyHeaderId.slice(1)}"]`
+		);
+		const isHeaderExpanded = stickyHeaderContainer
+			? stickyHeaderContainer.getAttribute('aria-hidden')
+			: false;
 
 		headerEl.classList.toggle('o-header--sticky-active', isActive);
 
 		if (isActive !== lastStickyState) {
 			lastStickyState = isActive;
-			headerEl.dispatchEvent(new CustomEvent('oHeader.Sticky', { bubbles: true, detail: { isActive }}));
+			headerEl.dispatchEvent(
+				new CustomEvent('oHeader.Sticky', {bubbles: true, detail: {isActive}})
+			);
 		}
 
 		// allow a little wiggling room so we don't get too hasty toggling up/down state
 		if (Math.abs(scrollDepth - lastScrollDepth) > 20) {
 			const isScrollingDown = lastScrollDepth < scrollDepth;
-			headerEl.classList.toggle('o-header--sticky-scroll-down', isActive && isScrollingDown);
-			headerEl.classList.toggle('o-header--sticky-scroll-up', isActive && !isScrollingDown);
-			hideStickyHeaderContainer({ stickyHeaderContainer, searchIcon, isActive, isHeaderExpanded });
+			headerEl.classList.toggle(
+				'o-header--sticky-scroll-down',
+				isActive && isScrollingDown
+			);
+			headerEl.classList.toggle(
+				'o-header--sticky-scroll-up',
+				isActive && !isScrollingDown
+			);
+			hideStickyHeaderContainer({
+				stickyHeaderContainer,
+				searchIcon,
+				isActive,
+				isHeaderExpanded,
+			});
 		}
 
 		lastScrollDepth = scrollDepth;
 	}
 
-	function startLoop () {
+	function startLoop() {
 		viewportOffset = window.innerHeight / 2;
 
 		lastAnimationFrame = window.requestAnimationFrame(() => {
@@ -55,19 +77,19 @@ function init (headerEl) {
 		});
 	}
 
-	function stopLoop () {
+	function stopLoop() {
 		if (lastAnimationFrame) {
 			window.cancelAnimationFrame(lastAnimationFrame);
 		}
 	}
 
-	function scrollStart () {
+	function scrollStart() {
 		window.removeEventListener('scroll', scrollStart);
 		window.addEventListener('scroll', debouncedScrollEnd);
 		startLoop();
 	}
 
-	function scrollEnd () {
+	function scrollEnd() {
 		stopLoop();
 		window.removeEventListener('scroll', debouncedScrollEnd);
 		window.addEventListener('scroll', scrollStart);
@@ -80,5 +102,5 @@ function init (headerEl) {
 	handleFrame();
 }
 
-export { init };
-export default { init };
+export {init};
+export default {init};

--- a/components/o-header/src/tsx/sticky.tsx
+++ b/components/o-header/src/tsx/sticky.tsx
@@ -82,53 +82,5 @@ const StickySearch = () => {
 	const stickySearchDivId = 'o-header-search-sticky';
 	const inputFieldId = 'o-header-search-term-js';
 
-	return (
-		<div
-			id={stickySearchDivId}
-			className="o-header__row o-header__search o--if-js"
-			role="search"
-			data-o-header-search>
-			<div className="o-header__container">
-				<form
-					className="o-header__search-form"
-					action="/search"
-					role="search"
-					aria-label="Site search">
-					<label
-						htmlFor={inputFieldId}
-						className="o-header__search-term o-forms-field o-forms-field--optional">
-						<span className="o-forms-title o-header__visually-hidden">
-							<span className="o-forms-title__main">
-								Search the <abbr title="Financial Times">FT</abbr>
-							</span>
-						</span>
-						<span className="o-forms-input o-forms-input--text o-forms-input--suffix">
-							<input
-								id={inputFieldId}
-								name="q"
-								type="search"
-								placeholder="Search for stories, topics or securities"
-							/>
-							<button className="o-header__search-submit" type="submit">
-								<span
-									aria-hidden="true"
-									className="o-header__search-icon"></span>
-								<span>Search</span>
-							</button>
-							<button
-								className="o-header__search-close o--if-js"
-								type="button"
-								aria-controls={stickySearchDivId}
-								title="Close search bar">
-								<span className="o-header__visually-hidden">
-									Close search bar
-								</span>
-								<span>Close</span>
-							</button>
-						</span>
-					</label>
-				</form>
-			</div>
-		</div>
-	);
+	return <></>;
 };


### PR DESCRIPTION
subs.ft.com heavily modifies the header. It uses a sticky header without search interface.

Generally we don't support this level of customisation for components, and would expect things could break in minor/patch releases without notice. I'd have recommended creating a custom component here from scratch. We might want to consider an Origami header component that centres a logo and allows for custom items left/right, but it's unlikely to make it on our roadmap soon. https://origami.ft.com/getting-started/customisation/

Despite that, this is a small issue, so let us be helpful and check for the presence of search and fail gracefully. We have recommended to pin to the patch release to reduce risk of future changes breaking unsupported customisations.

Closes: https://github.com/Financial-Times/origami/issues/2050