### PR TITLE
fix: Improve focus styling.

### DIFF
--- a/components/o3-foundation/src/css/components/focus.css
+++ b/components/o3-foundation/src/css/components/focus.css
@@ -1,41 +1,42 @@
 /* stylelint-disable value-list-comma-space-after */
 /* focus styles */
-:focus {
-	box-shadow: var(--o3-focus-use-case-outline-color);
-	outline: 0;
+
+:focus,
+:focus-visible {
+	--_o3-focus-rings: var(--o3-focus-use-case-ring-inner),
+		var(--o3-focus-use-case-ring-outer);
+	--_o3-focus-outline: var(--o3-focus-use-case-outline-color);
 }
 
 [data-o3-theme='inverse']:focus,
-:where([data-o3-theme='inverse']) :focus {
-	box-shadow: var(--o3-focus-use-case-outline-inverse-color);
-}
-
-input:focus,
-button:focus,
-select:focus,
-textarea:focus {
-	box-shadow: var(--o3-focus-use-case-ring-inner),
-		var(--o3-focus-use-case-ring-outer);
-	outline: 0;
-}
-
-[data-o3-theme='inverse'] input:focus,
-[data-o3-theme='inverse'] button:focus,
-[data-o3-theme='inverse'] select:focus,
-[data-o3-theme='inverse'] textarea:focus,
-:where([data-o3-theme='inverse']) input:focus,
-:where([data-o3-theme='inverse']) button:focus,
-:where([data-o3-theme='inverse']) select:focus,
-:where([data-o3-theme='inverse']) textarea:focus {
-	box-shadow: var(--o3-focus-use-case-ring-inverse-inner),
+:where([data-o3-theme='inverse']) :focus,
+[data-o3-theme='inverse']:focus-visible,
+:where([data-o3-theme='inverse']) :focus-visible {
+	--_o3-focus-outline: var(--o3-focus-use-case-outline-inverse-color);
+	--_o3-focus-rings: var(--o3-focus-use-case-ring-inverse-inner),
 		var(--o3-focus-use-case-ring-inverse-outer);
 }
 
-/* focus-visible styles */
+:focus {
+	box-shadow: var(--_o3-focus-outline);
+	outline: 0;
+}
+
+.o3-apply-focus-rings:focus,
+button:focus,
+[class^='o3'][class*='button']:focus,
+input:focus,
+select:focus,
+textarea:focus {
+	box-shadow: var(--_o3-focus-rings);
+	outline: 0;
+}
 
 @supports selector(:focus-visible) {
-	input:focus,
+	.o3-apply-focus-rings:focus,
 	button:focus,
+	[class^='o3'][class*='button']:focus,
+	input:focus,
 	select:focus,
 	textarea:focus,
 	:focus {
@@ -43,76 +44,24 @@ textarea:focus {
 	}
 
 	:focus-visible {
-		box-shadow: var(--o3-focus-use-case-outline-color);
+		box-shadow: var(--_o3-focus-outline);
 		outline: 0;
 	}
 
-	[data-o3-theme='inverse']:focus-visible,
-	:where([data-o3-theme='inverse']) :focus-visible {
-		box-shadow: var(--o3-focus-use-case-outline-inverse-color);
-	}
-
-	input:focus-visible,
+	.o3-apply-focus-rings:focus-visible,
 	button:focus-visible,
+	[class^='o3'][class*='button']:focus-visible,
+	input:focus-visible,
 	select:focus-visible,
 	textarea:focus-visible {
-		box-shadow: var(--o3-focus-use-case-ring-inner),
-			var(--o3-focus-use-case-ring-outer);
+		box-shadow: var(--_o3-focus-rings);
 		outline: 0;
-	}
-
-	[data-o3-theme='inverse'] input:focus-visible,
-	[data-o3-theme='inverse'] button:focus-visible,
-	[data-o3-theme='inverse'] select:focus-visible,
-	[data-o3-theme='inverse'] textarea:focus-visible,
-	:where([data-o3-theme='inverse']) input:focus-visible,
-	:where([data-o3-theme='inverse']) button:focus-visible,
-	:where([data-o3-theme='inverse']) select:focus-visible,
-	:where([data-o3-theme='inverse']) textarea:focus-visible {
-		box-shadow: var(--o3-focus-use-case-ring-inverse-inner),
-			var(--o3-focus-use-case-ring-inverse-outer);
 	}
 }
 
 /* revert focus styles */
+.o3-revert-focus:focus-visible,
 .o3-revert-focus:focus {
 	outline: revert;
 	box-shadow: revert;
-}
-
-.o3-revert-focus:focus-visible {
-	outline: revert;
-	box-shadow: revert;
-}
-
-/* add focus rings on specific element */
-
-.o3-apply-focus-rings:focus {
-	box-shadow: var(--o3-focus-use-case-ring-inner),
-		var(--o3-focus-use-case-ring-outer);
-	outline: 0;
-}
-
-[data-o3-theme='inverse'].o3-apply-focus-rings:focus,
-:where([data-o3-theme='inverse']) .o3-apply-focus-rings:focus {
-	box-shadow: var(--o3-focus-use-case-ring-inverse-inner),
-		var(--o3-focus-use-case-ring-inverse-outer);
-}
-
-@supports selector(:focus-visible) {
-	.o3-apply-focus-rings:focus {
-		box-shadow: unset;
-	}
-
-	.o3-apply-focus-rings:focus-visible {
-		box-shadow: var(--o3-focus-use-case-ring-inner),
-			var(--o3-focus-use-case-ring-outer);
-		outline: 0;
-	}
-
-	[data-o3-theme='inverse'].o3-apply-focus-rings:focus-visible,
-	:where([data-o3-theme='inverse']) .o3-apply-focus-rings:focus-visible {
-		box-shadow: var(--o3-focus-use-case-ring-inverse-inner),
-			var(--o3-focus-use-case-ring-inverse-outer);
-	}
 }


### PR DESCRIPTION
- A button with inverse theme applied should not show a focus state on click where focus-visible is supported.
- Refactor to reduce repeated declarations.
- Apply ring focus states to any element with a class which begins with "o3" and includes "button". This includes o3-button but is more generic, making me feel warm fuzzy feelings by _technically_ avoiding a dependency (o3-foundation) knowing about its dependent (o3-button), or repeating styles in o3-button. I do foresee this potentially being helpful for other buttons like concept buttons / pills.