### PR TITLE
feat: Adjust `headline` type use-case tokens.

### DIFF
--- a/apps/dictionary/tokens/core/use-case/typography.json
+++ b/apps/dictionary/tokens/core/use-case/typography.json
@@ -55,8 +55,8 @@
         "value": {
           "fontFamily": "{o3.font.family.financier-display}",
           "fontWeight": "{o3.font.weight.light}",
-          "fontSize": "{o3.font.size.3}",
-          "lineHeight": "{o3.font.lineheight.3}"
+          "fontSize": "{o3.font.size.2}",
+          "lineHeight": "{o3.font.lineheight.2}"
         },
         "type": "typography",
         "description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News)."

--- a/apps/dictionary/tokens/sustainable-views/use-case/typography.json
+++ b/apps/dictionary/tokens/sustainable-views/use-case/typography.json
@@ -55,8 +55,8 @@
         "value": {
           "fontFamily": "{o3.font.family.metric}",
           "fontWeight": "{o3.font.weight.regular}",
-          "fontSize": "{o3.font.size-metric2.3}",
-          "lineHeight": "{o3.font.lineheight-metric2.3}"
+          "fontSize": "{o3.font.size-metric2.2}",
+          "lineHeight": "{o3.font.lineheight-metric2.2}"
         },
         "type": "typography",
         "description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News)."

--- a/apps/dictionary/tokens/whitelabel/use-case/typography.json
+++ b/apps/dictionary/tokens/whitelabel/use-case/typography.json
@@ -55,8 +55,8 @@
         "value": {
           "fontFamily": "{o3.font.family.financier-display}",
           "fontWeight": "{o3.font.weight.light}",
-          "fontSize": "{o3.font.size.3}",
-          "lineHeight": "{o3.font.lineheight.3}"
+          "fontSize": "{o3.font.size.2}",
+          "lineHeight": "{o3.font.lineheight.2}"
         },
         "type": "typography",
         "description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News)."

--- a/components/o-private-foundation/src/scss/tokens/core.scss
+++ b/components/o-private-foundation/src/scss/tokens/core.scss
@@ -305,9 +305,9 @@ $tokens: (
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
   'o3-type-headline-sm-font-weight': 300,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-font-size': 1.5rem,
+  'o3-type-headline-sm-font-size': 1.25rem,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-line-height': 1.75rem,
+  'o3-type-headline-sm-line-height': 1.5rem,
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.
   'o3-type-title-lg-font-family': ('metric 2 VF', sans-serif),
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.

--- a/components/o-private-foundation/src/scss/tokens/professional.scss
+++ b/components/o-private-foundation/src/scss/tokens/professional.scss
@@ -178,9 +178,9 @@ $tokens: (
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
   'o3-type-headline-sm-font-weight': 300,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-font-size': 1.5rem,
+  'o3-type-headline-sm-font-size': 1.25rem,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-line-height': 1.75rem,
+  'o3-type-headline-sm-line-height': 1.5rem,
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.
   'o3-type-title-lg-font-family': ('metric 2 VF', sans-serif),
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.

--- a/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
+++ b/components/o-private-foundation/src/scss/tokens/sustainable-views.scss
@@ -237,9 +237,9 @@ $tokens: (
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
   'o3-type-headline-sm-font-weight': 400,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-font-size': 1.5rem,
+  'o3-type-headline-sm-font-size': 1.25rem,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-line-height': 2rem,
+  'o3-type-headline-sm-line-height': 1.75rem,
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.
   'o3-type-title-lg-font-family': ('metric 2 VF', sans-serif),
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.

--- a/components/o-private-foundation/src/scss/tokens/whitelabel.scss
+++ b/components/o-private-foundation/src/scss/tokens/whitelabel.scss
@@ -247,9 +247,9 @@ $tokens: (
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
   'o3-type-headline-sm-font-weight': 300,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-font-size': 1.5rem,
+  'o3-type-headline-sm-font-size': 1.25rem,
   // Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).
-  'o3-type-headline-sm-line-height': 1.75rem,
+  'o3-type-headline-sm-line-height': 1.5rem,
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.
   'o3-type-title-lg-font-family': ('metric 2 VF', sans-serif),
   // Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints.

--- a/components/o-teaser-collection/src/scss/_mixins.scss
+++ b/components/o-teaser-collection/src/scss/_mixins.scss
@@ -146,10 +146,10 @@
 		position: relative;
 
 		&:before {
-			font-family: oPrivateFoundationGet('o3-type-headline-sm-font-family');
-			font-size: oPrivateFoundationGet('o3-type-headline-sm-font-size');
-			font-weight: oPrivateFoundationGet('o3-type-headline-sm-font-weight');
-			line-height: oPrivateFoundationGet('o3-type-headline-sm-line-height');
+			font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+			font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+			font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+			line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 			content: counter(o-teaser-collection-items);
 			position: absolute;
 			top: 0;

--- a/components/o-teaser/src/scss/_mixins.scss
+++ b/components/o-teaser/src/scss/_mixins.scss
@@ -87,6 +87,7 @@
 }
 
 @mixin _oTeaserElementsTimestamp {
+	.o-teaser__timestamp-date,
 	.o-teaser__timestamp {
 		@include _oTeaserTimestamp;
 	}

--- a/components/o-teaser/src/scss/elements/_default.scss
+++ b/components/o-teaser/src/scss/elements/_default.scss
@@ -56,10 +56,10 @@
 /// Tag styling.
 /// Element should be a link, otherwise use _oTeaserMeta
 @mixin _oTeaserTag {
-	font-family: oPrivateFoundationGet('o3-type-detail-font-family');
-	font-size: oPrivateFoundationGet('o3-type-detail-font-size');
-	font-weight: oPrivateFoundationGet('o3-type-detail-font-weight');
-	line-height: oPrivateFoundationGet('o3-type-detail-line-height');
+	font-family: oPrivateFoundationGet('o3-type-body-base-font-family');
+	font-size: oPrivateFoundationGet('o3-type-body-base-font-size');
+	font-weight: oPrivateFoundationGet('o3-type-body-base-font-weight');
+	line-height: oPrivateFoundationGet('o3-type-body-base-line-height');
 
 	color: inherit;
 	text-decoration: none;
@@ -121,7 +121,7 @@
 		}
 
 		&:visited {
-			color: $_o-teaser-muted;
+			// color: $_o-teaser-muted;
 		}
 	}
 }

--- a/components/o-teaser/src/scss/themes/_hero.scss
+++ b/components/o-teaser/src/scss/themes/_hero.scss
@@ -188,7 +188,10 @@
 	}
 
 	.o-teaser__heading {
-		@include oPrivateTypographyDisplay($scale: 4);
+		font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 	}
 
 	.o-teaser__meta:after {
@@ -207,10 +210,10 @@
 /// Hero standalone theme styles
 @mixin _oTeaserHeroStandalone {
 	.o-teaser__heading {
-		font-family: oPrivateFoundationGet('o3-type-headline-sm-font-family');
-		font-size: oPrivateFoundationGet('o3-type-headline-sm-font-size');
-		font-weight: oPrivateFoundationGet('o3-type-headline-sm-font-weight');
-		line-height: oPrivateFoundationGet('o3-type-headline-sm-line-height');
+		font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 	}
 
 	.o-teaser__image-container {

--- a/components/o-teaser/src/scss/themes/_large.scss
+++ b/components/o-teaser/src/scss/themes/_large.scss
@@ -9,10 +9,10 @@
 	}
 
 	.o-teaser__heading {
-		font-family: oPrivateFoundationGet('o3-type-headline-sm-font-family');
-		font-size: oPrivateFoundationGet('o3-type-headline-sm-font-size');
-		font-weight: oPrivateFoundationGet('o3-type-headline-sm-font-weight');
-		line-height: oPrivateFoundationGet('o3-type-headline-sm-line-height');
+		font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 	}
 
 	.o-teaser__standfirst {

--- a/components/o-teaser/src/scss/themes/_package.scss
+++ b/components/o-teaser/src/scss/themes/_package.scss
@@ -19,6 +19,7 @@
 		position: relative;
 		top: -50px;
 		background: inherit;
+		margin-bottom: 0;
 
 		&:after {
 			content: '';
@@ -67,11 +68,30 @@
 		color: oPrivateFoundationGet('o3-color-palette-white');
 
 		a:hover,
-		a:visited,
-		&:focus {
-			$special-report-color: oPrivateFoundationGet(
+		a:visited {
+			$special-report-color: oPrivateFoundationGet('o3-color-palette-white');
+			$special-report-background: oPrivateFoundationGet(
 				'o3-color-palette-claret-70'
 			);
+			color: oPrivateColorsMix(
+				$special-report-color,
+				$special-report-background,
+				$percentage: 78
+			);
+		}
+	}
+
+	.package-teaser__landing-link {
+		color: oPrivateFoundationGet('o3-color-palette-white');
+
+		a {
+			color: inherit;
+		}
+
+		a:hover,
+		a:visited,
+		&:focus {
+			$special-report-color: oPrivateFoundationGet('o3-color-palette-white');
 			$special-report-background: oPrivateFoundationGet(
 				'o3-color-palette-claret-70'
 			);
@@ -105,6 +125,18 @@
 		a:hover,
 		&:focus {
 			color: oPrivateFoundationGet('o3-color-palette-lemon');
+		}
+	}
+
+	.package-teaser__landing-link {
+		a,
+		a:visited {
+			color: oPrivateFoundationGet('o3-color-palette-lemon');
+		}
+
+		a:hover,
+		&:focus {
+			color: oPrivateFoundationGet('o3-color-palette-white');
 		}
 	}
 
@@ -153,12 +185,9 @@
 				$special-report-color: oPrivateFoundationGet(
 					'o3-color-palette-claret-70'
 				);
-				$special-report-background: oPrivateFoundationGet(
-					'o3-color-palette-claret-70'
-				);
 				color: oPrivateColorsMix(
 					$special-report-color,
-					$special-report-background,
+					transparent,
 					$percentage: 78
 				);
 			}

--- a/components/o-teaser/src/scss/themes/_package.scss
+++ b/components/o-teaser/src/scss/themes/_package.scss
@@ -31,7 +31,10 @@
 	}
 
 	.o-teaser__heading {
-		@include oPrivateTypographyDisplay($scale: 4);
+		font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 		color: $_o-teaser-base-color;
 		background: inherit;
 		padding: 20px;

--- a/components/o-teaser/src/scss/themes/_small.scss
+++ b/components/o-teaser/src/scss/themes/_small.scss
@@ -123,7 +123,10 @@
 
 	.o-teaser__heading,
 	.o-teaser__heading a {
-		@include oPrivateTypographyDisplay($scale: 2, $weight: 'medium');
+		font-family: oPrivateFoundationGet('o3-type-headline-sm-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-sm-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-sm-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-sm-line-height');
 		color: oPrivateFoundationGet('o3-color-palette-black');
 	}
 

--- a/components/o-teaser/src/scss/themes/_standard.scss
+++ b/components/o-teaser/src/scss/themes/_standard.scss
@@ -11,7 +11,11 @@
 	.o-teaser__standfirst a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
-		color: oPrivateColorsMix($inverse-color, $inverse-background, $percentage: 60);
+		color: oPrivateColorsMix(
+			$inverse-color,
+			$inverse-background,
+			$percentage: 60
+		);
 	}
 
 	.o-teaser__meta,
@@ -21,8 +25,13 @@
 	}
 
 	.o-teaser__standfirst,
+	.o-teaser__timestamp-date,
 	.o-teaser__timestamp {
-		color: oPrivateColorsMix($inverse-color, $inverse-background, $percentage: 60);
+		color: oPrivateColorsMix(
+			$inverse-color,
+			$inverse-background,
+			$percentage: 60
+		);
 	}
 
 	&.o-teaser--hero .o-teaser__meta:after {
@@ -55,10 +64,17 @@
 /// Opinion background theme - colours background blue and adjust text
 @mixin _oTeaserOpinionBackground {
 	$theme-opinion-background: oPrivateFoundationGet('o3-color-palette-sky');
-	$theme-opinion-color: oPrivateColorsGetTextColor($theme-opinion-background, 100);
+	$theme-opinion-color: oPrivateColorsGetTextColor(
+		$theme-opinion-background,
+		100
+	);
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {
-		color: oPrivateColorsMix($theme-opinion-color, $theme-opinion-background, $percentage: 60);
+		color: oPrivateColorsMix(
+			$theme-opinion-color,
+			$theme-opinion-background,
+			$percentage: 60
+		);
 	}
 
 	&.o-teaser--large {
@@ -83,7 +99,10 @@
 /// Highlight theme - colours background claret and adjust text colours
 @mixin _oTeaserHighlight {
 	$theme-highlight-background: oPrivateFoundationGet('o3-color-palette-claret');
-	$theme-highlight-color: oPrivateColorsGetTextColor($theme-highlight-background, 100);
+	$theme-highlight-color: oPrivateColorsGetTextColor(
+		$theme-highlight-background,
+		100
+	);
 	.o-teaser__heading a:hover,
 	.o-teaser__heading a:focus,
 	.o-teaser__heading a:visited,
@@ -92,17 +111,29 @@
 	.o-teaser__standfirst a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
-		color: oPrivateColorsMix($theme-highlight-color, $theme-highlight-background, $percentage: 73);
+		color: oPrivateColorsMix(
+			$theme-highlight-color,
+			$theme-highlight-background,
+			$percentage: 73
+		);
 	}
 
 	.o-teaser__standfirst,
 	.o-teaser__timestamp,
 	.o-teaser__timestamp-prefix:before {
-		color: oPrivateColorsMix($theme-highlight-color, $theme-highlight-background, $percentage: 80);
+		color: oPrivateColorsMix(
+			$theme-highlight-color,
+			$theme-highlight-background,
+			$percentage: 80
+		);
 	}
 
 	.o-teaser__timestamp-prefix:before {
-		background-color: oPrivateColorsMix(oPrivateFoundationGet('o3-color-palette-white'), $theme-highlight-background, 80);
+		background-color: oPrivateColorsMix(
+			oPrivateFoundationGet('o3-color-palette-white'),
+			$theme-highlight-background,
+			80
+		);
 	}
 
 	&.o-teaser--hero {

--- a/components/o-teaser/src/scss/themes/_top-stories.scss
+++ b/components/o-teaser/src/scss/themes/_top-stories.scss
@@ -6,15 +6,15 @@
 	}
 
 	.o-teaser__heading {
-		font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
-		font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
-		font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
-		line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
+		font-family: oPrivateFoundationGet('o3-type-headline-lg-font-family');
+		font-size: oPrivateFoundationGet('o3-type-headline-lg-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-headline-lg-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-headline-lg-line-height');
 		@include oPrivateGridRespondTo('L') {
-			font-family: oPrivateFoundationGet('o3-type-headline-lg-font-family');
-			font-size: oPrivateFoundationGet('o3-font-size-7');
-			font-weight: oPrivateFoundationGet('o3-type-headline-lg-font-weight');
-			line-height: oPrivateFoundationGet('o3-font-lineheight-7');
+			font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+			font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+			font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+			line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 		}
 	}
 

--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -159,17 +159,10 @@
 		.o-topper__headline {
 			margin: 0;
 			margin-bottom: oPrivateSpacingByIncrement(5);
-			font-family: oPrivateFoundationGet('o3-type-headline-sm-font-family');
-			font-size: oPrivateFoundationGet('o3-type-headline-sm-font-size');
-			font-weight: oPrivateFoundationGet('o3-type-headline-sm-font-weight');
-			line-height: oPrivateFoundationGet('o3-type-headline-sm-line-height');
-
-			@include oPrivateGridRespondTo('S') {
-				font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
-				font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
-				font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
-				line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
-			}
+			font-family: oPrivateFoundationGet('o3-type-headline-md-font-family');
+			font-size: oPrivateFoundationGet('o3-type-headline-md-font-size');
+			font-weight: oPrivateFoundationGet('o3-type-headline-md-font-weight');
+			line-height: oPrivateFoundationGet('o3-type-headline-md-line-height');
 
 			@include oPrivateGridRespondTo('L') {
 				font-family: oPrivateFoundationGet('o3-type-headline-lg-font-family');

--- a/components/o3-editorial-typography/heading.css
+++ b/components/o3-editorial-typography/heading.css
@@ -1,8 +1,8 @@
 .o3-editorial-typography-headline {
-	font-family: var(--o3-type-headline-sm-font-family);
-	font-size: var(--o3-type-headline-sm-font-size);
-	font-weight: var(--o3-type-headline-sm-font-weight);
-	line-height: var(--o3-type-headline-sm-line-height);
+	font-family: var(--o3-type-headline-md-font-family);
+	font-size: var(--o3-type-headline-md-font-size);
+	font-weight: var(--o3-type-headline-md-font-weight);
+	line-height: var(--o3-type-headline-md-line-height);
 }
 
 .o3-editorial-typography-display {
@@ -43,12 +43,6 @@
 }
 
 @media (min-width: 740px) {
-	.o3-editorial-typography-headline {
-		font-size: var(--o3-type-headline-md-font-size);
-		font-weight: var(--o3-type-headline-md-font-weight);
-		line-height: var(--o3-type-headline-md-line-height);
-	}
-
 	.o3-editorial-typography-display {
 		font-size: var(--o3-type-display-md-font-size);
 		font-weight: var(--o3-type-display-md-font-weight);

--- a/components/o3-foundation/src/css/tokens/core/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/_variables.css
@@ -209,8 +209,8 @@
   --o3-type-headline-md-line-height: var(--o3-font-lineheight-5); /* Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-family: var(--o3-font-family-financier-display); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-weight: var(--o3-font-weight-light); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-font-size: var(--o3-font-size-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-font-size: var(--o3-font-size-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-title-lg-font-family: var(--o3-font-family-metric); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-weight: var(--o3-font-weight-semibold); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-size: var(--o3-font-size-metric2-4); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */

--- a/components/o3-foundation/src/css/tokens/core/professional/_variables.css
+++ b/components/o3-foundation/src/css/tokens/core/professional/_variables.css
@@ -220,8 +220,8 @@
   --o3-type-headline-md-line-height: var(--o3-font-lineheight-5); /* Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-family: var(--o3-font-family-financier-display); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-weight: var(--o3-font-weight-light); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-font-size: var(--o3-font-size-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-font-size: var(--o3-font-size-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-title-lg-font-family: var(--o3-font-family-metric); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-weight: var(--o3-font-weight-semibold); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-size: var(--o3-font-size-metric2-4); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */

--- a/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
+++ b/components/o3-foundation/src/css/tokens/sustainable-views/_variables.css
@@ -144,8 +144,8 @@
   --o3-type-headline-md-line-height: var(--o3-font-lineheight-metric2-5); /* Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-family: var(--o3-font-family-metric); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-weight: var(--o3-font-weight-regular); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-font-size: var(--o3-font-size-metric2-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-metric2-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-font-size: var(--o3-font-size-metric2-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-metric2-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-title-lg-font-family: var(--o3-font-family-metric); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-weight: var(--o3-font-weight-semibold); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-size: var(--o3-font-size-metric2-4); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */

--- a/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
+++ b/components/o3-foundation/src/css/tokens/whitelabel/_variables.css
@@ -155,8 +155,8 @@
   --o3-type-headline-md-line-height: var(--o3-font-lineheight-5); /* Use this style for medium screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-family: var(--o3-font-family-financier-display); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-headline-sm-font-weight: var(--o3-font-weight-light); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-font-size: var(--o3-font-size-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
-  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-3); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-font-size: var(--o3-font-size-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
+  --o3-type-headline-sm-line-height: var(--o3-font-lineheight-2); /* Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News). */
   --o3-type-title-lg-font-family: var(--o3-font-family-metric); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-weight: var(--o3-font-weight-semibold); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */
   --o3-type-title-lg-font-size: var(--o3-font-size-metric2-4); /* Use for the main page title H1 in functional pages such as account and settings. Use across all breakpoints. */

--- a/libraries/o3-tooling-token/build/core/_variables.js
+++ b/libraries/o3-tooling-token/build/core/_variables.js
@@ -2658,8 +2658,8 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "24px",
-		"originalValue": "{o3.font.size.3}",
+		"value": "20px",
+		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {
@@ -2677,8 +2677,8 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "28px",
-		"originalValue": "{o3.font.lineheight.3}",
+		"value": "24px",
+		"originalValue": "{o3.font.lineheight.2}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/core/professional/_variables.js
+++ b/libraries/o3-tooling-token/build/core/professional/_variables.js
@@ -2896,8 +2896,8 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "24px",
-		"originalValue": "{o3.font.size.3}",
+		"value": "20px",
+		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {
@@ -2915,8 +2915,8 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "28px",
-		"originalValue": "{o3.font.lineheight.3}",
+		"value": "24px",
+		"originalValue": "{o3.font.lineheight.2}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/sustainable-views/_variables.js
+++ b/libraries/o3-tooling-token/build/sustainable-views/_variables.js
@@ -1461,8 +1461,8 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "24px",
-		"originalValue": "{o3.font.size-metric2.3}",
+		"value": "20px",
+		"originalValue": "{o3.font.size-metric2.2}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {
@@ -1480,8 +1480,8 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "32px",
-		"originalValue": "{o3.font.lineheight-metric2.3}",
+		"value": "28px",
+		"originalValue": "{o3.font.lineheight-metric2.2}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {

--- a/libraries/o3-tooling-token/build/whitelabel/_variables.js
+++ b/libraries/o3-tooling-token/build/whitelabel/_variables.js
@@ -2735,8 +2735,8 @@ export default {
 },
 	"o3-type-headline-sm-font-size": {
 		"shortName": "fontSize",
-		"value": "24px",
-		"originalValue": "{o3.font.size.3}",
+		"value": "20px",
+		"originalValue": "{o3.font.size.2}",
 		"type": "dimension",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {
@@ -2754,8 +2754,8 @@ export default {
 },
 	"o3-type-headline-sm-line-height": {
 		"shortName": "lineHeight",
-		"value": "28px",
-		"originalValue": "{o3.font.lineheight.3}",
+		"value": "24px",
+		"originalValue": "{o3.font.lineheight.2}",
 		"type": "number",
 		"description": "Use this style for small screens headlines in smaller teasers and text only toppers (eg. Opinion and News).",
 		"attributes": {


### PR DESCRIPTION
The design team have reported we are missing a smaller `headline` use-case for some key product areas. We believe we can reduce the size of the headlines without too big an impact.

We have had to update o-teaser and the o-editorial typography header component, which is used in article page toppers.

```
Headline small usecase reduced:
headline-sm -> scale 3 to scale 2 -> 20/24px, weight 300
headline-md -> scale 5 -> 32/32px, weight 300
headline-lg -> scale 6 -> 40/40px, weight 300

Heading component (aka topper headline):
mobile (sm) -> headline-sm to  headline-md -> 32/32px, weight 300 (increase against o2, 28/32px)
tablet (md) -> headline-md -> 32/32px, weight 300 (same as o2)
desktop (lg) -> headline-lg -> 40/40px, weight 300 (same as o2)
```

Long term, Erika (design team) would like to move to use `display` only in toppers.

This PR also includes a number of minor fixes to teaser colours.


<img width="1280" alt="Screenshot 2025-04-10 at 16 09 36" src="https://github.com/user-attachments/assets/e92c67cf-de90-4131-ae48-6edbe5bd48aa" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 09 51" src="https://github.com/user-attachments/assets/fcb99311-9322-4546-bd64-f8efd818c182" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 09" src="https://github.com/user-attachments/assets/71e51b77-fb39-4cbc-9ae3-933bc4979470" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 19" src="https://github.com/user-attachments/assets/062379a3-45cb-4e1e-b8a5-0c0685e9821f" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 25" src="https://github.com/user-attachments/assets/d6fce84a-5fe4-4a6f-af32-cabc83658f84" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 28" src="https://github.com/user-attachments/assets/57b355d5-a0f4-458f-a442-9b84d62f71c6" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 39" src="https://github.com/user-attachments/assets/1c81108c-7ecb-4d6d-8450-ba95e838f77c" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 48" src="https://github.com/user-attachments/assets/542d0867-3a3c-4886-9eaa-17ef31c75b78" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 52" src="https://github.com/user-attachments/assets/ac192e9f-a721-41e2-9194-a5f433eab497" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 10 58" src="https://github.com/user-attachments/assets/f00984a8-44ee-4b33-8fef-feb28367a6b6" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 11 12" src="https://github.com/user-attachments/assets/018e8354-ade0-4d7a-8e0e-3e1b3ca36693" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 11 33" src="https://github.com/user-attachments/assets/ba97ad22-b5fe-40f1-93a8-810d101e7560" />
<img width="1280" alt="Screenshot 2025-04-10 at 16 11 39" src="https://github.com/user-attachments/assets/b5eff1d6-1cd0-40e1-af91-0c49859c8b78" />
