### PR TITLE
feat: introduce utility class for outside page icon to o3-button

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -551,6 +551,10 @@
 	--o3-button-icon: var(--o3-icon-grid);
 }
 
+.o3-button-icon.o3-button-icon--outside-page::before {
+	--o3-button-icon: var(--o3-icon-outside-page);
+}
+
 .o3-button-icon.o3-button-icon--upload::before {
 	--o3-button-icon: var(--o3-icon-upload);
 }

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -15,6 +15,7 @@ export interface ButtonProps {
 		| 'chevron-up'
 		| 'edit'
 		| 'download'
+		| 'outside-page'
 		| 'search'
 		| 'refresh'
 		| 'cross'


### PR DESCRIPTION
## Describe your changes

Introduces a utility class to allow the outside-page icon to be used on o3 buttons

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
