### PR TITLE
fix: ci-2617 add export to main.js

### DIFF
--- a/components/o-comments/main.js
+++ b/components/o-comments/main.js
@@ -1,4 +1,4 @@
-import Comments from './src/js/comments.js';
+import Comments, { auth } from './src/js/comments.js';
 
 const constructAll = function () {
 	Comments.init();
@@ -10,3 +10,4 @@ if (typeof document !== 'undefined') {
 }
 
 export default Comments;
+export { auth };


### PR DESCRIPTION
Pass the export from comments.js up to main.js so we can import from `@financial-times/o-comments`, not the js file.

## Additional context
[JIRA ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2617)

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
