### PR TITLE
feat: list / grid button icon helper

### DIFF
--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -25,8 +25,10 @@ export interface ButtonProps {
 		| 'calendar'
 		| 'scroll-to'
 		| 'sparkles'
-		| "first"
-		| "last";
+		| 'first'
+		| 'last'
+		| 'list'
+		| 'grid';
 	iconPosition?: 'start' | 'end';
 	iconOnly?: boolean;
 	visuallyHideDisabled?: boolean;


### PR DESCRIPTION
## Describe your changes

This adds `list` & `grid` to the allowed list for the icon helper in buttons. As we are using both in the Button Guidelines documentation.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1499](https://financialtimes.atlassian.net/browse/OR-1499) | [Figma: Button Guidelines Review](https://www.figma.com/design/Jou5E2lLAobniGB3ZmwYSq/Button-Guidelines-Review?node-id=4208-19088&t=QRuieNC3W1CVBkQB-4) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1499]: https://financialtimes.atlassian.net/browse/OR-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ