### PR TITLE
feat: Change the o3-foundation font styles for Chromatic label testing

### DIFF
--- a/components/o3-foundation/src/css/components/fonts.css
+++ b/components/o3-foundation/src/css/components/fonts.css
@@ -2,8 +2,8 @@
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=Metric2-VF&system_code=origami&font_format=woff2')
 		format('woff2-variations');
-	font-family: 'metric 2 VF';
-	font-weight: 300 800;
+	font-family: 'arial';
+	font-weight: 600 600;
 	font-style: normal;
 	font-display: swap;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1749,7 +1749,7 @@
 		},
 		"components/o-topper": {
 			"name": "@financial-times/o-topper",
-			"version": "7.0.5",
+			"version": "7.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-normalise": "^3.3.2"
@@ -2908,7 +2908,7 @@
 		},
 		"libraries/o-tracking": {
 			"name": "@financial-times/o-tracking",
-			"version": "4.7.0",
+			"version": "4.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"ftdomdelegate": "^5"


### PR DESCRIPTION
## Describe your changes

A test PR to check the Chromatic workflow

## Additional context

JIRA ticket
[OR-1491](https://financialtimes.atlassian.net/browse/OR-1491) 

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
