### PR TITLE
fix: Revert o-topper breaking markup change

### DIFF
--- a/components/o-topper/README.md
+++ b/components/o-topper/README.md
@@ -18,7 +18,7 @@ Check out [how to include Origami components in your project](https://origami.ft
 The basic markup structure for a topper will look something like this:
 
 ```html
-<div class="o-topper o-topper--basic o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--basic o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/german-election" class="o-topper__topic"
@@ -81,16 +81,16 @@ These themes affect the layout and visual style of all elements. See the [demos]
 These colors affect the background of the `.o-topper__background` and `.o-topper__visual` elements, and select a contrasting text color for all other elements.
 
 ```
-.o-topper--color-o3-color-palette-paper
-.o-topper--color-o3-color-palette-wheat
-.o-topper--color-o3-color-palette-white
-.o-topper--color-o3-color-palette-black
-.o-topper--color-o3-color-palette-claret
-.o-topper--color-o3-color-palette-oxford
-.o-topper--color-o3-color-palette-slate
-.o-topper--color-o3-color-palette-crimson
-.o-topper--color-o3-color-palette-sky
-.o-topper--color-o3-color-palette-matisse
+.o-topper--color-paper
+.o-topper--color-wheat
+.o-topper--color-white
+.o-topper--color-black
+.o-topper--color-claret
+.o-topper--color-oxford
+.o-topper--color-slate
+.o-topper--color-crimson
+.o-topper--color-sky
+.o-topper--color-matisse
 ```
 
 ### Modifiers
@@ -158,9 +158,9 @@ To include o-topper styles granularly specify which elements, themes, and colour
 		),
 		'colors': (
 			'o3-color-palette-white',
-			// .o-topper--color-o3-color-palette-white
+			// .o-topper--color-white
 			'o3-color-palette-black',
-			// .o-topper--color-o3-color-palette-black
+			// .o-topper--color-black
 			'o3-color-palette-claret',
 			'o3-color-palette-oxford',
 			'o3-color-palette-paper',

--- a/components/o-topper/demos/src/basic.mustache
+++ b/components/o-topper/demos/src/basic.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--basic o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--basic o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/german-election" class="o-topper__topic">German election</a>

--- a/components/o-topper/demos/src/branded.mustache
+++ b/components/o-topper/demos/src/branded.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--branded o-topper--color-o3-color-palette-wheat">
+<div class="o-topper o-topper--branded o-topper--color-wheat">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/stream/c65ad97e-ccf0-4b6a-b34a-0e03744a9431" class="o-topper__brand">

--- a/components/o-topper/demos/src/centered.mustache
+++ b/components/o-topper/demos/src/centered.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--centered o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--centered o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/german-election" class="o-topper__topic">German election</a>

--- a/components/o-topper/demos/src/deep-landscape-left.mustache
+++ b/components/o-topper/demos/src/deep-landscape-left.mustache
@@ -1,7 +1,7 @@
 <h2>
 Text Shadow + Slate background
 </h2>
-<div class="o-topper o-topper--deep-landscape o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--deep-landscape o-topper--color-slate">
 	<div class="o-topper__content o-topper__content--text-shadow">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
@@ -28,7 +28,7 @@ Text Shadow + Slate background
 
 <h2>Background Box + Slate background</h2>
 
-<div class="o-topper o-topper--deep-landscape o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--deep-landscape o-topper--color-slate">
 	<div class="o-topper__content o-topper__content--background-box">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
@@ -55,7 +55,7 @@ Text Shadow + Slate background
 
 <h2>White background</h2>
 
-<div class="o-topper o-topper--deep-landscape o-topper--color-o3-color-palette-white">
+<div class="o-topper o-topper--deep-landscape o-topper--color-white">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>
@@ -76,7 +76,7 @@ Text Shadow + Slate background
 
 <h2>Background Box + White background</h2>
 
-<div class="o-topper o-topper--deep-landscape o-topper--color-o3-color-palette-white">
+<div class="o-topper o-topper--deep-landscape o-topper--color-white">
 	<div class="o-topper__content o-topper__content--text-shadow o-topper__content--background-box">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>

--- a/components/o-topper/demos/src/deep-portrait.mustache
+++ b/components/o-topper/demos/src/deep-portrait.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--deep-portrait o-topper--color-o3-color-palette-claret">
+<div class="o-topper o-topper--deep-portrait o-topper--color-claret">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="/uk-general-election" class="o-topper__topic">
@@ -22,9 +22,9 @@
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/81988afb-56ea-47d3-832d-8f06eb2e7cc3.jpg?source=origami-build-tools&amp;fit=scale-down&amp;quality=highest&amp;width=800">
 		</picture>
 		<figcaption class="o-topper__image-caption">
-			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo 
-			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo 
-			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo 
+			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo
+			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo
+			Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo
 		</figcaption>
 	</figure>
 </div>

--- a/components/o-topper/demos/src/full-bleed-image-center.mustache
+++ b/components/o-topper/demos/src/full-bleed-image-center.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-image-center o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--full-bleed-image-center o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>

--- a/components/o-topper/demos/src/full-bleed-image-left.mustache
+++ b/components/o-topper/demos/src/full-bleed-image-left.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-image-left o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--full-bleed-image-left o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>

--- a/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset-right-rail.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-offset o-topper--right-rail o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--full-bleed-offset o-topper--right-rail o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/comment/the-big-read" class="o-topper__brand">

--- a/components/o-topper/demos/src/full-bleed-offset.mustache
+++ b/components/o-topper/demos/src/full-bleed-offset.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-offset o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--full-bleed-offset o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/comment/the-big-read" class="o-topper__brand">

--- a/components/o-topper/demos/src/live-blog-package.mustache
+++ b/components/o-topper/demos/src/live-blog-package.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-offset o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--full-bleed-offset o-topper--color-paper">
     <div class="o-topper__content">
         <div class="o-topper__tags"></div>
         <h1 class="o-topper__headline o-topper__headline--large"><span class="article-classifier__gap">Coronavirus

--- a/components/o-topper/demos/src/opinion.mustache
+++ b/components/o-topper/demos/src/opinion.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-o3-color-palette-sky">
+<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-sky">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<span class="o-topper__opinion-genre">

--- a/components/o-topper/demos/src/pa11y.mustache
+++ b/components/o-topper/demos/src/pa11y.mustache
@@ -1,5 +1,5 @@
 <div id="demo-container">
-<div class="o-topper o-topper--basic o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--basic o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/german-election" class="o-topper__topic">German election</a>
@@ -12,7 +12,7 @@
 
 	<div class="o-topper__background"></div>
 </div>
-<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--color-o3-color-palette-wheat">
+<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--color-wheat">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/stream/c65ad97e-ccf0-4b6a-b34a-0e03744a9431" class="o-topper__brand">
@@ -52,7 +52,7 @@
 		</picture>
 	</figure>
 </div>
-<div class="o-topper o-topper--full-bleed-offset o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--full-bleed-offset o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/comment/the-big-read" class="o-topper__brand">
@@ -80,7 +80,7 @@
 		<figcaption class="o-topper__image-credit">© Bloomberg</figcaption>
 	</figure>
 </div>
-<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-o3-color-palette-sky">
+<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-sky">
 	<div class="o-topper__content">
 		<div class="o-topper__tags tags--large">
 			<span class="o-topper__opinion-genre">
@@ -108,7 +108,7 @@
 
 	<div class="o-topper__background"></div>
 </div>
-<div class="o-topper o-topper--split-text-left o-topper--package o-topper--package-extra o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--package-extra o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/ft-series" class="o-topper__topic tags--large">FT Series</a>
@@ -132,7 +132,7 @@
 		<figcaption class="o-topper__image-credit">© FT montage</figcaption>
 	</figure>
 </div>
-<div class="o-topper o-topper--split-text-left o-topper--package o-topper--color-o3-color-palette-wheat">
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--color-wheat">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/ft-guides" class="o-topper__topic tags--large">FT Guides</a>
@@ -153,7 +153,7 @@
 		</picture>
 	</figure>
 </div>
-<div class="o-topper o-topper--split-text-center o-topper--color-o3-color-palette-black">
+<div class="o-topper o-topper--split-text-center o-topper--color-black">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/comment/the-big-read" class="o-topper__brand">
@@ -183,7 +183,7 @@
 		<figcaption class="o-topper__image-credit">© Ollanski</figcaption>
 	</figure>
 </div>
-<div class="o-topper o-topper--split-text-left o-topper--color-o3-color-palette-claret">
+<div class="o-topper o-topper--split-text-left o-topper--color-claret">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="/uk-general-election" class="o-topper__topic">

--- a/components/o-topper/demos/src/package-extra.mustache
+++ b/components/o-topper/demos/src/package-extra.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--split-text-left o-topper--package o-topper--package-extra o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--package-extra o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/ft-series" class="o-topper__topic tags--large">FT Series</a>

--- a/components/o-topper/demos/src/package-special-report.mustache
+++ b/components/o-topper/demos/src/package-special-report.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--split-text-left o-topper--package o-topper--special-report o-topper--color-o3-color-palette-claret">
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--special-report o-topper--color-claret">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/reports" class="o-topper__topic tags--large">Special Report</a>
@@ -17,9 +17,9 @@
 	<figure class="o-topper__visual">
 		<picture class="o-topper__picture">
 			<source media="(min-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:0eac32d0-1cec-4f20-a183-d9f4370309fb?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067 1067w">
-			
+
 			<source media="(max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:63ebca9e-3091-4cde-a958-33ee6405c741?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=720 720w">
-			
+
 			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:0eac32d0-1cec-4f20-a183-d9f4370309fb?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067">
 		</picture>
 	</figure>

--- a/components/o-topper/demos/src/package.mustache
+++ b/components/o-topper/demos/src/package.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--split-text-left o-topper--package o-topper--color-o3-color-palette-wheat">
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--color-wheat">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/ft-guides" class="o-topper__topic tags--large">FT Guides</a>

--- a/components/o-topper/demos/src/podcast.mustache
+++ b/components/o-topper/demos/src/podcast.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-o3-color-palette-slate">
+<div class="o-topper o-topper--branded o-topper--has-headshot o-topper--opinion o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/topics/themes/US_Treasury_Bonds" class="o-topper__topic">

--- a/components/o-topper/demos/src/right-rail.mustache
+++ b/components/o-topper/demos/src/right-rail.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--basic o-topper--right-rail o-topper--color-o3-color-palette-paper">
+<div class="o-topper o-topper--basic o-topper--right-rail o-topper--color-paper">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/german-election" class="o-topper__topic">German election</a>

--- a/components/o-topper/demos/src/split-text-center.mustache
+++ b/components/o-topper/demos/src/split-text-center.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--split-text-center o-topper--color-o3-color-palette-black">
+<div class="o-topper o-topper--split-text-center o-topper--color-black">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/comment/the-big-read" class="o-topper__brand">

--- a/components/o-topper/demos/src/split-text-left.mustache
+++ b/components/o-topper/demos/src/split-text-left.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--split-text-left o-topper--color-o3-color-palette-claret">
+<div class="o-topper o-topper--split-text-left o-topper--color-claret">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="/uk-general-election" class="o-topper__topic">

--- a/components/o-topper/src/scss/_mixins.scss
+++ b/components/o-topper/src/scss/_mixins.scss
@@ -285,13 +285,13 @@
 
 @mixin _oTopperColors($colors) {
 	@each $color in $colors {
-		$color: if(
+		$o3-color-name: if(
 			$color == 'matisse',
 			'o3-color-palette-#{$color}-blue',
 			'o3-color-palette-#{$color}'
 		);
 		.o-topper--color-#{$color} {
-			@include _oTopperColor($color);
+			@include _oTopperColor($o3-color-name);
 		}
 	}
 }


### PR DESCRIPTION
o-tooper v7 renamed classes o-topper--color-[color] to o-topper--color-o3-color-palette-[color]. This was a breaking change we did not need to make, and it was not documented in the migration guide. As we are working closely with the migration team we can safely revert this.