### PR TITLE
[OR-1522] Fix O3 Storybook READMEs

### DIFF
--- a/components/o3-foundation/stories/core/color-readme.mdx
+++ b/components/o3-foundation/stories/core/color-readme.mdx
@@ -13,7 +13,7 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-o3-fou
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Colours')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Colours')[1].split('\n## ')[0]}</Markdown>
 
 ## Storybook stories
 

--- a/components/o3-foundation/stories/core/grid-readme.mdx
+++ b/components/o3-foundation/stories/core/grid-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-o3-fou
 
 ## Markup
 
-<Markdown>{Readme.split('### Grid')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Grid')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/icon-readme.mdx
+++ b/components/o3-foundation/stories/core/icon-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-o3-fou
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Icons')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Icons')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/proffesional/color-readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/color-readme.mdx
@@ -13,7 +13,7 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-profes
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Colours')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Colours')[1].split('\n## ')[0]}</Markdown>
 
 ## Storybook stories
 

--- a/components/o3-foundation/stories/core/proffesional/grid-readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/grid-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-profes
 
 ## Markup
 
-<Markdown>{Readme.split('### Grid')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Grid')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/proffesional/icon-readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/icon-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-profes
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Icons')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Icons')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/proffesional/readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/readme.mdx
@@ -6,40 +6,45 @@ import Readme from '../../../README.md';
 # o3-foundation
 
 - [o3-foundation](#o3-foundation)
-  - [Usage](#usage)
-    - [Normalisation](#normalisation)
-    - [Stacking with z-index](#stacking-with-z-index)
-    - [Focus rings](#focus-rings)
-    - [Fonts](#fonts)
-    - [Helper classes](#helper-classes)
+  - [Normalisation](#normalisation)
+  - [Stacking with z-index](#stacking-with-z-index)
+  - [Focus rings](#focus-rings)
+  - [Fonts](#fonts)
+  - [Helper classes](#helper-classes)
   - [Migration](#migration)
   - [Contact](#contact)
   - [Licence](#licence)
 
-## Usage
+## Normalisation
 
-<Markdown>{Readme.split('## Usage')[1].split('\n### ')[0]}</Markdown>
-### Normalisation
-<Markdown>{Readme.split('### Normalisation')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Normalisation')[1].split('\n## ')[0]}</Markdown>
 
-### Stacking with z-index
+## Stacking with z-index
 
 <Markdown>
-	{Readme.split('### Stacking with z-index')[1].split('\n### ')[0]}
+	{Readme.split('## Stacking with z-index')[1].split('\n## ')[0]}
 </Markdown>
 
-### Focus rings
+## Focus rings
 
-<Markdown>{Readme.split('### Focus rings')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Focus rings')[1].split('\n## ')[0]}</Markdown>
 
-### Fonts
+## Fonts
 
-<Markdown>{Readme.split('### Fonts')[1].split('\n### ')[0]}</Markdown>
-### Helper classes
-<Markdown>{Readme.split('### Helper classes')[1].split('\n## ')[0]}</Markdown>
+<Markdown>{Readme.split('## Fonts')[1].split('\n## ')[0]}</Markdown>
+
+## Helper classes
+
+<Markdown>{Readme.split('## Helper classes')[1].split('\n## ')[0]}</Markdown>
+
 ## Migration
+
 <Markdown>{Readme.split('## Migration')[1].split('\n## ')[0]}</Markdown>
+
 ## Contact
+
 <Markdown>{Readme.split('## Contact')[1].split('\n## ')[0]}</Markdown>
+
 ## Licence
+
 <Markdown>{Readme.split('## Licence')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/proffesional/spacing-readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/spacing-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-profes
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Spacing')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Spacing')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/proffesional/typography-readme.mdx
+++ b/components/o3-foundation/stories/core/proffesional/typography-readme.mdx
@@ -15,4 +15,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-profes
 
 See our documentation website for [detailed information](https://origami-beta.ft.com/guides/typography/).
 
-<Markdown>{Readme.split('### Typography')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Typography')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/readme.mdx
+++ b/components/o3-foundation/stories/core/readme.mdx
@@ -6,40 +6,45 @@ import Readme from '../../README.md';
 # o3-foundation
 
 - [o3-foundation](#o3-foundation)
-  - [Usage](#usage)
-    - [Normalisation](#normalisation)
-    - [Stacking with z-index](#stacking-with-z-index)
-    - [Focus rings](#focus-rings)
-    - [Fonts](#fonts)
-    - [Helper classes](#helper-classes)
+  - [Normalisation](#normalisation)
+  - [Stacking with z-index](#stacking-with-z-index)
+  - [Focus rings](#focus-rings)
+  - [Fonts](#fonts)
+  - [Helper classes](#helper-classes)
   - [Migration](#migration)
   - [Contact](#contact)
   - [Licence](#licence)
 
-## Usage
+## Normalisation
 
-<Markdown>{Readme.split('## Usage')[1].split('\n### ')[0]}</Markdown>
-### Normalisation
-<Markdown>{Readme.split('### Normalisation')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Normalisation')[1].split('\n## ')[0]}</Markdown>
 
-### Stacking with z-index
+## Stacking with z-index
 
 <Markdown>
-	{Readme.split('### Stacking with z-index')[1].split('\n### ')[0]}
+	{Readme.split('## Stacking with z-index')[1].split('\n## ')[0]}
 </Markdown>
 
-### Focus rings
+## Focus rings
 
-<Markdown>{Readme.split('### Focus rings')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Focus rings')[1].split('\n## ')[0]}</Markdown>
 
-### Fonts
+## Fonts
 
-<Markdown>{Readme.split('### Fonts')[1].split('\n### ')[0]}</Markdown>
-### Helper classes
-<Markdown>{Readme.split('### Helper classes')[1].split('\n## ')[0]}</Markdown>
+<Markdown>{Readme.split('## Fonts')[1].split('\n## ')[0]}</Markdown>
+
+## Helper classes
+
+<Markdown>{Readme.split('## Helper classes')[1].split('\n## ')[0]}</Markdown>
+
 ## Migration
+
 <Markdown>{Readme.split('## Migration')[1].split('\n## ')[0]}</Markdown>
+
 ## Contact
+
 <Markdown>{Readme.split('## Contact')[1].split('\n## ')[0]}</Markdown>
+
 ## Licence
+
 <Markdown>{Readme.split('## Licence')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/spacing-readme.mdx
+++ b/components/o3-foundation/stories/core/spacing-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-o3-fou
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Spacing')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Spacing')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/core/typography-readme.mdx
+++ b/components/o3-foundation/stories/core/typography-readme.mdx
@@ -15,4 +15,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/core-o3-fou
 
 See our documentation website for [detailed information](https://origami-beta.ft.com/guides/typography/).
 
-<Markdown>{Readme.split('### Typography')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Typography')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/internal/color-readme.mdx
+++ b/components/o3-foundation/stories/internal/color-readme.mdx
@@ -13,7 +13,7 @@ Check out [how to include o3-foundation in your project](?path=/docs/internal-o3
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Colours')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Colours')[1].split('\n## ')[0]}</Markdown>
 
 ## Storybook stories
 

--- a/components/o3-foundation/stories/internal/grid-readme.mdx
+++ b/components/o3-foundation/stories/internal/grid-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/internal-o3
 
 ## Markup
 
-<Markdown>{Readme.split('### Grid')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Grid')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/internal/icon-readme.mdx
+++ b/components/o3-foundation/stories/internal/icon-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/internal-o3
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Icons')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Icons')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/internal/readme.mdx
+++ b/components/o3-foundation/stories/internal/readme.mdx
@@ -6,40 +6,45 @@ import Readme from '../../README.md';
 # o3-foundation
 
 - [o3-foundation](#o3-foundation)
-  - [Usage](#usage)
-    - [Normalisation](#normalisation)
-    - [Stacking with z-index](#stacking-with-z-index)
-    - [Focus rings](#focus-rings)
-    - [Fonts](#fonts)
-    - [Helper classes](#helper-classes)
+  - [Normalisation](#normalisation)
+  - [Stacking with z-index](#stacking-with-z-index)
+  - [Focus rings](#focus-rings)
+  - [Fonts](#fonts)
+  - [Helper classes](#helper-classes)
   - [Migration](#migration)
   - [Contact](#contact)
   - [Licence](#licence)
 
-## Usage
+## Normalisation
 
-<Markdown>{Readme.split('## Usage')[1].split('\n### ')[0]}</Markdown>
-### Normalisation
-<Markdown>{Readme.split('### Normalisation')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Normalisation')[1].split('\n## ')[0]}</Markdown>
 
-### Stacking with z-index
+## Stacking with z-index
 
 <Markdown>
-	{Readme.split('### Stacking with z-index')[1].split('\n### ')[0]}
+	{Readme.split('## Stacking with z-index')[1].split('\n## ')[0]}
 </Markdown>
 
-### Focus rings
+## Focus rings
 
-<Markdown>{Readme.split('### Focus rings')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Focus rings')[1].split('\n## ')[0]}</Markdown>
 
-### Fonts
+## Fonts
 
-<Markdown>{Readme.split('### Fonts')[1].split('\n### ')[0]}</Markdown>
-### Helper classes
-<Markdown>{Readme.split('### Helper classes')[1].split('\n## ')[0]}</Markdown>
+<Markdown>{Readme.split('## Fonts')[1].split('\n## ')[0]}</Markdown>
+
+## Helper classes
+
+<Markdown>{Readme.split('## Helper classes')[1].split('\n## ')[0]}</Markdown>
+
 ## Migration
+
 <Markdown>{Readme.split('## Migration')[1].split('\n## ')[0]}</Markdown>
+
 ## Contact
+
 <Markdown>{Readme.split('## Contact')[1].split('\n## ')[0]}</Markdown>
+
 ## Licence
+
 <Markdown>{Readme.split('## Licence')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/internal/spacing-readme.mdx
+++ b/components/o3-foundation/stories/internal/spacing-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/internal-o3
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Spacing')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Spacing')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/internal/typography-readme.mdx
+++ b/components/o3-foundation/stories/internal/typography-readme.mdx
@@ -15,4 +15,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/internal-o3
 
 See our documentation website for [detailed information](https://origami-beta.ft.com/guides/typography/).
 
-<Markdown>{Readme.split('### Typography')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Typography')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/sustainable-views/color-readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/color-readme.mdx
@@ -13,7 +13,7 @@ Check out [how to include o3-foundation in your project](?path=/docs/sustainable
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Colours')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Colours')[1].split('\n## ')[0]}</Markdown>
 
 ## Storybook stories
 

--- a/components/o3-foundation/stories/sustainable-views/grid-readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/grid-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/sustainable
 
 ## Markup
 
-<Markdown>{Readme.split('### Grid')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Grid')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/sustainable-views/icon-readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/icon-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/sustainable
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Icons')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Icons')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/sustainable-views/readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/readme.mdx
@@ -6,40 +6,45 @@ import Readme from '../../README.md';
 # o3-foundation
 
 - [o3-foundation](#o3-foundation)
-  - [Usage](#usage)
-    - [Normalisation](#normalisation)
-    - [Stacking with z-index](#stacking-with-z-index)
-    - [Focus rings](#focus-rings)
-    - [Fonts](#fonts)
-    - [Helper classes](#helper-classes)
+  - [Normalisation](#normalisation)
+  - [Stacking with z-index](#stacking-with-z-index)
+  - [Focus rings](#focus-rings)
+  - [Fonts](#fonts)
+  - [Helper classes](#helper-classes)
   - [Migration](#migration)
   - [Contact](#contact)
   - [Licence](#licence)
 
-## Usage
+## Normalisation
 
-<Markdown>{Readme.split('## Usage')[1].split('\n### ')[0]}</Markdown>
-### Normalisation
-<Markdown>{Readme.split('### Normalisation')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Normalisation')[1].split('\n## ')[0]}</Markdown>
 
-### Stacking with z-index
+## Stacking with z-index
 
 <Markdown>
-	{Readme.split('### Stacking with z-index')[1].split('\n### ')[0]}
+	{Readme.split('## Stacking with z-index')[1].split('\n## ')[0]}
 </Markdown>
 
-### Focus rings
+## Focus rings
 
-<Markdown>{Readme.split('### Focus rings')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Focus rings')[1].split('\n## ')[0]}</Markdown>
 
-### Fonts
+## Fonts
 
-<Markdown>{Readme.split('### Fonts')[1].split('\n### ')[0]}</Markdown>
-### Helper classes
-<Markdown>{Readme.split('### Helper classes')[1].split('\n## ')[0]}</Markdown>
+<Markdown>{Readme.split('## Fonts')[1].split('\n## ')[0]}</Markdown>
+
+## Helper classes
+
+<Markdown>{Readme.split('## Helper classes')[1].split('\n## ')[0]}</Markdown>
+
 ## Migration
+
 <Markdown>{Readme.split('## Migration')[1].split('\n## ')[0]}</Markdown>
+
 ## Contact
+
 <Markdown>{Readme.split('## Contact')[1].split('\n## ')[0]}</Markdown>
+
 ## Licence
+
 <Markdown>{Readme.split('## Licence')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/sustainable-views/spacing-readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/spacing-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/sustainable
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Spacing')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Spacing')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/sustainable-views/typography-readme.mdx
+++ b/components/o3-foundation/stories/sustainable-views/typography-readme.mdx
@@ -15,4 +15,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/sustainable
 
 See our documentation website for [detailed information](https://origami-beta.ft.com/guides/typography/).
 
-<Markdown>{Readme.split('### Typography')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Typography')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/whitelabel/color-readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/color-readme.mdx
@@ -13,7 +13,7 @@ Check out [how to include o3-foundation in your project](?path=/docs/whitelabel-
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Colours')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Colours')[1].split('\n## ')[0]}</Markdown>
 
 ## Storybook stories
 

--- a/components/o3-foundation/stories/whitelabel/grid-readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/grid-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/whitelabel-
 
 ## Markup
 
-<Markdown>{Readme.split('### Grid')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Grid')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/whitelabel/icon-readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/icon-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/whitelabel-
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Icons')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Icons')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/whitelabel/readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/readme.mdx
@@ -6,40 +6,45 @@ import Readme from '../../README.md';
 # o3-foundation
 
 - [o3-foundation](#o3-foundation)
-  - [Usage](#usage)
-    - [Normalisation](#normalisation)
-    - [Stacking with z-index](#stacking-with-z-index)
-    - [Focus rings](#focus-rings)
-    - [Fonts](#fonts)
-    - [Helper classes](#helper-classes)
+  - [Normalisation](#normalisation)
+  - [Stacking with z-index](#stacking-with-z-index)
+  - [Focus rings](#focus-rings)
+  - [Fonts](#fonts)
+  - [Helper classes](#helper-classes)
   - [Migration](#migration)
   - [Contact](#contact)
   - [Licence](#licence)
 
-## Usage
+## Normalisation
 
-<Markdown>{Readme.split('## Usage')[1].split('\n### ')[0]}</Markdown>
-### Normalisation
-<Markdown>{Readme.split('### Normalisation')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Normalisation')[1].split('\n## ')[0]}</Markdown>
 
-### Stacking with z-index
+## Stacking with z-index
 
 <Markdown>
-	{Readme.split('### Stacking with z-index')[1].split('\n### ')[0]}
+	{Readme.split('## Stacking with z-index')[1].split('\n## ')[0]}
 </Markdown>
 
-### Focus rings
+## Focus rings
 
-<Markdown>{Readme.split('### Focus rings')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Focus rings')[1].split('\n## ')[0]}</Markdown>
 
-### Fonts
+## Fonts
 
-<Markdown>{Readme.split('### Fonts')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Fonts')[1].split('\n## ')[0]}</Markdown>
+
 ### Helper classes
-<Markdown>{Readme.split('### Helper classes')[1].split('\n## ')[0]}</Markdown>
+
+<Markdown>{Readme.split('## Helper classes')[1].split('\n## ')[0]}</Markdown>
+
 ## Migration
+
 <Markdown>{Readme.split('## Migration')[1].split('\n## ')[0]}</Markdown>
+
 ## Contact
+
 <Markdown>{Readme.split('## Contact')[1].split('\n## ')[0]}</Markdown>
+
 ## Licence
+
 <Markdown>{Readme.split('## Licence')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/whitelabel/spacing-readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/spacing-readme.mdx
@@ -13,4 +13,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/whitelabel-
 
 ## CSS Custom Properties
 
-<Markdown>{Readme.split('### Spacing')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Spacing')[1].split('\n## ')[0]}</Markdown>

--- a/components/o3-foundation/stories/whitelabel/typography-readme.mdx
+++ b/components/o3-foundation/stories/whitelabel/typography-readme.mdx
@@ -15,4 +15,4 @@ Check out [how to include o3-foundation in your project](?path=/docs/whitelabel-
 
 See our documentation website for [detailed information](https://origami-beta.ft.com/guides/typography/).
 
-<Markdown>{Readme.split('### Typography')[1].split('\n### ')[0]}</Markdown>
+<Markdown>{Readme.split('## Typography')[1].split('\n## ')[0]}</Markdown>


### PR DESCRIPTION
## Describe your changes

The error with `Cannot read properties of undefined (reading 'split')` on the READMEs for the O3 Components was due to the READMEs that it was pulling from using different heading levels, i.e. it was looking for H3s when it should be looking for H2s. Also some were looking for sections which didn't exist and hence breaking the pages when looking for a README.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1522](https://financialtimes.atlassian.net/browse/OR-1522) | N/A |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [X] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
