### PR TITLE
fix: ci-2748 pass through options to display name validation

### DIFF
--- a/components/o-comments/src/js/stream.js
+++ b/components/o-comments/src/js/stream.js
@@ -184,7 +184,7 @@ class Stream {
 
 			if (displayNameForm) {
 				displayNameForm.addEventListener('submit', (event) => {
-					displayName.promptValidation(event)
+					displayName.promptValidation(event, this.options)
 						.then(displayName => {
 							overlay.close();
 							this.authenticateUser(displayName)


### PR DESCRIPTION
## Describe your changes
Found a quite old bug where options were not passed into display name prompt validation, resulting in always hitting comments API prod

## Additional context
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2748)

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
