### PR TITLE
chore: move some user logic in it is own model

### DIFF
--- a/components/o-comments/src/js/models/user.js
+++ b/components/o-comments/src/js/models/user.js
@@ -1,0 +1,45 @@
+class User {
+    constructor() {
+        this.isSubscribed = false;
+        this.isTrialist = false;
+    }
+
+    /**
+     * Setter for multiple user properties at once.
+     *
+     * @param {Object} [userProperties={}] - An object containing user status flags.
+     * @param {boolean} [userProperties.isSubscribed=false] - Subscription status.
+     * @param {boolean} [userProperties.isTrialist=false] - Trial status.
+     * @param {boolean} [userProperties.isRegistered=false] - Registration status.
+     */
+    setUser(userProperties) {
+        this.isSubscribed = userProperties?.isSubscribed || false;
+        this.isTrialist = userProperties?.isTrialist || false;
+        this.isRegistered = userProperties?.isRegistered || false;
+    }
+
+    /**
+    * Get the access level for users who are not subscribed.
+    *
+    * @returns {'trialist' | 'registered' | 'anonymous'} The access level string.
+    */
+    getNonSubscribersAccessLevel() {
+        this.isTrialist
+            ? 'trialist'
+            : this.isRegistered
+                ? 'registered'
+                : 'anonymous';
+    }
+
+    /**
+    * Getter for subscription status.
+    *
+    * @returns {boolean} True if the user is subscribed, otherwise false.
+    */
+    isSubscribed() {
+        return this.isSubscribed;
+    }
+
+}
+
+export default User;

--- a/components/o-comments/test/models/user.test.js
+++ b/components/o-comments/test/models/user.test.js
@@ -1,0 +1,58 @@
+import User from '../../src/js/models/user';
+
+describe('User', () => {
+    let user;
+
+    beforeEach(() => {
+        user = new User();
+    });
+
+    test('should initialize with default values', () => {
+        expect(user.isSubscribed).toBe(false);
+        expect(user.isTrialist).toBe(false);
+        expect(user.isRegistered).toBe(false);
+    });
+
+    test('setUser should update isSubscribed, isTrialist, and isRegistered', () => {
+        const props = { isSubscribed: true, isTrialist: true, isRegistered: true };
+        user.setUser(props);
+        expect(user.isSubscribed).toBe(true);
+        expect(user.isTrialist).toBe(true);
+        expect(user.isRegistered).toBe(true);
+    });
+
+    test('setUser with missing properties should default to false', () => {
+        user.setUser({});
+        expect(user.isSubscribed).toBe(false);
+        expect(user.isTrialist).toBe(false);
+        expect(user.isRegistered).toBe(false);
+    });
+
+    describe('getNonSubscribersAccessLevel', () => {
+        test('returns "trialist" when user is on trial', () => {
+            user.setUser({ isTrialist: true, isRegistered: true });
+            expect(user.getNonSubscribersAccessLevel()).toBe('trialist');
+        });
+
+        test('returns "registered" when user is registered but not a trialist', () => {
+            user.setUser({ isTrialist: false, isRegistered: true });
+            expect(user.getNonSubscribersAccessLevel()).toBe('registered');
+        });
+
+        test('returns "anonymous" when user is neither trialist nor registered', () => {
+            user.setUser({ isTrialist: false, isRegistered: false });
+            expect(user.getNonSubscribersAccessLevel()).toBe('anonymous');
+        });
+    });
+
+    describe('isSubscribed getter', () => {
+        test('returns false by default', () => {
+            expect(user.isSubscribed()).toBe(false);
+        });
+
+        test('returns true after setting isSubscribed to true', () => {
+            user.setUser({ isSubscribed: true });
+            expect(user.isSubscribed()).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
To help us refactor this package in the future we may start moving some complexity from presentational element like Stream.
In this PR I suggest that we start having a user model that split a little bit of logic away from Stream