### PR TITLE
Add play icon as an option in button icons

### DIFF
--- a/components/o3-button/main.css
+++ b/components/o3-button/main.css
@@ -616,3 +616,6 @@
 .o3-button-icon.o3-button-icon--last::before {
 	--o3-button-icon: var(--o3-icon-last);
 }
+.o3-button-icon.o3-button-icon--play::before {
+	--o3-button-icon: var(--o3-icon-play);
+}

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -28,7 +28,8 @@ export interface ButtonProps {
 		| 'first'
 		| 'last'
 		| 'list'
-		| 'grid';
+		| 'grid'
+		| 'play';
 	iconPosition?: 'start' | 'end';
 	iconOnly?: boolean;
 	visuallyHideDisabled?: boolean;


### PR DESCRIPTION
## Describe your changes

Add the play icon as an optional icon in o3-button as I've already had to implement this twice.

## Additional context

https://financialtimes.slack.com/archives/C02FU5ARJ/p1752494245195429?thread_ts=1752494174.661179&cid=C02FU5ARJ

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
