### PR TITLE
fix: use correct editorial typography private token

### DIFF
--- a/components/o3-editorial-typography/details.css
+++ b/components/o3-editorial-typography/details.css
@@ -95,12 +95,12 @@ a.o3-editorial-typography-byline-author[data-o3-theme='inverse'] {
 	font-weight: var(--o3-type-label-font-weight);
 	line-height: var(--o3-type-label-line-height);
 	text-transform: uppercase;
-	color: var(--_o3-editorial-typography-byline-timestamp);
+	color: var(--_o3-editorial-typography-byline-timestamp-color);
 }
 
 [data-o3-theme='inverse'] .o3-editorial-typography-byline-timestamp,
 .o3-editorial-typography-byline-timestamp[data-o3-theme='inverse'] {
-	color: var(--_o3-editorial-typography-byline-timestamp-inverse);
+	color: var(--_o3-editorial-typography-byline-timestamp-inverse-color);
 }
 
 .o3-editorial-typography-pullquote {


### PR DESCRIPTION
## Describe your changes

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
