### PR TITLE
fix: Allow 200+ financier display weights.

### DIFF
--- a/components/o-private-foundation/main.scss
+++ b/components/o-private-foundation/main.scss
@@ -5,7 +5,7 @@
 @import './src/scss/o-spacing/main';
 @import './src/scss/o-colors/main';
 @import './src/scss/o-normalise/main';
-@import "./src/scss/o-icons/main";
+@import './src/scss/o-icons/main';
 @import './src/scss/o-visual-effects/main';
 @import './src/scss/o-buttons/main';
 @import './src/scss/o-grid/main';
@@ -25,7 +25,7 @@
 		src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=FinancierDisplay-VF&system_code=origami&font_format=woff2')
 			format('woff2-variations');
 		font-family: 'financier display VF';
-		font-weight: 300 800;
+		font-weight: 200 800;
 		font-style: normal;
 		font-display: swap;
 	}

--- a/components/o3-foundation/src/css/brands/core.css
+++ b/components/o3-foundation/src/css/brands/core.css
@@ -4,7 +4,7 @@
 @font-face {
 	src: url('https://www.ft.com/__origami/service/build/v3/font?version=1.13&font_name=FinancierDisplay-VF&system_code=origami&font_format=woff2') format('woff2-variations');
 	font-family: 'financier display VF';
-	font-weight: 300 800;
+	font-weight: 200 800;
 	font-style: normal;
 	font-display: swap;
 }


### PR DESCRIPTION
So the editorial team can apply a very special 242 weight instead of 300.