### PR TITLE
feat: Add sparkles helper class for o3-button

### DIFF
--- a/components/o3-button/README.md
+++ b/components/o3-button/README.md
@@ -116,22 +116,9 @@ Make buttons full width using a [container query](https://developer.mozilla.org/
 
 To add an icon to your button add the class `o3-button-icon` and `o3-button-icon--{icon-name}`.
 
-A limited number of button icons are available. Limiting the number of icons keeps the CSS bundle smaller. If you need an icon button that we don't currently support, please contact the Origami team:
+A limited number of button icons are available. Limiting the number of icons keeps the CSS bundle smaller.
 
-- chevron-left
-- chevron-right
-- upload
-- tick
-- plus
-- warning
-- chevron-down
-- chevron-up
-- edit
-- download
-- search
-- refresh
-- cross
-- calendar
+If you need an icon button that we don't currently support, please contact the Origami team.
 
 ```html
 <button

--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -598,3 +598,6 @@
 .o3-button-icon.o3-button-icon--scroll-to::before {
 	--o3-button-icon: var(--o3-icon-scroll-to);
 }
+.o3-button-icon.o3-button-icon--sparkles::before {
+	--o3-button-icon: var(--o3-icon-sparkles);
+}

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -21,7 +21,8 @@ export interface ButtonProps {
 		| 'cross'
 		| 'link'
 		| 'calendar'
-		| 'scroll-to';
+		| 'scroll-to'
+		| 'sparkles';
 	iconPosition?: 'start' | 'end';
 	iconOnly?: boolean;
 	visuallyHideDisabled?: boolean;


### PR DESCRIPTION
This is used for Ask AI / FT Professional features.

I removed a list of icons from the README which was out of date. Instead rely on Storybook and the TSX template.