### PR TITLE
feat: introduce helper classes for o3 button grid and list icons

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -532,6 +532,15 @@
 .o3-button-icon.o3-button-icon--cross::before {
 	--o3-button-icon: var(--o3-icon-cross);
 }
+
+.o3-button-icon.o3-button-icon--list::before {
+	--o3-button-icon: var(--o3-icon-list);
+}
+
+.o3-button-icon.o3-button-icon--grid::before {
+	--o3-button-icon: var(--o3-icon-grid);
+}
+
 .o3-button-icon.o3-button-icon--upload::before {
 	--o3-button-icon: var(--o3-icon-upload);
 }


### PR DESCRIPTION
## Describe your changes

* introduces css helper class for list icon in o3-button
* * introduces css helper class for grid icon in o3-button

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
