### PR TITLE
feat: introduce utility class for settings icon to o3-button

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -565,6 +565,11 @@
 .o3-button-icon.o3-button-icon--tick::before {
 	--o3-button-icon: var(--o3-icon-tick);
 }
+
+.o3-button-icon.o3-button-icon--settings::before {
+	--o3-button-icon: var(--o3-icon-settings);
+}
+
 .o3-button-icon.o3-button-icon--search::before {
 	--o3-button-icon: var(--o3-icon-search);
 }

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -18,6 +18,7 @@ export interface ButtonProps {
 		| 'notification'
 		| 'outside-page'
 		| 'search'
+		| 'settings'
 		| 'refresh'
 		| 'cross'
 		| 'link'


### PR DESCRIPTION
## Describe your changes

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
