### PR TITLE
fix: o-teaser timestamp margin

### DIFF
--- a/components/o-teaser/src/scss/_mixins.scss
+++ b/components/o-teaser/src/scss/_mixins.scss
@@ -89,7 +89,20 @@
 @mixin _oTeaserElementsTimestamp {
 	.o-teaser__timestamp-date,
 	.o-teaser__timestamp {
-		@include _oTeaserTimestamp;
+		font-family: oPrivateFoundationGet('o3-type-label-font-family');
+		font-size: oPrivateFoundationGet('o3-type-label-font-size');
+		font-weight: oPrivateFoundationGet('o3-type-label-font-weight');
+		line-height: oPrivateFoundationGet('o3-type-label-line-height');
+		text-transform: oPrivateFoundationGet('o3-type-label-text-case');
+		color: $_o-teaser-muted;
+		display: block;
+		// Moves timestamp to the bottom when stretched modifier is used
+		margin-top: auto;
+	}
+
+	.o-teaser__timestamp {
+		// and ensures there is always some gap above
+		padding-top: oPrivateSpacingByName('s4');
 	}
 
 	@include _oTeaserTimestampVariants;

--- a/components/o-teaser/src/scss/elements/_timestamp.scss
+++ b/components/o-teaser/src/scss/elements/_timestamp.scss
@@ -1,18 +1,3 @@
-/// Timestamp base styles
-@mixin _oTeaserTimestamp {
-	font-family: oPrivateFoundationGet('o3-type-label-font-family');
-	font-size: oPrivateFoundationGet('o3-type-label-font-size');
-	font-weight: oPrivateFoundationGet('o3-type-label-font-weight');
-	line-height: oPrivateFoundationGet('o3-type-label-line-height');
-	text-transform: oPrivateFoundationGet('o3-type-label-text-case');
-	color: $_o-teaser-muted;
-	display: block;
-	// Moves timestamp to the bottom when stretched modifier is used
-	margin-top: auto;
-	// and ensures there is always some gap above
-	padding-top: oPrivateSpacingByName('s4');
-}
-
 /// Timestamp variant styles adding coloured prefixes.
 /// Includes keyframe declaration so must be used outside of
 /// a selector


### PR DESCRIPTION
Introduced here by applying `_oTeaserTimestamp` to both `o-teaser__timestamp-date` and `o-teaser__timestamp`. https://github.com/Financial-Times/origami/pull/2072/files#diff-1433f756fbfb1d8889f0bd544114575c0c533fbfcf275892c916f37ff36556aeR89

A little confusing as the relationship is not clear through BEM as usual with Origami components. Here is example markup from prod:

```html
<div class="o-teaser__timestamp o-teaser__timestamp--"><time class="o-teaser__timestamp-date o-date" data-o-component="o-date" data-o-date-format="time-ago-limit-4-hours" datetime="2025-05-29T08:02:08+0000" title="May 29 2025 9:02 am" data-o-date-js="">2 hours ago</time></div>
```