### PR TITLE
feat: Add support-inverse colour use-case.

### DIFF
--- a/apps/dictionary/src/config/styledictionary.js
+++ b/apps/dictionary/src/config/styledictionary.js
@@ -7,11 +7,16 @@ import {transformSVG} from '../transforms/transformSVG.js';
 import {tintGroup} from '../transforms/tint-group.js';
 import {privatePrefix} from '../transforms/private-prefix.js';
 
-register(StyleDictionaryPackage);
+register(StyleDictionaryPackage, {
+	'ts/color/modifiers': {
+		format: 'hex',
+	},
+});
 
-StyleDictionaryPackage.format
+StyleDictionaryPackage.format;
 
-const originalScssMapFlat = StyleDictionaryPackage.hooks.formats['scss/map-flat'];
+const originalScssMapFlat =
+	StyleDictionaryPackage.hooks.formats['scss/map-flat'];
 
 StyleDictionaryPackage.registerTransform({
 	name: 'name/origamiPrivatePrefix',
@@ -51,12 +56,13 @@ StyleDictionaryPackage.registerTransform({
 // Workaround to allow font families to be processed correctly by map-flat. From https://github.com/amzn/style-dictionary/issues/298#issuecomment-2173382666
 StyleDictionaryPackage.registerFormat({
 	name: 'origami/scss/map-flat',
-	format: (args) => {
-		const { dictionary } = args;
-		const fontFamilyTokens =
-			dictionary.allTokens.filter(({ type }) => type === 'fontFamily');
-		fontFamilyTokens.forEach((token) => {
-			const { value } = token;
+	format: args => {
+		const {dictionary} = args;
+		const fontFamilyTokens = dictionary.allTokens.filter(
+			({type}) => type === 'fontFamily'
+		);
+		fontFamilyTokens.forEach(token => {
+			const {value} = token;
 			// encase in interpolation so map value is treated as singular value
 			token.value = `(${value})`;
 		});
@@ -64,7 +70,6 @@ StyleDictionaryPackage.registerFormat({
 		return originalScssMapFlat(args);
 	},
 });
-
 
 StyleDictionaryPackage.registerTransform({
 	name: 'value/figma-shadow-shorthand',

--- a/apps/dictionary/tokens/core/use-case/color.json
+++ b/apps/dictionary/tokens/core/use-case/color.json
@@ -65,28 +65,32 @@
             "type": "color"
           }
         },
-        "support": {
-          "text": {
-            "value": "{o3.color.palette.black-70}",
-            "type": "color"
-          }
-        },
         "body-inverse": {
           "text": {
             "value": "{o3.color.palette.white}",
             "type": "color"
           }
         },
-        "heading": {
+        "support": {
           "text": {
-            "value": "{o3.color.palette.black-80}",
+            "value": "{o3.color.palette.black-70}",
             "type": "color"
           }
         },
-        "heading-inverse": {
+        "support-inverse": {
           "text": {
             "value": "{o3.color.palette.white}",
-            "type": "color"
+            "type": "color",
+            "$extensions": {
+              "studio.tokens": {
+                "modify": {
+                  "type": "mix",
+                  "value": "0.1",
+                  "space": "srgb",
+                  "color": "{o3.color.palette.slate} "
+                }
+              }
+            }
           }
         },
         "muted": {
@@ -101,6 +105,18 @@
             "value": "#a8aaad",
             "type": "color",
             "description": "\"Muted\" text is less prominent, for example credits and captions."
+          }
+        },
+        "heading": {
+          "text": {
+            "value": "{o3.color.palette.black-80}",
+            "type": "color"
+          }
+        },
+        "heading-inverse": {
+          "text": {
+            "value": "{o3.color.palette.white}",
+            "type": "color"
           }
         },
         "footer": {

--- a/apps/dictionary/tokens/internal/use-case/color.json
+++ b/apps/dictionary/tokens/internal/use-case/color.json
@@ -71,6 +71,22 @@
             "type": "color"
           }
         },
+        "support-inverse": {
+          "text": {
+            "value": "{o3.color.palette.white}",
+            "type": "color",
+            "$extensions": {
+              "studio.tokens": {
+                "modify": {
+                  "type": "mix",
+                  "value": "0.1",
+                  "space": "srgb",
+                  "color": "{o3.color.palette.slate} "
+                }
+              }
+            }
+          }
+        },
         "body-inverse": {
           "text": {
             "value": "{o3.color.palette.white}",

--- a/apps/dictionary/tokens/sustainable-views/use-case/color.json
+++ b/apps/dictionary/tokens/sustainable-views/use-case/color.json
@@ -50,6 +50,22 @@
             "type": "color"
           }
         },
+        "support-inverse": {
+          "text": {
+            "value": "{o3.color.palette.white}",
+            "type": "color",
+            "$extensions": {
+              "studio.tokens": {
+                "modify": {
+                  "type": "mix",
+                  "value": "0.1",
+                  "space": "srgb",
+                  "color": "{o3.color.palette.slate} "
+                }
+              }
+            }
+          }
+        },
         "muted-inverse": {
           "text": {
             "value": "#a8aaad",

--- a/apps/dictionary/tokens/whitelabel/use-case/color.json
+++ b/apps/dictionary/tokens/whitelabel/use-case/color.json
@@ -71,6 +71,12 @@
             "type": "color"
           }
         },
+        "support-inverse": {
+          "text": {
+            "value": "{o3.color.palette.black-10}",
+            "type": "color"
+          }
+        },
         "body-inverse": {
           "text": {
             "value": "{o3.color.palette.white}",

--- a/components/o-private-foundation/src/scss/tokens/core.scss
+++ b/components/o-private-foundation/src/scss/tokens/core.scss
@@ -89,14 +89,15 @@ $tokens: (
   'o3-color-use-case-page-background': #fff1e5,
   'o3-color-use-case-page-inverse-background': #262a33,
   'o3-color-use-case-body-text': #33302e,
-  'o3-color-use-case-support-text': #4d4845,
   'o3-color-use-case-body-inverse-text': #ffffff,
-  'o3-color-use-case-heading-text': #33302e,
-  'o3-color-use-case-heading-inverse-text': #ffffff,
+  'o3-color-use-case-support-text': #4d4845,
+  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-inverse-text': #a8aaad,
+  'o3-color-use-case-heading-text': #33302e,
+  'o3-color-use-case-heading-inverse-text': #ffffff,
   'o3-color-use-case-footer-text': #33302e,
   'o3-color-use-case-caption-text': #33302e,
   'o3-color-use-case-button-foreground': #ffffff,

--- a/components/o-private-foundation/src/scss/tokens/core.scss
+++ b/components/o-private-foundation/src/scss/tokens/core.scss
@@ -91,7 +91,7 @@ $tokens: (
   'o3-color-use-case-body-text': #33302e,
   'o3-color-use-case-body-inverse-text': #ffffff,
   'o3-color-use-case-support-text': #4d4845,
-  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
+  'o3-color-use-case-support-inverse-text': #e9eaeb,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   // "Muted" text is less prominent, for example credits and captions.

--- a/components/o-private-foundation/src/scss/tokens/internal.scss
+++ b/components/o-private-foundation/src/scss/tokens/internal.scss
@@ -163,7 +163,7 @@ $tokens: (
   'o3-color-use-case-page-inverse-background': #262a33,
   'o3-color-use-case-body-text': #333333,
   'o3-color-use-case-support-text': #4d4d4d,
-  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
+  'o3-color-use-case-support-inverse-text': #e9eaeb,
   'o3-color-use-case-body-inverse-text': #ffffff,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #cccccc,

--- a/components/o-private-foundation/src/scss/tokens/internal.scss
+++ b/components/o-private-foundation/src/scss/tokens/internal.scss
@@ -163,6 +163,7 @@ $tokens: (
   'o3-color-use-case-page-inverse-background': #262a33,
   'o3-color-use-case-body-text': #333333,
   'o3-color-use-case-support-text': #4d4d4d,
+  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
   'o3-color-use-case-body-inverse-text': #ffffff,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #cccccc,

--- a/components/o-private-foundation/src/scss/tokens/professional.scss
+++ b/components/o-private-foundation/src/scss/tokens/professional.scss
@@ -100,7 +100,7 @@ $tokens: (
   'o3-color-use-case-body-text': #33302e,
   'o3-color-use-case-body-inverse-text': #ffffff,
   'o3-color-use-case-support-text': #4d4845,
-  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
+  'o3-color-use-case-support-inverse-text': #e9eaeb,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   // "Muted" text is less prominent, for example credits and captions.

--- a/components/o-private-foundation/src/scss/tokens/professional.scss
+++ b/components/o-private-foundation/src/scss/tokens/professional.scss
@@ -98,14 +98,15 @@ $tokens: (
   'o3-color-use-case-page-background': #fff1e5,
   'o3-color-use-case-page-inverse-background': #262a33,
   'o3-color-use-case-body-text': #33302e,
-  'o3-color-use-case-support-text': #4d4845,
   'o3-color-use-case-body-inverse-text': #ffffff,
-  'o3-color-use-case-heading-text': #33302e,
-  'o3-color-use-case-heading-inverse-text': #ffffff,
+  'o3-color-use-case-support-text': #4d4845,
+  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-inverse-text': #a8aaad,
+  'o3-color-use-case-heading-text': #33302e,
+  'o3-color-use-case-heading-inverse-text': #ffffff,
   'o3-color-use-case-footer-text': #33302e,
   'o3-color-use-case-caption-text': #33302e,
   'o3-color-use-case-button-foreground': #ffffff,

--- a/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
+++ b/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
@@ -151,6 +151,7 @@ $tokens: (
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   'o3-color-use-case-support-text': #4d4d4d,
+  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-inverse-text': #a8aaad,
   'o3-color-use-case-link-inverse-text': #ffffff,

--- a/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
+++ b/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
@@ -151,7 +151,7 @@ $tokens: (
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #807973,
   'o3-color-use-case-support-text': #4d4d4d,
-  'o3-color-use-case-support-inverse-text': rgb(91.5% 91.6% 92%),
+  'o3-color-use-case-support-inverse-text': #e9eaeb,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-inverse-text': #a8aaad,
   'o3-color-use-case-link-inverse-text': #ffffff,

--- a/components/o-private-foundation/src/scss/tokens/whitelabel.scss
+++ b/components/o-private-foundation/src/scss/tokens/whitelabel.scss
@@ -95,6 +95,7 @@ $tokens: (
   'o3-color-use-case-page-inverse-background': #333333,
   'o3-color-use-case-body-text': #333333,
   'o3-color-use-case-support-text': #4d4d4d,
+  'o3-color-use-case-support-inverse-text': #e6e6e6,
   'o3-color-use-case-body-inverse-text': #ffffff,
   // "Muted" text is less prominent, for example credits and captions.
   'o3-color-use-case-muted-text': #757575,

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -172,7 +172,7 @@
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
-  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-support-inverse-text: #e9eaeb;
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-heading-inverse-text: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -170,11 +170,12 @@
   --o3-color-use-case-page-background: var(--o3-color-palette-paper);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
-  --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
+  --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
+  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-heading-inverse-text: var(--o3-color-palette-white);
-  --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-footer-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-caption-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-button-foreground: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -186,7 +186,7 @@
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
-  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-support-inverse-text: #e9eaeb;
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-heading-inverse-text: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -184,11 +184,12 @@
   --o3-color-use-case-page-background: var(--o3-color-palette-paper);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
-  --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
+  --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
+  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-heading-inverse-text: var(--o3-color-palette-white);
-  --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-footer-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-caption-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-button-foreground: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/internal/_variables.css
+++ b/components/o3-foundation/src/css/tokens/internal/_variables.css
@@ -130,7 +130,7 @@
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
-  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-support-inverse-text: #e9eaeb;
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-20); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-90);

--- a/components/o3-foundation/src/css/tokens/internal/_variables.css
+++ b/components/o3-foundation/src/css/tokens/internal/_variables.css
@@ -130,6 +130,7 @@
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
+  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-20); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-90);

--- a/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
+++ b/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
@@ -110,7 +110,7 @@
   --o3-color-use-case-body-text: var(--o3-color-palette-black-90);
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
-  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
+  --o3-color-use-case-support-inverse-text: #e9eaeb;
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-button-foreground: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
+++ b/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
@@ -110,6 +110,7 @@
   --o3-color-use-case-body-text: var(--o3-color-palette-black-90);
   --o3-color-use-case-muted-text: var(--o3-color-palette-black-50); /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
+  --o3-color-use-case-support-inverse-text: rgb(91.5% 91.6% 92%);
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-slate);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-button-foreground: var(--o3-color-palette-white);

--- a/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
+++ b/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
@@ -118,6 +118,7 @@
   --o3-color-use-case-page-inverse-background: var(--o3-color-palette-black-80);
   --o3-color-use-case-body-text: var(--o3-color-palette-black-80);
   --o3-color-use-case-support-text: var(--o3-color-palette-black-70);
+  --o3-color-use-case-support-inverse-text: var(--o3-color-palette-black-10);
   --o3-color-use-case-body-inverse-text: var(--o3-color-palette-white);
   --o3-color-use-case-muted-inverse-text: var(--o3-color-palette-black-20);
   --o3-color-use-case-heading-text: var(--o3-color-palette-black-90);

--- a/libraries/o3-tooling-token/build/core/_variables.js
+++ b/libraries/o3-tooling-token/build/core/_variables.js
@@ -1695,7 +1695,7 @@ export default {
 },
 	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "rgb(91.5% 91.6% 92%)",
+		"value": "#e9eaeb",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/core/_variables.js
+++ b/libraries/o3-tooling-token/build/core/_variables.js
@@ -1653,26 +1653,6 @@ export default {
 		"css": "--o3-color-use-case-body-text",
 		"figma": "o3/color/use-case/body/text"
 },
-	"o3-color-use-case-support-text": {
-		"shortName": "text",
-		"value": "#4d4845",
-		"originalValue": "{o3.color.palette.black-70}",
-		"type": "color",
-		"attributes": {
-				"item": "use-case",
-				"subitem": "support",
-				"state": "text"
-		},
-		"path": [
-				"o3",
-				"color",
-				"use-case",
-				"support",
-				"text"
-		],
-		"css": "--o3-color-use-case-support-text",
-		"figma": "o3/color/use-case/support/text"
-},
 	"o3-color-use-case-body-inverse-text": {
 		"shortName": "text",
 		"value": "#ffffff",
@@ -1693,45 +1673,45 @@ export default {
 		"css": "--o3-color-use-case-body-inverse-text",
 		"figma": "o3/color/use-case/body-inverse/text"
 },
-	"o3-color-use-case-heading-text": {
+	"o3-color-use-case-support-text": {
 		"shortName": "text",
-		"value": "#33302e",
-		"originalValue": "{o3.color.palette.black-80}",
+		"value": "#4d4845",
+		"originalValue": "{o3.color.palette.black-70}",
 		"type": "color",
 		"attributes": {
 				"item": "use-case",
-				"subitem": "heading",
+				"subitem": "support",
 				"state": "text"
 		},
 		"path": [
 				"o3",
 				"color",
 				"use-case",
-				"heading",
+				"support",
 				"text"
 		],
-		"css": "--o3-color-use-case-heading-text",
-		"figma": "o3/color/use-case/heading/text"
+		"css": "--o3-color-use-case-support-text",
+		"figma": "o3/color/use-case/support/text"
 },
-	"o3-color-use-case-heading-inverse-text": {
+	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "#ffffff",
+		"value": "rgb(91.5% 91.6% 92%)",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {
 				"item": "use-case",
-				"subitem": "heading-inverse",
+				"subitem": "support-inverse",
 				"state": "text"
 		},
 		"path": [
 				"o3",
 				"color",
 				"use-case",
-				"heading-inverse",
+				"support-inverse",
 				"text"
 		],
-		"css": "--o3-color-use-case-heading-inverse-text",
-		"figma": "o3/color/use-case/heading-inverse/text"
+		"css": "--o3-color-use-case-support-inverse-text",
+		"figma": "o3/color/use-case/support-inverse/text"
 },
 	"o3-color-use-case-muted-text": {
 		"shortName": "text",
@@ -1774,6 +1754,46 @@ export default {
 		],
 		"css": "--o3-color-use-case-muted-inverse-text",
 		"figma": "o3/color/use-case/muted-inverse/text"
+},
+	"o3-color-use-case-heading-text": {
+		"shortName": "text",
+		"value": "#33302e",
+		"originalValue": "{o3.color.palette.black-80}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "heading",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"heading",
+				"text"
+		],
+		"css": "--o3-color-use-case-heading-text",
+		"figma": "o3/color/use-case/heading/text"
+},
+	"o3-color-use-case-heading-inverse-text": {
+		"shortName": "text",
+		"value": "#ffffff",
+		"originalValue": "{o3.color.palette.white}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "heading-inverse",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"heading-inverse",
+				"text"
+		],
+		"css": "--o3-color-use-case-heading-inverse-text",
+		"figma": "o3/color/use-case/heading-inverse/text"
 },
 	"o3-color-use-case-footer-text": {
 		"shortName": "text",

--- a/libraries/o3-tooling-token/build/core/professional/_variables.js
+++ b/libraries/o3-tooling-token/build/core/professional/_variables.js
@@ -1891,26 +1891,6 @@ export default {
 		"css": "--o3-color-use-case-body-text",
 		"figma": "o3/color/use-case/body/text"
 },
-	"o3-color-use-case-support-text": {
-		"shortName": "text",
-		"value": "#4d4845",
-		"originalValue": "{o3.color.palette.black-70}",
-		"type": "color",
-		"attributes": {
-				"item": "use-case",
-				"subitem": "support",
-				"state": "text"
-		},
-		"path": [
-				"o3",
-				"color",
-				"use-case",
-				"support",
-				"text"
-		],
-		"css": "--o3-color-use-case-support-text",
-		"figma": "o3/color/use-case/support/text"
-},
 	"o3-color-use-case-body-inverse-text": {
 		"shortName": "text",
 		"value": "#ffffff",
@@ -1931,45 +1911,45 @@ export default {
 		"css": "--o3-color-use-case-body-inverse-text",
 		"figma": "o3/color/use-case/body-inverse/text"
 },
-	"o3-color-use-case-heading-text": {
+	"o3-color-use-case-support-text": {
 		"shortName": "text",
-		"value": "#33302e",
-		"originalValue": "{o3.color.palette.black-80}",
+		"value": "#4d4845",
+		"originalValue": "{o3.color.palette.black-70}",
 		"type": "color",
 		"attributes": {
 				"item": "use-case",
-				"subitem": "heading",
+				"subitem": "support",
 				"state": "text"
 		},
 		"path": [
 				"o3",
 				"color",
 				"use-case",
-				"heading",
+				"support",
 				"text"
 		],
-		"css": "--o3-color-use-case-heading-text",
-		"figma": "o3/color/use-case/heading/text"
+		"css": "--o3-color-use-case-support-text",
+		"figma": "o3/color/use-case/support/text"
 },
-	"o3-color-use-case-heading-inverse-text": {
+	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "#ffffff",
+		"value": "rgb(91.5% 91.6% 92%)",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {
 				"item": "use-case",
-				"subitem": "heading-inverse",
+				"subitem": "support-inverse",
 				"state": "text"
 		},
 		"path": [
 				"o3",
 				"color",
 				"use-case",
-				"heading-inverse",
+				"support-inverse",
 				"text"
 		],
-		"css": "--o3-color-use-case-heading-inverse-text",
-		"figma": "o3/color/use-case/heading-inverse/text"
+		"css": "--o3-color-use-case-support-inverse-text",
+		"figma": "o3/color/use-case/support-inverse/text"
 },
 	"o3-color-use-case-muted-text": {
 		"shortName": "text",
@@ -2012,6 +1992,46 @@ export default {
 		],
 		"css": "--o3-color-use-case-muted-inverse-text",
 		"figma": "o3/color/use-case/muted-inverse/text"
+},
+	"o3-color-use-case-heading-text": {
+		"shortName": "text",
+		"value": "#33302e",
+		"originalValue": "{o3.color.palette.black-80}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "heading",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"heading",
+				"text"
+		],
+		"css": "--o3-color-use-case-heading-text",
+		"figma": "o3/color/use-case/heading/text"
+},
+	"o3-color-use-case-heading-inverse-text": {
+		"shortName": "text",
+		"value": "#ffffff",
+		"originalValue": "{o3.color.palette.white}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "heading-inverse",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"heading-inverse",
+				"text"
+		],
+		"css": "--o3-color-use-case-heading-inverse-text",
+		"figma": "o3/color/use-case/heading-inverse/text"
 },
 	"o3-color-use-case-footer-text": {
 		"shortName": "text",

--- a/libraries/o3-tooling-token/build/core/professional/_variables.js
+++ b/libraries/o3-tooling-token/build/core/professional/_variables.js
@@ -1933,7 +1933,7 @@ export default {
 },
 	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "rgb(91.5% 91.6% 92%)",
+		"value": "#e9eaeb",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/internal/_variables.js
+++ b/libraries/o3-tooling-token/build/internal/_variables.js
@@ -1084,6 +1084,26 @@ export default {
 		"css": "--o3-color-use-case-support-text",
 		"figma": "o3/color/use-case/support/text"
 },
+	"o3-color-use-case-support-inverse-text": {
+		"shortName": "text",
+		"value": "rgb(91.5% 91.6% 92%)",
+		"originalValue": "{o3.color.palette.white}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "support-inverse",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"support-inverse",
+				"text"
+		],
+		"css": "--o3-color-use-case-support-inverse-text",
+		"figma": "o3/color/use-case/support-inverse/text"
+},
 	"o3-color-use-case-body-inverse-text": {
 		"shortName": "text",
 		"value": "#ffffff",

--- a/libraries/o3-tooling-token/build/internal/_variables.js
+++ b/libraries/o3-tooling-token/build/internal/_variables.js
@@ -1086,7 +1086,7 @@ export default {
 },
 	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "rgb(91.5% 91.6% 92%)",
+		"value": "#e9eaeb",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/sustainable-views/_variables.js
+++ b/libraries/o3-tooling-token/build/sustainable-views/_variables.js
@@ -665,6 +665,26 @@ export default {
 		"css": "--o3-color-use-case-support-text",
 		"figma": "o3/color/use-case/support/text"
 },
+	"o3-color-use-case-support-inverse-text": {
+		"shortName": "text",
+		"value": "rgb(91.5% 91.6% 92%)",
+		"originalValue": "{o3.color.palette.white}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "support-inverse",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"support-inverse",
+				"text"
+		],
+		"css": "--o3-color-use-case-support-inverse-text",
+		"figma": "o3/color/use-case/support-inverse/text"
+},
 	"o3-color-use-case-muted-inverse-text": {
 		"shortName": "text",
 		"value": "#a8aaad",

--- a/libraries/o3-tooling-token/build/sustainable-views/_variables.js
+++ b/libraries/o3-tooling-token/build/sustainable-views/_variables.js
@@ -667,7 +667,7 @@ export default {
 },
 	"o3-color-use-case-support-inverse-text": {
 		"shortName": "text",
-		"value": "rgb(91.5% 91.6% 92%)",
+		"value": "#e9eaeb",
 		"originalValue": "{o3.color.palette.white}",
 		"type": "color",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/whitelabel/_variables.js
+++ b/libraries/o3-tooling-token/build/whitelabel/_variables.js
@@ -1791,6 +1791,26 @@ export default {
 		"css": "--o3-color-use-case-support-text",
 		"figma": "o3/color/use-case/support/text"
 },
+	"o3-color-use-case-support-inverse-text": {
+		"shortName": "text",
+		"value": "#e6e6e6",
+		"originalValue": "{o3.color.palette.black-10}",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "support-inverse",
+				"state": "text"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"support-inverse",
+				"text"
+		],
+		"css": "--o3-color-use-case-support-inverse-text",
+		"figma": "o3/color/use-case/support-inverse/text"
+},
 	"o3-color-use-case-body-inverse-text": {
 		"shortName": "text",
 		"value": "#ffffff",


### PR DESCRIPTION
This aligns with our other body colour usecases, which have an inverse alternative.

I've updated our Style Dictionary config to ensure a hex is generated from a token which is a colour mix.

Tested across brands on the website locally:
<img width="710" alt="Screenshot 2025-03-27 at 16 58 07" src="https://github.com/user-attachments/assets/4c0116eb-965f-429e-85d1-ac596e126f8d" />
