### PR TITLE
fix: Ensure enough space for focus + validation message

### DIFF
--- a/components/o-forms/src/scss/shared/_validity.scss
+++ b/components/o-forms/src/scss/shared/_validity.scss
@@ -27,7 +27,8 @@
 			color: _oFormsGet('invalid-base');
 			display: block;
 			position: relative;
-			margin-bottom: -$_o-forms-spacing-five;
+			margin-top: oPrivateSpacingByIncrement(1);
+			margin-bottom: -#{oPrivateSpacingByIncrement(7)};
 		}
 	}
 }


### PR DESCRIPTION
<img width="542" alt="1-before" src="https://github.com/user-attachments/assets/d883997a-58d3-4bfa-964e-e27807e245cd" />

<img width="577" alt="1-after" src="https://github.com/user-attachments/assets/66951b8c-603b-4635-8cb1-09961b2aec80" />
