### PR TITLE
ci-2644 docs: update comment on response usage

### DIFF
--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -19,8 +19,9 @@ export default {
 			if (response.ok) {
 				return response.json();
 			} else {
-			// TODO: CI-1493 to remove after subscriber only is not behind a flag
+			// TODO: CI-1493 to remove after subscriber only is not behind a flag - check on Q&A usage, see below
 			// response for when onlySubscribers is false and user is signed in but has no display name
+			// also used in live Q&A when a user is signed in but has no display name
 				if (response.status === 409) {
 					return { userHasValidSession: true };
 				}


### PR DESCRIPTION
## Describe your changes
Updating a comment that suggests something can be removed when a ticket is done, but it has other dependencies

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [CI-2644](https://financialtimes.atlassian.net/browse/CI-2644) | n/a |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[CI-2644]: https://financialtimes.atlassian.net/browse/CI-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ