### PR TITLE
fix: Remove _o-topper__tag anchor colour unset

### DIFF
--- a/components/o-topper/src/scss/_elements.scss
+++ b/components/o-topper/src/scss/_elements.scss
@@ -96,10 +96,7 @@
 
 @include _oTopperDefineOnce(tag) {
 	%_o-topper__tag {
-		// Non-linked tags and author tags are the same colour as the body copy.
-		@if not is-superselector('a', '#{&}') {
-			color: oPrivateFoundationGet('o3-color-use-case-body-text');
-		}
+		color: unset;
 
 		font-family: oPrivateFoundationGet('o3-type-body-highlight-font-family');
 		font-size: oPrivateFoundationGet('o3-type-body-highlight-font-size');
@@ -119,14 +116,6 @@
 
 			&:hover {
 				color: oPrivateFoundationGet('o3-color-palette-claret-30');
-			}
-		}
-		color: unset;
-
-		@at-root a#{&} {
-			color: unset;
-			&:hover {
-				color: unset;
 			}
 		}
 	}


### PR DESCRIPTION
This is causing issues for downstream apps. It is not clear why. Perhaps some source order issue because of the placeholder and/or use of at-root. It appears safe to remove the anchor colour unset as other topper themes define the colour of their links explicitly, as demoed in the screenshots below 


<img width="737" alt="Screenshot 2025-04-29 at 10 45 58" src="https://github.com/user-attachments/assets/f1e83f57-bcaa-492f-95da-5b44be401044" />
<img width="1039" alt="Screenshot 2025-04-29 at 10 45 41" src="https://github.com/user-attachments/assets/a22e2320-90c5-4381-89a4-70db3ddee49c" />
<img width="670" alt="Screenshot 2025-04-29 at 10 45 31" src="https://github.com/user-attachments/assets/9ec1910b-d756-4109-9762-189126719c64" />
<img width="681" alt="Screenshot 2025-04-29 at 10 45 25" src="https://github.com/user-attachments/assets/9b3dd73f-517c-4f18-a574-a6935a52c7b4" />
