### PR TITLE
feat!: ci-2617 type declaration file for o-comments

### DIFF
--- a/components/o-comments/README.md
+++ b/components/o-comments/README.md
@@ -163,6 +163,8 @@ const Comments = new oComments(commentsElement, {
 
 Add `useStagingEnvironment: true` to the options if you want to use Coral staging environment.
 
+This component includes a [TypeScript declaration file](`types/index.d.ts`). The types are automatically included when you import the o-comments component in a TypeScript project.
+
 If you want to initialise every comment stream or count element on the page (based on the presence of the attribute: `data-o-component="o-comments"`):
 
 ```js

--- a/components/o-comments/package.json
+++ b/components/o-comments/package.json
@@ -15,6 +15,7 @@
 	"license": "MIT",
 	"type": "module",
 	"browser": "main.js",
+	"types": "types/index.d.ts",
 	"scripts": {
 		"start": "npx serve ./demos/local",
 		"build": "bash ../../scripts/component/build.bash",

--- a/components/o-comments/src/js/utils/auth.js
+++ b/components/o-comments/src/js/utils/auth.js
@@ -1,4 +1,19 @@
+/**
+ * Authentication utilities for o-comments
+ * Provides methods to handle user authentication with the comments API
+ */
 export default {
+	/**
+	 * Fetches a JSON Web Token for the current user from the comments API
+	 *
+	 * @param {Object} options - Configuration options
+	 * @param {string} [options.commentsAPIUrl] - URL of the comments API (defaults to https://comments-api.ft.com)
+	 * @param {string} [options.commentsAuthUrl] - Custom URL for authentication
+	 * @param {boolean} [options.onlySubscribers] - Whether to limit comments to subscribers only
+	 * @param {string} [options.displayName] - Display name to use for the user
+	 * @param {boolean} [options.useStagingEnvironment] - Whether to use the staging environment
+	 * @returns {Promise<Object>} Promise resolving to auth response with token and user status
+	 */
 	fetchJsonWebToken: function fetchJsonWebToken (options = {}) {
 
 		const commentsAPIUrl = options?.commentsAPIUrl || 'https://comments-api.ft.com';
@@ -14,6 +29,7 @@ export default {
 			url.searchParams.append('staging', '1');
 		}
 
+		// Make authenticated request to the comments API
 		return fetch(url, { credentials: 'include' }).then(response => {
 		// user is signed in
 			if (response.ok) {

--- a/components/o-comments/types/index.d.ts
+++ b/components/o-comments/types/index.d.ts
@@ -1,0 +1,190 @@
+// Type definitions for o-comments
+
+/**
+ * Options that can be passed when running the auth script
+ */
+export interface AuthOptions {
+/**
+   * URL of the comments API. Defaults to 'https://comments-api.ft.com'
+   */
+  commentsAPIUrl?: string;
+  
+  /**
+   * Custom URL for authentication. Defaults to '/user/auth'
+   */
+  commentsAuthUrl?: string;
+  
+  /**
+   * Whether to allow only subscribers to comment
+   */
+  onlySubscribers?: boolean;
+  
+  /**
+   * Display name to use for the user
+   */
+  displayName?: string;
+  
+  /**
+   * Whether to use the Coral staging environment
+   */
+  useStagingEnvironment?: boolean;
+}
+
+/**
+ * Options that can be passed when initializing the o-comments component
+ */
+export interface CommentsOptions extends AuthOptions {
+  /**
+   * Article identifier. Required.
+   */
+  articleId: string;
+  
+  /**
+   * URL of the article. Required.
+   */
+  articleUrl: string;
+  
+  /**
+   * Title of the article. Required.
+   */
+  title: string;
+  
+  /**
+   * Additional class name to add to the comments container created by Coral's script
+   */
+  addClass?: string;
+  
+  /**
+   * Selector for the scrollable container
+   */
+  scrollContainer?: string;
+  
+  /**
+   * Type of asset (e.g., "article", "video", etc.)
+   */
+  assetType?: string;
+  
+  /**
+   * Whether to disable o-tracking integration
+   */
+  disableOTracking?: boolean;
+  
+  /**
+   * Additional options that may be passed to the component
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * Options that can be passed when fetching the comment count
+ */
+export interface CountOptions {
+    /**
+     * Article identifier
+     */
+    articleId: string;
+
+    /**
+     * URL of the comments API. Defaults to 'https://comments-api.ft.com'
+     */
+    commentsAPIUrl?: string;
+
+    /**
+     * Whether to use the Coral staging environment
+     */
+    useStagingEnvironment?: boolean;
+    
+    /**
+     * Additional options for count fetching
+     */
+    [key: string]: unknown;
+}
+
+/**
+ * Authentication response object
+ */
+export interface AuthResponse {
+  /**
+   * Whether the user has a valid session
+   */
+  userHasValidSession?: boolean;
+  
+  /**
+   * Whether the user is subscribed
+   */
+  isSubscribed?: boolean;
+  
+  /**
+   * Whether the user is on a trial
+   */
+  isTrialist?: boolean;
+  
+  /**
+   * Whether the user is registered only
+   */
+  isRegistered?: boolean;
+
+  /**
+   * JWT token (can be empty string if none exists)
+   */
+  token: string;
+  /**
+   * User's display name (can be empty string if none exists)
+   */
+  displayName : string;
+
+  /**
+   * Additional properties that may be in the response
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * Authentication utilities
+ */
+export interface Auth {
+  /**
+   * Fetches a JWT token for the current user
+   * 
+   * @param options - Options for the JWT fetch
+   * @returns A promise that resolves to the auth response
+   */
+    fetchJsonWebToken(options?: AuthOptions): Promise<AuthResponse>;
+}
+
+/**
+ * Comments component main class
+ */
+export default class Comments {
+  
+  /**
+   * Create a new Comments instance
+   * 
+   * @param rootEl - Element to initialize the comments in
+   * @param opts - Options for configuring the component
+   */
+  constructor(rootEl: HTMLElement, opts?: CommentsOptions);
+
+  /**
+   * Get the comment count for a specific article
+   * 
+   * @param id - Article ID to fetch the count for
+   * @param options - Options for the count fetch
+   * @returns Promise resolving to the count
+   */
+  static getCount(id: string, options?: CountOptions): Promise<number>;
+  
+  /**
+   * Initialize the component
+   * 
+   * @param rootEl - The root element to initialize the component in, or a CSS selector for the root element
+   * @param opts - An options object for configuring the component
+   * @returns Comments instance(s)
+   */
+  static init(rootEl?: HTMLElement | string, opts?: CommentsOptions): Comments | Comments[];
+}
+
+/**
+ * Authentication utility
+ */
+export const auth: Auth;


### PR DESCRIPTION
## Describe your changes
Adding a type declaration file for o-comments

Pushing out as a major release, because if another app also has types and they don't match, this will cause issues

## Additional context

[JIRA ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2617)

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [x] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
