### PR TITLE
feat: (o-tracking) ci-2846  add custom to allowed tracking attributes…

### DIFF
--- a/libraries/o-tracking/src/javascript/events/component-view.js
+++ b/libraries/o-tracking/src/javascript/events/component-view.js
@@ -7,6 +7,7 @@ const TRACKING_ATTRIBUTES = [
 	'type',
 	'subtype',
 	'component',
+	'custom',
 ];
 
 const decorateEventData = (eventData, viewedEl, opts) => {

--- a/libraries/o-tracking/test/core/session.test.js
+++ b/libraries/o-tracking/test/core/session.test.js
@@ -66,8 +66,9 @@ describe('Core.Session', function () {
 			const currentTimestamp = new Date().getTime();
 			const timestamp = getSession().timestamp;
 			proclaim.isNumber(timestamp);
-			proclaim.isTrue(timestamp >= currentTimestamp);
-			proclaim.isTrue(timestamp <= currentTimestamp + 1000); // within 1 second
+			// sometimes timestamp is a few ms behind currentTimeStamp and sometimes ahead, the point is that it is close enough
+			proclaim.greaterThanOrEqual(timestamp, currentTimestamp - 5);
+			proclaim.lessThanOrEqual(timestamp, currentTimestamp + 1000); // allow up to 1 second
 		})
 
 		it('should generate a new timestamp if session has expired', (done) => {

--- a/libraries/o-tracking/test/core/session.test.js
+++ b/libraries/o-tracking/test/core/session.test.js
@@ -64,7 +64,10 @@ describe('Core.Session', function () {
 
 		it('should generate timestamp for session', () => {
 			const currentTimestamp = new Date().getTime();
-			proclaim.equal(currentTimestamp, getSession().timestamp)
+			const timestamp = getSession().timestamp;
+			proclaim.isNumber(timestamp);
+			proclaim.isTrue(timestamp >= currentTimestamp);
+			proclaim.isTrue(timestamp <= currentTimestamp + 1000); // within 1 second
 		})
 
 		it('should generate a new timestamp if session has expired', (done) => {


### PR DESCRIPTION
… for component-view

## Describe your changes
Allows to add the custom fields to component view contexts, so we can use them as per https://docs.google.com/spreadsheets/d/16d2-uDM8rhz1wSKOkoupcpPDRFQ8AtY1GxVJpt74vY4/edit?gid=1318706009#gid=1318706009

## Additional context

[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-2734)

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
