### PR TITLE
feat: Add a pagination pattern to show the current page only.

### DIFF
--- a/apps/for-everyone-website/src/components/button/preview/ButtonPagination-inverse.tsx
+++ b/apps/for-everyone-website/src/components/button/preview/ButtonPagination-inverse.tsx
@@ -5,6 +5,7 @@ function ButtonPaginationPreview() {
 		<>
 			<meta itemProp="@preview" />
 			<ButtonPagination
+				currentPageOnly={false}
 				previousPager={{label: 'previous', href: '#previous'}}
 				nextPager={{label: 'next', href: '#next'}}
 				pages={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(p => ({

--- a/apps/for-everyone-website/src/components/button/preview/ButtonPagination-standard.tsx
+++ b/apps/for-everyone-website/src/components/button/preview/ButtonPagination-standard.tsx
@@ -5,6 +5,7 @@ function ButtonPaginationPreview() {
 		<>
 			<meta itemProp="@preview" />
 			<ButtonPagination
+				currentPageOnly={false}
 				previousPager={{label: 'previous', href: '#previous'}}
 				nextPager={{label: 'next', href: '#next'}}
 				pages={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(p => ({

--- a/apps/for-everyone-website/src/content/docs/patterns/pagination.mdx
+++ b/apps/for-everyone-website/src/content/docs/patterns/pagination.mdx
@@ -3,48 +3,67 @@ title: Pagination
 description: How to paginate
 ---
 
-import {Button, ButtonPagination} from '@financial-times/o3-button';
+import { Button, ButtonPagination } from '@financial-times/o3-button';
 import '@financial-times/o3-button/css/whitelabel.css';
 import '@financial-times/o3-button/css/internal.css';
 import '@financial-times/o3-button/css/professional.css';
 import '@financial-times/o3-button/css/sustainable-views.css';
-import {renderToString} from 'react-dom/server';
-import {Code} from 'astro:components';
+import { renderToString } from 'react-dom/server';
+import { Code } from 'astro:components';
 import * as starlightExpressiveCode from '@astrojs/starlight/expressive-code';
-import {default as Example} from '../../../components/Example.astro';
-import {default as Guideline} from '../../../components/Guideline.astro';
-import {default as PaginationAnatomy} from '../../../components/PaginationAnatomy.astro';
-import {default as Preview} from '../../../components/button/ButtonPaginationPreview.astro';
+import { default as Example } from '../../../components/Example.astro';
+import { default as Guideline } from '../../../components/Guideline.astro';
+import { default as PaginationAnatomy } from '../../../components/PaginationAnatomy.astro';
+import { default as Preview } from '../../../components/button/ButtonPaginationPreview.astro';
 
 Pagination aids user movement across an ordered collection of items that has been split into pages.
 
 - We provide infinite scrolling guidelines, as an acceptable alternative for some usecases.
 - Our pagination pattern shows a variable number of pages to accommodate mobile and desktop experiences.
 - This pattern is available via [your brands Figma library](https://www.figma.com/files/938480807921629744/team/1237702133754424766) and our [o3-button](https://github.com/Financial-Times/origami/tree/main/components/o3-button) npm package.
-- A similar legacy pagination pattern exists within our [legacy o-buttons component](https://o2.origami.ft.com/?path=/story/o2-core_deprecated-o-buttons--pagination). However, this legacy pattern does not support a mobile experience. It also is not represented in our legacy Figma UI Library.
 
-## Anatomy
+## Standard Pagination
 
+### Anatomy
 <PaginationAnatomy />
 
 - **Navigation (1, 5)**: Previous and next buttons to navigate relatively from the currently selected page.
 - **Page (2,3)**: Numbers that indicate pages.
 - **Truncation (4)**: Indicated by ellipses (…) to replace any skipped pages.
 
-## Usage Guidelines
+### Usage Guidelines
 
-### Standard pagination
+Pagination should be used when:
+- A list has a significant number of items, typically more than 25.
+- When showing all the content on a single page makes the page take too long to load.
 
-We recommend using our standard pagination pattern, which is available within [your brands Figma library](https://www.figma.com/files/938480807921629744/team/1237702133754424766) and our [o3-button](https://github.com/Financial-Times/origami/tree/main/components/o3-button) npm package. This:
-
-- Should be placed at the bottom of a long list that has been split up into pages.
-- Should navigate to the previous and next set of items in the paged list.
+It must:
+- Be placed at the bottom of a long list that has been split up into pages.
+- Navigate to the previous and next set of items in the paged list.
 - Indicate when users are at the first or the last page by disabling the arrows.
 
-<Example title="Choose pagination when" do={true}>
-	- A list has a significant number of items, typically more than 25. - When
-	showing all the content on a single page makes the page take too long to load.
+<Preview theme="standard" brand={props.brand} />
+
+### Current page only
+
+Show the current page only when jumping quickly to the beginning or end of results does not enhance the user experience.
+
+<Example>
+	<ButtonPagination
+		currentPageOnly = {true}
+		previousPager={{label: 'previous', href: '#previous'}}
+		nextPager={{label: 'next', href: '#next'}}
+		pages={[1, 2, 3, 4, 5, 6, 7].map(p => ({
+			href: `#${p}`,
+			current: p === 2,
+			number: p,
+		}))}
+	/>
 </Example>
+
+### Contextual pages
+
+For enhanced navigation of pages, including the ability to jump to the first and last page, use the following pattern:
 
 #### When all pages can be displayed
 
@@ -142,7 +161,21 @@ Show the first page; ellipsis; the selected page, with 1 page either side if spa
 	/>
 </Example>
 
-### Infinite scroll
+### Themes
+
+Our pagination pattern supports all button themes. For example:
+
+#### Standard Theme
+
+<Preview theme="standard" brand={props.brand} />
+
+#### Inverse Theme
+
+<div data-o3-theme="inverse">
+	<Preview theme="inverse" brand={props.brand} />
+</div>
+
+## Infinite scroll
 
 There are some cases when infinite scroll is appropriate. This is a common pattern within our iOS and Android apps. Origami does not currently provide a full pattern for this, however we recommend the following:
 
@@ -161,15 +194,3 @@ There are some cases when infinite scroll is appropriate. This is a common patte
 	given pages is helpful.
 </Example>
 
-## Themes
-
-Our pagination pattern supports all button themes. For example:
-
-### Standard Pagination
-
-<Preview theme="standard" brand={props.brand} />
-### Inverse Pagination
-
-<div data-o3-theme="inverse">
-	<Preview theme="inverse" brand={props.brand} />
-</div>

--- a/components/o3-button/README.md
+++ b/components/o3-button/README.md
@@ -337,6 +337,7 @@ import '@financial-times/o3-button/css/[your brand].css';
 			{href: '#9', current: false, number: 9},
 			{href: '#10', current: false, number: 10},
 		]}
+		currentPageOnly={false}
 	/>
 </div>;
 ```

--- a/components/o3-button/src/tsx/pagination.tsx
+++ b/components/o3-button/src/tsx/pagination.tsx
@@ -122,6 +122,7 @@ export function ButtonPagination({
 	previousPager,
 	pages,
 	nextPager,
+	currentPageOnly,
 }: ButtonPaginationProps) {
 	const mapPagesToElements = (mode, pages, index, pagesGroup) => {
 		pages = pages.map(page => {
@@ -177,10 +178,30 @@ export function ButtonPagination({
 			mapPagesToElements('narrow', pages, index, pagesGroup)
 	);
 
-	const paginationElements = [
-		...paginationElementsWide,
-		...paginationElementsNarrow,
-	];
+	const PageTag = currentPage.href ? LinkButton : Button;
+	const paginationElements = currentPageOnly
+		? [
+				<PageTag
+					key={`page-current-only-${currentPage.number}`}
+					href={currentPage.href}
+					label={currentPage.number.toString()}
+					attributes={(() => {
+						const pageAttributes = {};
+						if (currentPage.href) {
+							pageAttributes['aria-current'] = 'page';
+						}
+						if (!currentPage.href) {
+							pageAttributes['aria-selected'] = true;
+						}
+						if (currentPage.onClick) {
+							pageAttributes['onClick'] = currentPage.onClick;
+						}
+						return pageAttributes;
+					})()}
+					theme={theme}
+					type="secondary"></PageTag>,
+		  ]
+		: [...paginationElementsWide, ...paginationElementsNarrow];
 
 	const NextTag = nextPager.href ? LinkButton : Button;
 	const PreviousTag = previousPager.href ? LinkButton : Button;

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -38,6 +38,7 @@ export type ButtonPaginationProps = Pick<ButtonProps, 'theme'> & {
 	previousPager: ButtonPaginationPager;
 	pages: ButtonPaginationItem[];
 	nextPager: ButtonPaginationPager;
+	currentPageOnly?: boolean;
 };
 export interface ButtonPaginationItem {
 	href?: string;

--- a/components/o3-button/stories/pagination-template.tsx
+++ b/components/o3-button/stories/pagination-template.tsx
@@ -75,5 +75,6 @@ export const Pagination: PaginationStory = {
 			href: '#next',
 			label: 'next results',
 		},
+		currentPageOnly: false,
 	},
 };


### PR DESCRIPTION
Pagination: Due to concerns with bot scraping and costs, we need to avoid the current Origami pagination pattern which includes multiple page links and a link to the last page. This impacts stream and search pages. Since it's going to impact multiple pages, we decided to quickly implement a new pagination variant in Origami with a forward/back button, and current page only. We prefer this from a reader perspective also so win win win.

This could be improved to improve efficiency – we're still calculating desktop/mobile pages to show when we're only showing the current page – and provide an api which doesn't need to know _all of the pages_ in advance. However due to time constraints and getting into a bit of a Storybook mess, I have chosen a more simple route of adding a param to the current JSX component.

<img width="715" alt="Screenshot 2025-04-04 at 17 07 11" src="https://github.com/user-attachments/assets/a0d96639-5113-4773-81f7-306a02526563" />
