### PR TITLE
chore: add filter for secondary button on neutral theme

### DIFF
--- a/apps/for-everyone-website/src/components/button/preview/Types-Secondary.tsx
+++ b/apps/for-everyone-website/src/components/button/preview/Types-Secondary.tsx
@@ -11,6 +11,11 @@ function ButtonPreview() {
 	);
 }
 
-export const themes = buttonThemes;
+export const themes = Object.fromEntries(
+	Object.entries(buttonThemes).map(([key, value]) => [
+		key,
+		value.filter(theme => theme !== 'neutral'),
+	])
+);
 export const filePath = 'src/components/button/preview/Types-Secondary.tsx';
 export {ButtonPreview as preview};


### PR DESCRIPTION
## Describe your changes

Add a filter on the dropdown for the secondary button preview to exclude the `neutral` theme from the options.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
