### PR TITLE
feat: add success colour tokens

### DIFF
--- a/apps/dictionary/tokens/core/use-case/color.json
+++ b/apps/dictionary/tokens/core/use-case/color.json
@@ -167,6 +167,15 @@
         },
         "error": {
           "value": "{o3.color.palette.crimson}",
+          "type": "color",
+          "description": "[DEPRECATED] This token is going to be looked at in the upcoming audit."
+        },
+        "success-background": {
+          "value": "#D7F0D1",
+          "type": "color"
+        },
+        "success-foreground": {
+          "value": "#00572C",
           "type": "color"
         }
       }

--- a/apps/dictionary/tokens/internal/use-case/color.json
+++ b/apps/dictionary/tokens/internal/use-case/color.json
@@ -155,6 +155,15 @@
         },
         "error": {
           "value": "{o3.color.palette.crimson}",
+          "type": "color",
+          "description": "[DEPRECATED] This token is going to be looked at in the upcoming audit."
+        },
+        "success-background": {
+          "value": "#D7F0D1",
+          "type": "color"
+        },
+        "success-foreground": {
+          "value": "#00572C",
           "type": "color"
         }
       }

--- a/apps/dictionary/tokens/sustainable-views/use-case/color.json
+++ b/apps/dictionary/tokens/sustainable-views/use-case/color.json
@@ -143,6 +143,15 @@
         },
         "error": {
           "value": "{o3.color.palette.crimson}",
+          "type": "color",
+          "description": "[DEPRECATED] This token is going to be looked at in the upcoming audit."
+        },
+        "success-background": {
+          "value": "#D7F0D1",
+          "type": "color"
+        },
+        "success-foreground": {
+          "value": "#00572C",
           "type": "color"
         }
       }

--- a/apps/dictionary/tokens/whitelabel/use-case/color.json
+++ b/apps/dictionary/tokens/whitelabel/use-case/color.json
@@ -144,6 +144,15 @@
         },
         "error": {
           "value": "{o3.color.palette.crimson}",
+          "type": "color",
+          "description": "[DEPRECATED] This token is going to be looked at in the upcoming audit."
+        },
+        "success-background": {
+          "value": "#D7F0D1",
+          "type": "color"
+        },
+        "success-foreground": {
+          "value": "#00572C",
           "type": "color"
         }
       }

--- a/components/o-private-foundation/src/scss/tokens/core.scss
+++ b/components/o-private-foundation/src/scss/tokens/core.scss
@@ -108,7 +108,10 @@ $tokens: (
   'o3-color-use-case-button-disabled': #9ec0bd,
   'o3-color-use-case-error-background': rgba(204, 0, 0, 0.06),
   'o3-color-use-case-error-text': #cc0000,
+  // [DEPRECATED] This token is going to be looked at in the upcoming audit.
   'o3-color-use-case-error': #cc0000,
+  'o3-color-use-case-success-background': #d7f0d1,
+  'o3-color-use-case-success-foreground': #00572c,
   '_o3-button-primary-standard-color': #ffffff,
   '_o3-button-primary-standard-background': #0d7680,
   '_o3-button-primary-standard-border': rgba(255, 255, 255, 0),

--- a/components/o-private-foundation/src/scss/tokens/internal.scss
+++ b/components/o-private-foundation/src/scss/tokens/internal.scss
@@ -179,7 +179,10 @@ $tokens: (
   'o3-color-use-case-button-disabled': #9ec0bd,
   'o3-color-use-case-error-background': rgba(204, 0, 0, 0.06),
   'o3-color-use-case-error-text': #cc0000,
+  // [DEPRECATED] This token is going to be looked at in the upcoming audit.
   'o3-color-use-case-error': #cc0000,
+  'o3-color-use-case-success-background': #d7f0d1,
+  'o3-color-use-case-success-foreground': #00572c,
   'o3-spacing-5xs': 0.25rem,
   'o3-spacing-4xs': 0.5rem,
   'o3-spacing-3xs': 0.75rem,

--- a/components/o-private-foundation/src/scss/tokens/professional.scss
+++ b/components/o-private-foundation/src/scss/tokens/professional.scss
@@ -117,7 +117,10 @@ $tokens: (
   'o3-color-use-case-button-disabled': #d4c9c1,
   'o3-color-use-case-error-background': rgba(204, 0, 0, 0.06),
   'o3-color-use-case-error-text': #cc0000,
+  // [DEPRECATED] This token is going to be looked at in the upcoming audit.
   'o3-color-use-case-error': #cc0000,
+  'o3-color-use-case-success-background': #d7f0d1,
+  'o3-color-use-case-success-foreground': #00572c,
   'o3-spacing-5xs': 0.25rem,
   'o3-spacing-4xs': 0.5rem,
   'o3-spacing-3xs': 0.75rem,

--- a/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
+++ b/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
@@ -168,7 +168,10 @@ $tokens: (
   'o3-color-use-case-button-disabled': #9ec0bd,
   'o3-color-use-case-error-background': rgba(204, 0, 0, 0.06),
   'o3-color-use-case-error-text': #cc0000,
+  // [DEPRECATED] This token is going to be looked at in the upcoming audit.
   'o3-color-use-case-error': #cc0000,
+  'o3-color-use-case-success-background': #d7f0d1,
+  'o3-color-use-case-success-foreground': #00572c,
   '_o3-editorial-typography-topic-tag-color': #0d7680,
   '_o3-editorial-typography-topic-tag-inverse-color': #ffffff,
   '_o3-editorial-typography-topic-tag-hover-color': #262a33,

--- a/components/o-private-foundation/src/scss/tokens/whitelabel.scss
+++ b/components/o-private-foundation/src/scss/tokens/whitelabel.scss
@@ -110,7 +110,10 @@ $tokens: (
   'o3-color-use-case-button-disabled': #cccccc,
   'o3-color-use-case-error-background': rgba(204, 0, 0, 0.06),
   'o3-color-use-case-error-text': #cc0000,
+  // [DEPRECATED] This token is going to be looked at in the upcoming audit.
   'o3-color-use-case-error': #cc0000,
+  'o3-color-use-case-success-background': #d7f0d1,
+  'o3-color-use-case-success-foreground': #00572c,
   '_o3-button-primary-standard-color': #ffffff,
   '_o3-button-primary-standard-background': #000000,
   '_o3-button-primary-standard-border': rgba(255, 255, 255, 0),

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -85,6 +85,8 @@
   --o3-color-use-case-muted-inverse-text: #a8aaad; /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-button-disabled: #9ec0bd;
   --o3-color-use-case-error-background: rgba(204, 0, 0, 0.06);
+  --o3-color-use-case-success-background: #d7f0d1;
+  --o3-color-use-case-success-foreground: #00572c;
   --o3-spacing-5xs: 0.25rem;
   --o3-spacing-4xs: 0.5rem;
   --o3-spacing-3xs: 0.75rem;
@@ -184,7 +186,7 @@
   --o3-color-use-case-button-hover: var(--o3-color-palette-teal-40);
   --o3-color-use-case-button-pressed: var(--o3-color-palette-teal-20);
   --o3-color-use-case-error-text: var(--o3-color-palette-crimson);
-  --o3-color-use-case-error: var(--o3-color-palette-crimson);
+  --o3-color-use-case-error: var(--o3-color-palette-crimson); /* [DEPRECATED] This token is going to be looked at in the upcoming audit. */
   --o3-type-display-lg-font-family: var(--o3-font-family-financier-display); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-weight: var(--o3-font-weight-bold); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-size: var(--o3-font-size-7); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -90,6 +90,8 @@
   --o3-color-use-case-button-pressed: #7d7a7a;
   --o3-color-use-case-button-disabled: #d4c9c1;
   --o3-color-use-case-error-background: rgba(204, 0, 0, 0.06);
+  --o3-color-use-case-success-background: #d7f0d1;
+  --o3-color-use-case-success-foreground: #00572c;
   --o3-spacing-5xs: 0.25rem;
   --o3-spacing-4xs: 0.5rem;
   --o3-spacing-3xs: 0.75rem;
@@ -195,7 +197,7 @@
   --o3-color-use-case-button-foreground: var(--o3-color-palette-white);
   --o3-color-use-case-button-default: var(--o3-color-palette-slate);
   --o3-color-use-case-error-text: var(--o3-color-palette-crimson);
-  --o3-color-use-case-error: var(--o3-color-palette-crimson);
+  --o3-color-use-case-error: var(--o3-color-palette-crimson); /* [DEPRECATED] This token is going to be looked at in the upcoming audit. */
   --o3-type-display-lg-font-family: var(--o3-font-family-financier-display); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-weight: var(--o3-font-weight-bold); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-size: var(--o3-font-size-7); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */

--- a/components/o3-foundation/src/css/tokens/internal/_variables.css
+++ b/components/o3-foundation/src/css/tokens/internal/_variables.css
@@ -47,6 +47,8 @@
   --o3-color-use-case-muted-inverse-text: #a8aaad; /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-button-disabled: #9ec0bd;
   --o3-color-use-case-error-background: rgba(204, 0, 0, 0.06);
+  --o3-color-use-case-success-background: #d7f0d1;
+  --o3-color-use-case-success-foreground: #00572c;
   --o3-spacing-5xs: 0.25rem;
   --o3-spacing-4xs: 0.5rem;
   --o3-spacing-3xs: 0.75rem;
@@ -141,7 +143,7 @@
   --o3-color-use-case-button-hover: var(--o3-color-palette-teal-40);
   --o3-color-use-case-button-pressed: var(--o3-color-palette-teal-20);
   --o3-color-use-case-error-text: var(--o3-color-palette-crimson);
-  --o3-color-use-case-error: var(--o3-color-palette-crimson);
+  --o3-color-use-case-error: var(--o3-color-palette-crimson); /* [DEPRECATED] This token is going to be looked at in the upcoming audit. */
   --o3-type-display-lg-font-family: var(--o3-font-family-financier-display); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-weight: var(--o3-font-weight-bold); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-size: var(--o3-font-size-7); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */

--- a/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
+++ b/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
@@ -37,6 +37,8 @@
   --o3-color-use-case-link-inverse-underline-hover: #d4d4d6;
   --o3-color-use-case-button-disabled: #9ec0bd;
   --o3-color-use-case-error-background: rgba(204, 0, 0, 0.06);
+  --o3-color-use-case-success-background: #d7f0d1;
+  --o3-color-use-case-success-foreground: #00572c;
   --o3-type-label-text-case: uppercase; /* Use this style for labels such as badges and metadata in teasers and toppers (e.g., "Live," "Premium," or the main timestamp). Avoid using full sentences. */
   --o3-type-body-content-base-font-weight: 1; /* Use this style only for the body copy of content pages, such as articles, live news and other content experience page. */
   --o3-type-body-content-highlight-font-weight: 600; /* Use this style only for the body copy of content pages, such as articles, live news and other content experience page. */
@@ -119,7 +121,7 @@
   --o3-color-use-case-button-hover: var(--o3-color-palette-teal-40);
   --o3-color-use-case-button-pressed: var(--o3-color-palette-teal-20);
   --o3-color-use-case-error-text: var(--o3-color-palette-crimson);
-  --o3-color-use-case-error: var(--o3-color-palette-crimson);
+  --o3-color-use-case-error: var(--o3-color-palette-crimson); /* [DEPRECATED] This token is going to be looked at in the upcoming audit. */
   --o3-type-display-lg-font-family: var(--o3-font-family-metric); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-weight: var(--o3-font-weight-semibold); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-size: var(--o3-font-size-metric2-7); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */

--- a/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
+++ b/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
@@ -79,6 +79,8 @@
   --o3-color-use-case-link-text: #757575;
   --o3-color-use-case-muted-text: #757575; /* "Muted" text is less prominent, for example credits and captions. */
   --o3-color-use-case-error-background: rgba(204, 0, 0, 0.06);
+  --o3-color-use-case-success-background: #d7f0d1;
+  --o3-color-use-case-success-foreground: #00572c;
   --o3-spacing-5xs: 0.25rem;
   --o3-spacing-4xs: 0.5rem;
   --o3-spacing-3xs: 0.75rem;
@@ -130,7 +132,7 @@
   --o3-color-use-case-button-pressed: var(--o3-color-palette-black-70);
   --o3-color-use-case-button-disabled: var(--o3-color-palette-black-20);
   --o3-color-use-case-error-text: var(--o3-color-palette-crimson);
-  --o3-color-use-case-error: var(--o3-color-palette-crimson);
+  --o3-color-use-case-error: var(--o3-color-palette-crimson); /* [DEPRECATED] This token is going to be looked at in the upcoming audit. */
   --o3-type-display-lg-font-family: var(--o3-font-family-financier-display); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-weight: var(--o3-font-weight-bold); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */
   --o3-type-display-lg-font-size: var(--o3-font-size-7); /* Use this style for large screens headlines in the main headers (toppers) of content pages, for prominent, large teasers or landing pages. */

--- a/libraries/o3-tooling-token/build/core/_variables.js
+++ b/libraries/o3-tooling-token/build/core/_variables.js
@@ -1996,6 +1996,7 @@ export default {
 		"value": "#cc0000",
 		"originalValue": "{o3.color.palette.crimson}",
 		"type": "color",
+		"description": "[DEPRECATED] This token is going to be looked at in the upcoming audit.",
 		"attributes": {
 				"item": "use-case",
 				"subitem": "error"
@@ -2008,6 +2009,42 @@ export default {
 		],
 		"css": "--o3-color-use-case-error",
 		"figma": "o3/color/use-case/error"
+},
+	"o3-color-use-case-success-background": {
+		"shortName": "success-background",
+		"value": "#d7f0d1",
+		"originalValue": "#D7F0D1",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-background"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-background"
+		],
+		"css": "--o3-color-use-case-success-background",
+		"figma": "o3/color/use-case/success-background"
+},
+	"o3-color-use-case-success-foreground": {
+		"shortName": "success-foreground",
+		"value": "#00572c",
+		"originalValue": "#00572C",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-foreground"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-foreground"
+		],
+		"css": "--o3-color-use-case-success-foreground",
+		"figma": "o3/color/use-case/success-foreground"
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",

--- a/libraries/o3-tooling-token/build/core/professional/_variables.js
+++ b/libraries/o3-tooling-token/build/core/professional/_variables.js
@@ -2234,6 +2234,7 @@ export default {
 		"value": "#cc0000",
 		"originalValue": "{o3.color.palette.crimson}",
 		"type": "color",
+		"description": "[DEPRECATED] This token is going to be looked at in the upcoming audit.",
 		"attributes": {
 				"item": "use-case",
 				"subitem": "error"
@@ -2246,6 +2247,42 @@ export default {
 		],
 		"css": "--o3-color-use-case-error",
 		"figma": "o3/color/use-case/error"
+},
+	"o3-color-use-case-success-background": {
+		"shortName": "success-background",
+		"value": "#d7f0d1",
+		"originalValue": "#D7F0D1",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-background"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-background"
+		],
+		"css": "--o3-color-use-case-success-background",
+		"figma": "o3/color/use-case/success-background"
+},
+	"o3-color-use-case-success-foreground": {
+		"shortName": "success-foreground",
+		"value": "#00572c",
+		"originalValue": "#00572C",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-foreground"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-foreground"
+		],
+		"css": "--o3-color-use-case-success-foreground",
+		"figma": "o3/color/use-case/success-foreground"
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",

--- a/libraries/o3-tooling-token/build/internal/_variables.js
+++ b/libraries/o3-tooling-token/build/internal/_variables.js
@@ -1367,6 +1367,7 @@ export default {
 		"value": "#cc0000",
 		"originalValue": "{o3.color.palette.crimson}",
 		"type": "color",
+		"description": "[DEPRECATED] This token is going to be looked at in the upcoming audit.",
 		"attributes": {
 				"item": "use-case",
 				"subitem": "error"
@@ -1379,6 +1380,42 @@ export default {
 		],
 		"css": "--o3-color-use-case-error",
 		"figma": "o3/color/use-case/error"
+},
+	"o3-color-use-case-success-background": {
+		"shortName": "success-background",
+		"value": "#d7f0d1",
+		"originalValue": "#D7F0D1",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-background"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-background"
+		],
+		"css": "--o3-color-use-case-success-background",
+		"figma": "o3/color/use-case/success-background"
+},
+	"o3-color-use-case-success-foreground": {
+		"shortName": "success-foreground",
+		"value": "#00572c",
+		"originalValue": "#00572C",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-foreground"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-foreground"
+		],
+		"css": "--o3-color-use-case-success-foreground",
+		"figma": "o3/color/use-case/success-foreground"
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",

--- a/libraries/o3-tooling-token/build/sustainable-views/_variables.js
+++ b/libraries/o3-tooling-token/build/sustainable-views/_variables.js
@@ -991,6 +991,7 @@ export default {
 		"value": "#cc0000",
 		"originalValue": "{o3.color.palette.crimson}",
 		"type": "color",
+		"description": "[DEPRECATED] This token is going to be looked at in the upcoming audit.",
 		"attributes": {
 				"item": "use-case",
 				"subitem": "error"
@@ -1003,6 +1004,42 @@ export default {
 		],
 		"css": "--o3-color-use-case-error",
 		"figma": "o3/color/use-case/error"
+},
+	"o3-color-use-case-success-background": {
+		"shortName": "success-background",
+		"value": "#d7f0d1",
+		"originalValue": "#D7F0D1",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-background"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-background"
+		],
+		"css": "--o3-color-use-case-success-background",
+		"figma": "o3/color/use-case/success-background"
+},
+	"o3-color-use-case-success-foreground": {
+		"shortName": "success-foreground",
+		"value": "#00572c",
+		"originalValue": "#00572C",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-foreground"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-foreground"
+		],
+		"css": "--o3-color-use-case-success-foreground",
+		"figma": "o3/color/use-case/success-foreground"
 },
 	"o3-type-display-lg-font-family": {
 		"shortName": "fontFamily",

--- a/libraries/o3-tooling-token/build/whitelabel/_variables.js
+++ b/libraries/o3-tooling-token/build/whitelabel/_variables.js
@@ -2073,6 +2073,7 @@ export default {
 		"value": "#cc0000",
 		"originalValue": "{o3.color.palette.crimson}",
 		"type": "color",
+		"description": "[DEPRECATED] This token is going to be looked at in the upcoming audit.",
 		"attributes": {
 				"item": "use-case",
 				"subitem": "error"
@@ -2085,6 +2086,42 @@ export default {
 		],
 		"css": "--o3-color-use-case-error",
 		"figma": "o3/color/use-case/error"
+},
+	"o3-color-use-case-success-background": {
+		"shortName": "success-background",
+		"value": "#d7f0d1",
+		"originalValue": "#D7F0D1",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-background"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-background"
+		],
+		"css": "--o3-color-use-case-success-background",
+		"figma": "o3/color/use-case/success-background"
+},
+	"o3-color-use-case-success-foreground": {
+		"shortName": "success-foreground",
+		"value": "#00572c",
+		"originalValue": "#00572C",
+		"type": "color",
+		"attributes": {
+				"item": "use-case",
+				"subitem": "success-foreground"
+		},
+		"path": [
+				"o3",
+				"color",
+				"use-case",
+				"success-foreground"
+		],
+		"css": "--o3-color-use-case-success-foreground",
+		"figma": "o3/color/use-case/success-foreground"
 },
 	"o3-spacing-5xs": {
 		"shortName": "5xs",


### PR DESCRIPTION
Closes #2021 
_☝🏻 will autoclose the PR once this one is merged._

## Describe your changes

1. This change implements the `success-foreground` and `success-background` so it is available for use in the Origami Design Tokens and for CSS with forms.
2. It also marks `error` as deprecated with the upcoming colour audit, and to use the other two available error tokens instead.

## Additional context

As mentioned in a [Slack thread](https://financialtimes.slack.com/archives/G03ACR1MJ/p1743516074492649), the general consensus is to close the original PR and add in success tokens and mark the error one as deprecated due to the upcoming colours audit that Design has in mind soon.

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1396](https://financialtimes.atlassian.net/browse/OR-1396) | N/A |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1396]: https://financialtimes.atlassian.net/browse/OR-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ