### PR TITLE
chore: switch default sb theme

### DIFF
--- a/apps/o2-storybook-composition/.storybook/manager.ts
+++ b/apps/o2-storybook-composition/.storybook/manager.ts
@@ -1,0 +1,6 @@
+import {addons} from '@storybook/manager-api';
+import {themes} from '@storybook/theming';
+
+addons.setConfig({
+	theme: themes.light,
+});

--- a/apps/o2-storybook/.storybook/manager.ts
+++ b/apps/o2-storybook/.storybook/manager.ts
@@ -1,0 +1,6 @@
+import {addons} from '@storybook/manager-api';
+import {themes} from '@storybook/theming';
+
+addons.setConfig({
+	theme: themes.light,
+});

--- a/apps/o3-storybook/.storybook/manager.ts
+++ b/apps/o3-storybook/.storybook/manager.ts
@@ -1,0 +1,6 @@
+import {addons} from '@storybook/manager-api';
+import {themes} from '@storybook/theming';
+
+addons.setConfig({
+	theme: themes.light,
+});


### PR DESCRIPTION
Helps visibility for people who use inverted colours to support visibility, as the default theme for components is also light.