### PR TITLE
fix: handle email in use

### DIFF
--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -19,11 +19,17 @@ export default {
 			if (response.ok) {
 				return response.json();
 			} else {
-			// TODO: CI-1493 to remove after subscriber only is not behind a flag - check on Q&A usage, see below
-			// response for when onlySubscribers is false and user is signed in but has no display name
-			// also used in live Q&A when a user is signed in but has no display name
+				// TODO: CI-1493 to remove after subscriber only is not behind a flag - check on Q&A usage, see below
+				// response for when onlySubscribers is false and user is signed in but has no display name
+				// also used in live Q&A when a user is signed in but has no display name
 				if (response.status === 409) {
 					return { userHasValidSession: true };
+				}
+
+				// some users have coral accounts associated to old FT accounts that are using the same email address
+				// we need to remove this email before they can sign in to the new account
+				if (response.status === 403) {
+					return { emailInUse: true };
 				}
 
 				// user is not signed in or session token is invalid

--- a/components/o-comments/test/methods/stream/authenticate-user.js
+++ b/components/o-comments/test/methods/stream/authenticate-user.js
@@ -166,6 +166,19 @@ export default function authenticateUser () {
 			});
 		});
 
+		describe("emailInUse is true", () => {
+			it("sets this.emailInUse to true", () => {
+				fetchJWTStub.resolves({
+					emailInUse: true
+				});
+
+				const stream = new Stream();
+				return stream.authenticateUser()
+					.then(() => {
+						proclaim.isTrue(stream.emailInUse);
+					});
+			});
+		});
 	});
 
 	describe("fetchJsonWebToken returns if user is registered , trial or subscriber", () => { 


### PR DESCRIPTION
## Describe your changes
We have found a bug that causes users that have previously had an FT account to comment with their old coral account. We will be adding an additional check to the auth endpoint in next-comments-api, which will return a 403 when an old coral account is found. This PR checks for this status and returns a user-friendly error to the client.


## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| Parent: [CI-2823](https://financialtimes.atlassian.net/browse/CI-2823) |  |
| Sub: [CI-2827](https://financialtimes.atlassian.net/browse/CI-2827) | |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[CI-2823]: https://financialtimes.atlassian.net/browse/CI-2823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CI-2827]: https://financialtimes.atlassian.net/browse/CI-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ