### PR TITLE
CPO3-188: remove negative margin in o-topper

### DIFF
--- a/components/o-topper/src/scss/themes/_full-bleed-image.scss
+++ b/components/o-topper/src/scss/themes/_full-bleed-image.scss
@@ -43,7 +43,6 @@
 			background: transparent;
 		}
 
-		
 	}
 	@include oPrivateGridRespondTo(L) {
 		grid-template-rows: minmax(auto, 600px) 1fr;
@@ -68,6 +67,5 @@
 	.o-topper__image-caption {
 		background-color: transparent;
 		color: oPrivateFoundationGet("o3-color-palette-black-70");
-		margin-bottom: -20px;
 	}
 }

--- a/components/o-topper/src/scss/themes/_split-text.scss
+++ b/components/o-topper/src/scss/themes/_split-text.scss
@@ -107,6 +107,5 @@
 		width: 100%;
 		float: right;
 		box-sizing: border-box;
-		margin-bottom: -20px;
 	}
 }


### PR DESCRIPTION
## Describe your changes

- fix: remove negative margins in o-topper

These negative margins were added in this [PR](https://github.com/Financial-Times/origami/pull/877) but with o3 they are not needed.

## Additional context

| JIRA ticket                                                    |
| -------------------------------------------------------------- | 
| [CPO3-188](https://financialtimes.atlassian.net/browse/CPO3-188) | 

## Screenshots
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/ce347e0e-3207-4fe7-9667-8ccad796caab)|![image](https://github.com/user-attachments/assets/3365fade-1215-4326-a845-dc3b4922282e)|

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[CPO3-188]: https://financialtimes.atlassian.net/browse/CPO3-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ