### PR TITLE
fix: o-forms theme issue

### DIFF
--- a/.github/workflows/o2-chromatic.yml
+++ b/.github/workflows/o2-chromatic.yml
@@ -44,4 +44,4 @@ jobs:
           workingDir: apps/o2-storybook
           exitOnceUploaded: true
         env:
-          ORIGAMI_STORYBOOK_BRAND: ${{ matrix.brand }}
+          STORYBOOK_BRAND: ${{ matrix.brand }}

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Storybook can be run locally with the `storybook` command.
 npm run storybook
 ```
 
-To view components in other brands in Storybook, set the `ORIGAMI_STORYBOOK_BRAND` environment variable with the brand.
+To view components in other brands in Storybook, set the `STORYBOOK_BRAND` environment variable with the brand.
 
 ```shell
-ORIGAMI_STORYBOOK_BRAND=internal npm run storybook
+STORYBOOK_BRAND=internal npm run storybook
 ```
 
 Some demos in Storybook are embedded through the Build Service, meaning that local changes will not appear on Storybook. This can be verified by inspecting the `*.story.ts` file for a component and seeing if the root element is an `iframe`. Local development for these components can still be achieved by using [legacy](#legacy) demos instead.

--- a/apps/astro-website/src/content/documentation/tutorials/create-a-new-component-part-6.md
+++ b/apps/astro-website/src/content/documentation/tutorials/create-a-new-component-part-6.md
@@ -43,7 +43,7 @@ Once the storybook dev server is running we notice that some styles are already 
 
 ## Brands
 
-When we were working on [implementing brand](/documentation/tutorials/create-a-new-component-part-3/#component-brands) variants for our component we noticed that our build server generated different `html` files for us and we could swap between them. In storybook we will need to restart our dev server and provide an environment variable. To start internal component demos in storybook you will need to run `ORIGAMI_STORYBOOK_BRAND=internal npm run storybook` and similarly for whitelababel you can run `ORIGAMI_STORYBOOK_BRAND=whitelabel npm run storybook`.
+When we were working on [implementing brand](/documentation/tutorials/create-a-new-component-part-3/#component-brands) variants for our component we noticed that our build server generated different `html` files for us and we could swap between them. In storybook we will need to restart our dev server and provide an environment variable. To start internal component demos in storybook you will need to run `STORYBOOK_BRAND=internal npm run storybook` and similarly for whitelababel you can run `STORYBOOK_BRAND=whitelabel npm run storybook`.
 
 ## TSX template
 

--- a/apps/astro-website/src/content/documentation/tutorials/create-a-new-component-part-6.md
+++ b/apps/astro-website/src/content/documentation/tutorials/create-a-new-component-part-6.md
@@ -141,7 +141,7 @@ export const DefaultExample: ComponentStory&lt;typeof Example> = ExampleStory.bi
 + 	inverse: 'Inverse',
 + }
 +
-+ const Brand = process.env.ORIGAMI_STORYBOOK_BRAND || 'core';
++ const Brand = process.env.STORYBOOK_BRAND || 'core';
 +
 + if (Brand === 'core') {
 + 	themeOptions.push('b2c')

--- a/apps/o2-storybook-composition/.storybook/preview.ts
+++ b/apps/o2-storybook-composition/.storybook/preview.ts
@@ -49,15 +49,18 @@ export default preview;
 let channel = addons.getChannel();
 
 const storyArgsListener = args => {
-	if (args.args.theme === 'inverse') {
-		let colorTheme = args.args.theme;
-		channel.emit(UPDATE_GLOBALS, {
-			globals: {
-				theme: colorTheme,
-				backgrounds: {name: 'slate', value: '#262a33ff'},
-			},
-		});
-	}
+	const colorTheme = args.args.theme;
+	const slateBackground =
+		colorTheme === 'inverse' ||
+		colorTheme === 'professional-inverse' ||
+		colorTheme === 'ft-live';
+	channel.emit(UPDATE_GLOBALS, {
+		globals: {
+			backgrounds: slateBackground
+				? {name: 'slate', value: '#262a33ff'}
+				: undefined,
+		},
+	});
 };
 
 const storyChangedListener = () => {

--- a/apps/o2-storybook/.storybook/main.ts
+++ b/apps/o2-storybook/.storybook/main.ts
@@ -4,7 +4,7 @@ import {globby} from 'globby';
 import path from 'path';
 import type {StorybookConfig} from '@storybook/react-webpack5';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND || 'core';
+const brand = process.env.STORYBOOK_BRAND || 'core';
 
 const config: StorybookConfig = {
 	stories: (async () => {

--- a/apps/o2-storybook/.storybook/main.ts
+++ b/apps/o2-storybook/.storybook/main.ts
@@ -117,6 +117,12 @@ const config: StorybookConfig = {
 	docs: {
 		autodocs: 'tag',
 	},
+	env: config => {
+		return {
+			...config,
+			STORYBOOK_BRAND: brand,
+		}
+	},
 };
 
 const getComponentBrands = componentDir =>

--- a/apps/o2-storybook/.storybook/preview.ts
+++ b/apps/o2-storybook/.storybook/preview.ts
@@ -10,30 +10,30 @@ const preview: Preview = {
 	parameters: {
 		html: {
 			highlighter: {
-				showLineNumbers: true
-			}
+				showLineNumbers: true,
+			},
 		},
 		backgrounds: {
 			values: [
 				{
-					name: "paper",
-					value: "#fff1e5ff",
+					name: 'paper',
+					value: '#fff1e5ff',
 				},
 				{
-					name: "slate",
-					value: "#262a33ff",
+					name: 'slate',
+					value: '#262a33ff',
 				},
 				{
-					name: "wheat",
-					value: "#f2dfceff",
+					name: 'wheat',
+					value: '#f2dfceff',
 				},
 				{
-					name: "white",
-					value: "#ffffff",
+					name: 'white',
+					value: '#ffffff',
 				},
 			],
 		},
-		actions: {argTypesRegex: "^on[A-Z].*"},
+		actions: {argTypesRegex: '^on[A-Z].*'},
 		controls: {
 			matchers: {
 				color: /(background|color)$/i,
@@ -41,22 +41,22 @@ const preview: Preview = {
 			},
 		},
 	},
-}
+};
 
 export default preview
 
 let channel = addons.getChannel()
 
 const storyArgsListener = args => {
-	if (args.args.theme === "inverse") {
-		let colorTheme = args.args.theme
+	const colorTheme = args.args.theme
+	const slateBackground = colorTheme === 'inverse' || colorTheme === 'professional-inverse' || colorTheme === 'ft-live'
 		channel.emit(UPDATE_GLOBALS, {
 			globals: {
-				theme: colorTheme,
-				backgrounds: {name: "slate", value: "#262a33ff"},
+				backgrounds: slateBackground
+					? {name: 'slate', value: '#262a33ff'}
+					: undefined,
 			},
-		})
-	}
+		});
 }
 
 const storyChangedListener = () => {

--- a/apps/o2-storybook/readme.md
+++ b/apps/o2-storybook/readme.md
@@ -16,10 +16,10 @@ Run storybook:
 npm run storybook -w apps/o2-storybook
 ```
 
-By default, storybook will build demos for the `core` brand, you can change which brand storybook will build for by changing the value of `ORIGAMI_STORYBOOK_BRAND`:
+By default, storybook will build demos for the `core` brand, you can change which brand storybook will build for by changing the value of `STORYBOOK_BRAND`:
 
 ```bash
-ORIGAMI_STORYBOOK_BRAND=internal npm run storybook -w apps/o2-storybook
+STORYBOOK_BRAND=internal npm run storybook -w apps/o2-storybook
 ```
 
 Origami 2 supports these brands:

--- a/components/o-forms/src/scss/shared/_brand.scss
+++ b/components/o-forms/src/scss/shared/_brand.scss
@@ -73,22 +73,39 @@ $_o-forms-shared-brand-config: (
 						error-summary-border-inverse:
 							oPrivateFoundationGet('o3-color-palette-claret-100'),
 						'professional': (
-							default-text: oPrivateFoundationGet('o3-color-use-case-body-text'),
-							controls-base: oPrivateFoundationGet('o3-color-palette-slate'),
+							default-text:
+								oPrivateFoundationGet(
+									'o3-color-use-case-body-text',
+									'professional'
+								),
+							controls-base:
+								oPrivateFoundationGet('o3-color-palette-slate', 'professional'),
 							controls-negative-checked-background:
-								oPrivateFoundationGet('o3-color-palette-slate'),
-							radio-background: oPrivateFoundationGet('o3-color-palette-slate'),
-							default-border: oPrivateFoundationGet('o3-color-palette-black-50'),
+								oPrivateFoundationGet('o3-color-palette-slate', 'professional'),
+							radio-background:
+								oPrivateFoundationGet('o3-color-palette-slate', 'professional'),
+							default-border:
+								oPrivateFoundationGet(
+									'o3-color-palette-black-50',
+									'professional'
+								),
 							controls-checked-base:
-								oPrivateFoundationGet('o3-color-palette-white'),
+								oPrivateFoundationGet('o3-color-palette-white', 'professional'),
 						),
 						'professional-inverse': (
 							default-text:
-								oPrivateFoundationGet('o3-color-use-case-body-inverse-text'),
-							controls-base: oPrivateFoundationGet('o3-color-palette-mint'),
-							default-border: oPrivateFoundationGet('o3-color-palette-mint'),
+								oPrivateFoundationGet(
+									'o3-color-use-case-body-inverse-text',
+									'professional'
+								),
+							radio-background:
+								oPrivateFoundationGet('o3-color-palette-mint', 'professional'),
+							default-border:
+								oPrivateFoundationGet('o3-color-palette-mint', 'professional'),
+							controls-base:
+								oPrivateFoundationGet('o3-color-palette-mint', 'professional'),
 							controls-checked-base:
-								oPrivateFoundationGet('o3-color-palette-slate'),
+								oPrivateFoundationGet('o3-color-palette-slate', 'professional'),
 						),
 						'ft-live': (
 							default-text: oPrivateFoundationGet('o3-color-palette-white'),

--- a/components/o-forms/stories/boxRadioBtns.stories.tsx
+++ b/components/o-forms/stories/boxRadioBtns.stories.tsx
@@ -3,6 +3,7 @@ import {useEffect} from 'react';
 import {RadioBtn, RadioBtnsBox} from '../src/tsx/o-forms';
 import './forms.scss';
 import javascript from '../main.js';
+import {useArgs} from '@storybook/preview-api';
 
 const hideArg = {
 	table: {
@@ -10,7 +11,7 @@ const hideArg = {
 	},
 };
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+const Brand = process.env.STORYBOOK_BRAND;
 const themeControl =
 	Brand === 'core'
 		? {
@@ -24,7 +25,6 @@ const themeControl =
 export default {
 	title: 'Maintained/o-forms/box-radio-buttons',
 	component: RadioBtnsBox,
-	args: {},
 	argTypes: {
 		children: hideArg,
 		theme: themeControl,
@@ -32,11 +32,13 @@ export default {
 } as ComponentMeta<typeof RadioBtnsBox>;
 
 const Template: ComponentStory<typeof RadioBtnsBox> = args => {
+	const [_, updateArgs] = useArgs();
 	useEffect(() => {
 		let form = javascript.init();
 		return function cleanup() {
 			form = Array.isArray(form) ? form : [form];
 			form.forEach(element => element.destroy());
+			updateArgs({...args, theme: undefined});
 		};
 	}, []);
 	return <RadioBtnsBox {...args} />;

--- a/components/o-forms/stories/checkboxes.stories.tsx
+++ b/components/o-forms/stories/checkboxes.stories.tsx
@@ -3,6 +3,7 @@ import {useEffect} from 'react';
 import {Checkbox, Checkboxes} from '../src/tsx/o-forms';
 import './forms.scss';
 import javascript from '../main.js';
+import {useArgs} from '@storybook/preview-api';
 
 const hideArg = {
 	table: {
@@ -10,12 +11,13 @@ const hideArg = {
 	},
 };
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+const Brand = process.env.STORYBOOK_BRAND;
 const themeControl =
 	Brand === 'core'
 		? {
 				control: {
 					type: 'select',
+					default: {undefined},
 				},
 				options: [undefined, 'professional', 'professional-inverse', 'ft-live'],
 		  }
@@ -27,15 +29,18 @@ export default {
 	argTypes: {
 		children: hideArg,
 		theme: themeControl,
+		inputType: hideArg,
 	},
 } as ComponentMeta<typeof Checkboxes>;
 
 const Template: ComponentStory<typeof Checkboxes> = args => {
+	const [_, updateArgs] = useArgs();
 	useEffect(() => {
 		let form = javascript.init();
 		return function cleanup() {
 			form = Array.isArray(form) ? form : [form];
 			form.forEach(element => element.destroy());
+			updateArgs({...args, theme: undefined});
 		};
 	}, []);
 	return <Checkboxes {...args} />;

--- a/components/o-forms/stories/radioBtns.stories.tsx
+++ b/components/o-forms/stories/radioBtns.stories.tsx
@@ -3,6 +3,7 @@ import {useEffect} from 'react';
 import {RadioBtn, RadioBtns} from '../src/tsx/o-forms';
 import './forms.scss';
 import javascript from '../main.js';
+import {useArgs} from '@storybook/preview-api';
 
 const hideArg = {
 	table: {
@@ -10,7 +11,7 @@ const hideArg = {
 	},
 };
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+const Brand = process.env.STORYBOOK_BRAND;
 const themeControl =
 	Brand === 'core'
 		? {
@@ -31,11 +32,13 @@ export default {
 } as ComponentMeta<typeof RadioBtns>;
 
 const Template: ComponentStory<typeof RadioBtns> = args => {
+	const [_, updateArgs] = useArgs();
 	useEffect(() => {
 		let form = javascript.init();
 		return function cleanup() {
 			form = Array.isArray(form) ? form : [form];
 			form.forEach(element => element.destroy());
+			updateArgs({...args, theme: undefined});
 		};
 	}, []);
 	return <RadioBtns {...args} />;

--- a/components/o-forms/stories/toggleCheckboxes.stories.tsx
+++ b/components/o-forms/stories/toggleCheckboxes.stories.tsx
@@ -15,6 +15,7 @@ export default {
 	argTypes: {
 		children: hideArg,
 		theme: hideArg,
+		inputType: hideArg,
 	},
 } as ComponentMeta<typeof Checkboxes>;
 

--- a/components/o-header-services/stories/header-services.stories.tsx
+++ b/components/o-header-services/stories/header-services.stories.tsx
@@ -10,7 +10,7 @@ import {
 import js from '../main';
 import {useEffect} from 'react';
 
-const Brand = process.env.ORIGAMI_STORYBOOK_BRAND;
+const Brand = process.env.STORYBOOK_BRAND;
 const ThemeMapping = {
 	B2B: 'b2b',
 	B2C: 'b2c',
@@ -81,6 +81,11 @@ HeaderWithTitleSection.argTypes = {
 		},
 	},
 	secondaryNavData: {
+		table: {
+			disable: true,
+		},
+	},
+	theme: {
 		table: {
 			disable: true,
 		},

--- a/components/o-labels/stories/internal/content.stories.tsx
+++ b/components/o-labels/stories/internal/content.stories.tsx
@@ -1,7 +1,6 @@
 import {ContentLabel as ContentLabelTsx} from '../../src/tsx/label';
 import '../labels.scss';
 
-const brand = process.env.ORIGAMI_STORYBOOK_BRAND;
 const ComponentDescription = {
 	title: 'Maintained/o-labels',
 	component: ContentLabelTsx,

--- a/components/o-tooltip/src/scss/_brand.scss
+++ b/components/o-tooltip/src/scss/_brand.scss
@@ -1,7 +1,11 @@
 /// Helper for `o-brand` function.
 /// @access private
 @function _oTooltipGet($variables, $from: null) {
-	@return oBrandGet($component: 'o-tooltip', $variables: $variables, $from: $from);
+	@return oBrandGet(
+		$component: 'o-tooltip',
+		$variables: $variables,
+		$from: $from
+	);
 }
 
 /// Helper for `o-brand` function.
@@ -11,41 +15,62 @@
 }
 
 @if oBrandIs('core') {
-	@include oBrandDefine('o-tooltip', 'core', (
-		'variables': (
-			'background-color': oPrivateFoundationGet('o3-color-palette-white'),
-			'foreground-color': null, // inherit by default
-			'close-foreground-color': oPrivateFoundationGet('o3-color-palette-black-60'),
-			'professional': (
-				'background-color': oPrivateFoundationGet('o3-color-palette-slate'),
-				'foreground-color': oPrivateFoundationGet('o3-color-palette-white'),
-				'close-foreground-color': oPrivateFoundationGet('o3-color-palette-white')
-			)
-		),
-		'supports-variants': (
-			'professional'
+	@include oBrandDefine(
+		'o-tooltip',
+		'core',
+		(
+			'variables': (
+				'background-color': oPrivateFoundationGet('o3-color-palette-white'),
+				'foreground-color': null,
+				// inherit by default
+				'close-foreground-color':
+					oPrivateFoundationGet('o3-color-palette-black-60'),
+				'professional': (
+					'background-color':
+						oPrivateFoundationGet('o3-color-palette-slate', 'professional'),
+					'foreground-color':
+						oPrivateFoundationGet('o3-color-palette-white', 'professional'),
+					'close-foreground-color':
+						oPrivateFoundationGet('o3-color-palette-white', 'professional'),
+				),
+			),
+			'supports-variants': (
+				'professional',
+			),
 		)
-	));
+	);
 }
 
 @if oBrandIs('internal') {
-	@include oBrandDefine('o-tooltip', 'internal', (
-		'variables': (
-			'background-color': oPrivateFoundationGet('o3-color-palette-white'),
-			'foreground-color': null, // inherit by default
-			'close-foreground-color': oPrivateFoundationGet('o3-color-palette-black-60')
-		),
-		'supports-variants': ()
-	));
+	@include oBrandDefine(
+		'o-tooltip',
+		'internal',
+		(
+			'variables': (
+				'background-color': oPrivateFoundationGet('o3-color-palette-white'),
+				'foreground-color': null,
+				// inherit by default
+				'close-foreground-color':
+					oPrivateFoundationGet('o3-color-palette-black-60'),
+			),
+			'supports-variants': (),
+		)
+	);
 }
 
 @if oBrandIs('whitelabel') {
-	@include oBrandDefine('o-tooltip', 'whitelabel', (
-		'variables': (
-			'background-color': oPrivateFoundationGet('o3-color-palette-white'),
-			'foreground-color': null, // inherit by default,
-			'close-foreground-color': oPrivateFoundationGet('o3-color-palette-black')
-		),
-		'supports-variants': ()
-	));
+	@include oBrandDefine(
+		'o-tooltip',
+		'whitelabel',
+		(
+			'variables': (
+				'background-color': oPrivateFoundationGet('o3-color-palette-white'),
+				'foreground-color': null,
+				// inherit by default,
+				'close-foreground-color':
+					oPrivateFoundationGet('o3-color-palette-black'),
+			),
+			'supports-variants': (),
+		)
+	);
 }


### PR DESCRIPTION
## Describe your changes
With this PR, the following changes have been implemented:

- **Resolved `o-forms` Storybook Issue:**
The theme control option in Storybook was previously hidden because its enable/disable state depended on the `ORIGAMI_STORYBOOK_BRAND` environment variable. According to the Storybook documentation, only environment variables that start with the prefix `STORYBOOK_` can be used in story files (i.e., .jsx/.tsx files). In the `main.ts` configuration file, using `ORIGAMI_STORYBOOK_BRAND` is acceptable because its value is assigned at build time and is defined. However, in the story files, this variable is not defined. The fix changes all occurrences of `ORIGAMI_STORYBOOK_BRAND` to `STORYBOOK_BRAND` in the story files and sets the `STORYBOOK_BRAND` variable (via the `env` config option in `main.ts`) to use the value of `ORIGAMI_STORYBOOK_BRAND`.

  Other components, such as the header-services story, were also affected by the usage of the 
  ORIGAMI_STORYBOOK_BRAND environment variable. These issues have been fixed as well.

- **Fixed UI bugs in `o-forms` radio Input with professional-inverse theme:**
The radio input UI issues were caused by omitting the specification of the ‘professional’ sub-brand when using the `oPrivateFoundationGet()` function. This PR resolves those bugs.

### Screen records of the o2 Storybook after fixes
#### `core` brand

https://github.com/user-attachments/assets/67d44da7-8771-4858-8f94-ed369f02b1e8


#### `internal` brand

https://github.com/user-attachments/assets/43f74c41-1097-4b31-9f91-caad5787b912


## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
|  |  |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
