### PR TITLE
fix: use font-size instead of font-family for font-size

### DIFF
--- a/components/o3-form/src/css/components/form-field.css
+++ b/components/o3-form/src/css/components/form-field.css
@@ -21,7 +21,7 @@
 	.o3-form-field__title,
 	.o3-form-field__legend {
 		font-family: var(--o3-type-body-highlight-font-family);
-		font-size: var(--o3-type-body-highlight-font-family);
+		font-size: var(--o3-type-body-highlight-font-size);
 		font-weight: var(--o3-type-body-highlight-font-weight);
 		line-height: var(--o3-type-body-highlight-line-height);
 		color: var(--o3-color-use-case-body-text);
@@ -36,7 +36,7 @@
 
 	.o3-form-input__description {
 		font-family: var(--o3-type-body-base-font-family);
-		font-size: var(--o3-type-body-base-font-family);
+		font-size: var(--o3-type-body-base-font-size);
 		font-weight: var(--o3-type-body-base-font-weight);
 		line-height: var(--o3-type-body-base-line-height);
 		color: var(--o3-color-use-case-body-text);


### PR DESCRIPTION
## Describe your changes

Whilst reviewing a PR for the new description element for checkboxes, I came across a weird CSS thing. Might be a bug or might be a feature. One for reviewing!

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| Ad-hoc | No designs |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
