### PR TITLE
fix: ci-2809 o-topper fix text under headshot

### DIFF
--- a/components/o-topper/src/scss/themes/_branded.scss
+++ b/components/o-topper/src/scss/themes/_branded.scss
@@ -20,12 +20,14 @@
 
 @mixin _oTopperHasHeadshot {
 	.o-topper__tags,
-	.o-topper__standfirst {
+	.o-topper__standfirst,
+	.o-topper__summary {
 		box-sizing: border-box;
 	}
 
 	.o-topper__headline--no-standfirst,
-	.o-topper__standfirst {
+	.o-topper__standfirst,
+	.o-topper__summary {
 		padding-right: calc(
 			#{$_o-topper-headshot-width} + #{oPrivateSpacingByName('s2')}
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -798,7 +798,7 @@
 				"@financial-times/o3-editorial-typography": "^3.0.2",
 				"@financial-times/o3-figma-sb-links": "^0.0.0",
 				"@financial-times/o3-form": "^0.5.0",
-				"@financial-times/o3-foundation": "^3.5.2",
+				"@financial-times/o3-foundation": "^3.0.1",
 				"@financial-times/o3-social-sign-in": "^2.0.0",
 				"@financial-times/o3-tooling-token": "^0.0.0",
 				"@financial-times/o3-tooltip": "^3.0.0",
@@ -2133,7 +2133,7 @@
 		},
 		"components/o-comments": {
 			"name": "@financial-times/o-comments",
-			"version": "12.1.1",
+			"version": "13.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-forms": "^10.0.0",
@@ -2928,7 +2928,7 @@
 		},
 		"components/o3-foundation": {
 			"name": "@financial-times/o3-foundation",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o3-figma-sb-links": "^0.0.0",


### PR DESCRIPTION
## Describe your changes
Fixes the issue where a standfirst had been copied into the summary body in spark, but summary bodies aren't accounted for when inside an opinion box with a headshot in it.

## Additional context
https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2809

BEFORE - ignore the green checkmark
![Screenshot 2025-05-27 at 17 49 03](https://github.com/user-attachments/assets/87bbb5ff-d74b-4cb9-95d5-315f172f19d5)

AFTER
![Screenshot 2025-05-27 at 17 48 50](https://github.com/user-attachments/assets/2723160c-33e5-48c3-8055-1282baf09552)


## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
