### PR TITLE
fix: align o3-social-sign-in button text to center

### DIFF
--- a/components/o3-social-sign-in/main.css
+++ b/components/o3-social-sign-in/main.css
@@ -1,9 +1,10 @@
 .o3-social-sign-in-button {
+	position: relative;
 	--o3-grid-columns-to-span-count: 4;
 	max-width: var(--o3-grid-columns-to-span-width, 484px);
 	width: 100%;
 	min-height: 44px;
-	padding: 0 var(--o3-spacing-m) 0 var(--o3-spacing-s);
+	padding: 0 var(--o3-spacing-s) 0 var(--o3-spacing-s);
 	display: inline-flex;
 	gap: var(--o3-spacing-s);
 	align-items: center;
@@ -17,7 +18,6 @@
 
 	border: 1px solid var(--_o3-social-sign-in-border-color);
 	border-radius: var(--o3-border-radius-1);
-	text-align: center;
 	text-decoration: none;
 	cursor: pointer;
 
@@ -26,8 +26,7 @@
 }
 
 .o3-social-sign-in-button__copy {
-	margin-right: auto;
-	margin-left: auto;
+	justify-content: center;
 }
 
 .o3-social-sign-in-button--apple {
@@ -43,11 +42,12 @@
 }
 
 .o3-social-sign-in-button::before {
+	position: absolute;
 	content: '';
 
 	width: 16px;
 	height: 16px;
-	flex-shrink: 0;
+	left: var(--o3-spacing-s);
 }
 
 .o3-social-sign-in-button--google::before {


### PR DESCRIPTION
## Describe your changes

Aligns single-sign-in button text to center, so that it visually aligns to centered elements outside of the button.

| Before | After |
| ------- | ----- |
| <img width="565" alt="image" src="https://github.com/user-attachments/assets/9006af59-1447-48f5-a93b-a6470bbf9a27" /> | <img width="560" alt="image" src="https://github.com/user-attachments/assets/0d77592f-4443-4273-9955-9e4813e6f95e" /> |

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1721](hhttps://financialtimes.atlassian.net/browse/OR-1721) | [Figma: o3-social-sign-in](https://www.figma.com/design/5ATknbGociZMlnNXX4sy4f/Whitelabel---Origami--o3-?m=auto&node-id=8266-485&t=P76mxHYJLUeFIdjX-1) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1721]: https://financialtimes.atlassian.net/browse/OR-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ