### PR TITLE
feat: Add an outside-page icon helper to o3-button

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -610,3 +610,6 @@
 .o3-button-icon.o3-button-icon--sparkles::before {
 	--o3-button-icon: var(--o3-icon-sparkles);
 }
+.o3-button-icon.o3-button-icon--outside-page::before {
+	--o3-button-icon: var(--o3-icon-outside-page);
+}

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -24,6 +24,7 @@ export interface ButtonProps {
 		| 'link'
 		| 'calendar'
 		| 'scroll-to'
+		| 'outside-page'
 		| 'sparkles';
 	iconPosition?: 'start' | 'end';
 	iconOnly?: boolean;


### PR DESCRIPTION
Initially used within a chrome extension 