### PR TITLE
backstage: introduce tags to o3-storybook

### DIFF
--- a/apps/o3-storybook/.storybook/main.ts
+++ b/apps/o3-storybook/.storybook/main.ts
@@ -1,18 +1,18 @@
-import { dirname, join } from "path";
+import {dirname, join} from 'path';
 import type {StorybookConfig} from '@storybook/react-webpack5';
 
 const config: StorybookConfig = {
 	stories: [
 		'../../../components/o3-*/stories/**/*.mdx',
-		'../../../components/o3-*/stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+		'../../../components/o3-*/stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
 	],
 	addons: [
-		getAbsolutePath("@storybook/addon-links"),
-		getAbsolutePath("@storybook/addon-essentials"),
-		getAbsolutePath("@storybook/addon-interactions"),
-		"@whitespace/storybook-addon-html",
-		getAbsolutePath("@storybook/addon-a11y"),
-		getAbsolutePath("@storybook/addon-designs"),
+		getAbsolutePath('@storybook/addon-links'),
+		getAbsolutePath('@storybook/addon-essentials'),
+		getAbsolutePath('@storybook/addon-interactions'),
+		'@whitespace/storybook-addon-html',
+		getAbsolutePath('@storybook/addon-a11y'),
+		getAbsolutePath('@storybook/addon-designs'),
 		{
 			name: '@storybook/addon-styling-webpack',
 			options: {
@@ -42,11 +42,12 @@ const config: StorybookConfig = {
 				],
 			},
 		},
-		getAbsolutePath("@chromatic-com/storybook"),
-		getAbsolutePath("@storybook/addon-webpack5-compiler-swc"),
+		getAbsolutePath('@chromatic-com/storybook'),
+		getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
+		getAbsolutePath('storybook-addon-tag-badges'),
 	],
 	framework: {
-		name: getAbsolutePath("@storybook/react-webpack5"),
+		name: getAbsolutePath('@storybook/react-webpack5'),
 		options: {
 			builder: {useSWC: true},
 		},
@@ -62,12 +63,12 @@ const config: StorybookConfig = {
 		},
 	}),
 	docs: {
-        defaultName: 'JSX Documentation'
-    },
+		defaultName: 'JSX Documentation',
+	},
 };
 
 export default config;
 
 function getAbsolutePath(value: string): any {
-    return dirname(require.resolve(join(value, "package.json")));
+	return dirname(require.resolve(join(value, 'package.json')));
 }

--- a/apps/o3-storybook/.storybook/manager.ts
+++ b/apps/o3-storybook/.storybook/manager.ts
@@ -1,6 +1,32 @@
 import {addons} from '@storybook/manager-api';
 import {themes} from '@storybook/theming';
+import {defaultConfig} from 'storybook-addon-tag-badges';
 
 addons.setConfig({
 	theme: themes.light,
+	tagBadges: [
+		{
+			tags: 'experimental',
+			badge: {
+				text: 'Experimental',
+				style: {
+					backgroundColor: '#c263d4',
+					color: '#fcf0ff',
+				},
+				tooltip:
+					'This component is experimental and is not recommended for production use',
+			},
+			display: {
+				sidebar: [
+					{
+						type: 'component',
+						skipInherited: true,
+					},
+				],
+				toolbar: false,
+				mdx: true,
+			},
+		},
+		...defaultConfig,
+	],
 });

--- a/apps/o3-storybook/package.json
+++ b/apps/o3-storybook/package.json
@@ -37,6 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^8.1.2",
+    "storybook-addon-tag-badges": "^1.4.0",
     "style-loader": "^3.3.3",
     "typescript": "^5.2.2"
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -23,7 +23,7 @@
 		"@financial-times/o3-button": "^3.12.0",
 		"@financial-times/o3-editorial-typography": "^3.0.2",
 		"@financial-times/o3-figma-sb-links": "^0.0.0",
-		"@financial-times/o3-form": "^0.5.0",
+		"@financial-times/o3-form": "^0.6.0",
 		"@financial-times/o3-foundation": "^3.0.1",
 		"@financial-times/o3-social-sign-in": "^2.0.0",
 		"@financial-times/o3-tooling-token": "^0.0.0",

--- a/apps/website/src/content/docs/components/Forms/checkbox.mdx
+++ b/apps/website/src/content/docs/components/Forms/checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: Checkboxes allow users to select one or more items from a list or toggle an option on or off.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/components/Forms/error-summary.mdx
+++ b/apps/website/src/content/docs/components/Forms/error-summary.mdx
@@ -3,7 +3,7 @@ title: Error summary
 description: The Error Summary appears on the top of a page after a user submits a form which generates an error.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/components/Forms/index.mdx
+++ b/apps/website/src/content/docs/components/Forms/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: Form components are used to collect information and guide users. Here you’ll find general rules for using them that apply to all components. Structure, sequence, and messaging are essential to creating a good user experience.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/components/Forms/password-input.mdx
+++ b/apps/website/src/content/docs/components/Forms/password-input.mdx
@@ -3,7 +3,7 @@ title: Password Input
 description: The password input component is used for entering sensitive information, such as passwords or passphrases.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/components/Forms/radio-button.mdx
+++ b/apps/website/src/content/docs/components/Forms/radio-button.mdx
@@ -3,7 +3,7 @@ title: Radio Button
 description: Radio buttons allow users to select a single option from a predefined set of mutually exclusive choices. Unlike checkboxes, only one option can be selected at a time.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/components/Forms/text-input.mdx
+++ b/apps/website/src/content/docs/components/Forms/text-input.mdx
@@ -3,7 +3,7 @@ title: Text Input
 description: Text inputs allow users to enter free-form text data such as filling in contact or payment information.
 sidebar:
   badge:
-    text: wip
+    text: experimental
     variant: caution
 ---
 

--- a/apps/website/src/content/docs/contribution/badge-statuses.md
+++ b/apps/website/src/content/docs/contribution/badge-statuses.md
@@ -1,0 +1,12 @@
+---
+title: Badge Statuses
+description: How to use badge statuses in Origami
+sidebar:
+  order: 10
+---
+
+Components and usage guides throughout our website and Storybook will make use of badge statuses to indicate state.
+
+* **Experimental** - indicates a component or guide that is still in development and may change in the future. It is not recommended for production use.
+* **Updated** - indicates a component or guide that has been recently updated.
+* **New** - indicates a component or guide that has been added recently.

--- a/components/o3-form/stories/core/checkbox-group.stories.tsx
+++ b/components/o3-form/stories/core/checkbox-group.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBoxGroup as CheckBoxGroupTsx} from '../../src/tsx/index';
 import '../../src/css/brands/core.css';
 import {CheckBoxGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxGroupStory} from '../story-template';
 export default {
 	title: 'Core/o3-form',
 	component: CheckBoxGroupTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box-group"].figma
-		}
+			url: links['whitelabel-o3-form--check-box-group'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/core/checkbox.stories.tsx
+++ b/components/o3-form/stories/core/checkbox.stories.tsx
@@ -7,6 +7,7 @@ import {CheckBoxesWithDescriptionStory, CheckBoxStory} from '../story-template';
 export default {
 	title: 'Core/o3-form',
 	component: CheckBoxTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core">

--- a/components/o3-form/stories/core/error-summary.stories.tsx
+++ b/components/o3-form/stories/core/error-summary.stories.tsx
@@ -7,6 +7,7 @@ import {ErrorSummaryStory} from '../story-template';
 export default {
 	title: 'Core/o3-form',
 	component: ErrorSummaryTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core">

--- a/components/o3-form/stories/core/passwordInput.stories.tsx
+++ b/components/o3-form/stories/core/passwordInput.stories.tsx
@@ -8,6 +8,7 @@ import {Form} from '../../src/tsx';
 const meta: Meta<typeof PasswordInputTsx> = {
 	title: 'Core/o3-form',
 	component: PasswordInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core" className="o3-grid">

--- a/components/o3-form/stories/core/radio-button.stories.tsx
+++ b/components/o3-form/stories/core/radio-button.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {RadioButtonGroup as RadioButtonTsx} from '../../src/tsx/index';
 import '../../src/css/brands/core.css';
 import {RadioButtonGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {RadioButtonGroupStory} from '../story-template';
 export default {
 	title: 'Core/o3-form',
 	component: RadioButtonTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--radio-button"].figma
-		}
+			url: links['whitelabel-o3-form--radio-button'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/core/textInput.stories.tsx
+++ b/components/o3-form/stories/core/textInput.stories.tsx
@@ -7,6 +7,7 @@ import '../../src/css/brands/core.css';
 const meta: Meta<typeof TextInputTsx> = {
 	title: 'Core/o3-form',
 	component: TextInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="core" className="o3-grid">

--- a/components/o3-form/stories/internal/checkbox-group.stories.tsx
+++ b/components/o3-form/stories/internal/checkbox-group.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBoxGroup as CheckBoxGroupTsx} from '../../src/tsx/index';
 import '../../src/css/brands/internal.css';
 import {CheckBoxGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxGroupStory} from '../story-template';
 export default {
 	title: 'Internal/o3-form',
 	component: CheckBoxGroupTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="internal">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box-group"].figma
-		}
+			url: links['whitelabel-o3-form--check-box-group'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/internal/checkbox.stories.tsx
+++ b/components/o3-form/stories/internal/checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBox as CheckBoxTsx} from '../../src/tsx/index';
 import '../../src/css/brands/internal.css';
 import {CheckBoxStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxStory} from '../story-template';
 export default {
 	title: 'Internal/o3-form',
 	component: CheckBoxTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="professional">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box"].figma
-		}
+			url: links['whitelabel-o3-form--check-box'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/internal/error-summary.stories.tsx
+++ b/components/o3-form/stories/internal/error-summary.stories.tsx
@@ -7,6 +7,7 @@ import {ErrorSummaryStory} from '../story-template';
 export default {
 	title: 'Internal/o3-form',
 	component: ErrorSummaryTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="professional">

--- a/components/o3-form/stories/internal/passwordInput.stories.tsx
+++ b/components/o3-form/stories/internal/passwordInput.stories.tsx
@@ -8,6 +8,7 @@ import {Form} from '../../src/tsx';
 const meta: Meta<typeof PasswordInputTsx> = {
 	title: 'Internal/o3-form',
 	component: PasswordInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="professional" className="o3-grid">

--- a/components/o3-form/stories/internal/radio-button.stories.tsx
+++ b/components/o3-form/stories/internal/radio-button.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {RadioButtonGroup as RadioButtonTsx} from '../../src/tsx/index';
 import '../../src/css/brands/internal.css';
 import {RadioButtonGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {RadioButtonGroupStory} from '../story-template';
 export default {
 	title: 'Internal/o3-form',
 	component: RadioButtonTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="professional">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--radio-button"].figma
-		}
+			url: links['whitelabel-o3-form--radio-button'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/internal/textInput.stories.tsx
+++ b/components/o3-form/stories/internal/textInput.stories.tsx
@@ -7,6 +7,7 @@ import '../../src/css/brands/internal.css';
 const meta: Meta<typeof TextInputTsx> = {
 	title: 'Internal/o3-form',
 	component: TextInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="professional" className="o3-grid">

--- a/components/o3-form/stories/sustainable-views/checkbox-group.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/checkbox-group.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBoxGroup as CheckBoxGroupTsx} from '../../src/tsx/index';
 import '../../src/css/brands/sustainable-views.css';
 import {CheckBoxGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxGroupStory} from '../story-template';
 export default {
 	title: 'Sustainable Views/o3-form',
 	component: CheckBoxGroupTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box-group"].figma
-		}
+			url: links['whitelabel-o3-form--check-box-group'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/sustainable-views/checkbox.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBox as CheckBoxTsx} from '../../src/tsx/index';
 import '../../src/css/brands/sustainable-views.css';
 import {CheckBoxStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxStory} from '../story-template';
 export default {
 	title: 'Sustainable Views/o3-form',
 	component: CheckBoxTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box"].figma
-		}
+			url: links['whitelabel-o3-form--check-box'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/sustainable-views/error-summary.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/error-summary.stories.tsx
@@ -7,6 +7,7 @@ import {ErrorSummaryStory} from '../story-template';
 export default {
 	title: 'Sustainable Views/o3-form',
 	component: ErrorSummaryTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views">

--- a/components/o3-form/stories/sustainable-views/passwordInput.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/passwordInput.stories.tsx
@@ -8,6 +8,7 @@ import {Form} from '../../src/tsx';
 const meta: Meta<typeof PasswordInputTsx> = {
 	title: 'Sustainable Views/o3-form',
 	component: PasswordInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views" className="o3-grid">

--- a/components/o3-form/stories/sustainable-views/radio-button.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/radio-button.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {RadioButtonGroup as RadioButtonTsx} from '../../src/tsx/index';
 import '../../src/css/brands/sustainable-views.css';
 import {RadioButtonGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {RadioButtonGroupStory} from '../story-template';
 export default {
 	title: 'Sustainable Views/o3-form',
 	component: RadioButtonTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--radio-button"].figma
-		}
+			url: links['whitelabel-o3-form--radio-button'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/sustainable-views/textInput.stories.tsx
+++ b/components/o3-form/stories/sustainable-views/textInput.stories.tsx
@@ -7,6 +7,7 @@ import '../../src/css/brands/sustainable-views.css';
 const meta: Meta<typeof TextInputTsx> = {
 	title: 'Sustainable Views/o3-form',
 	component: TextInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="sustainable-views" className="o3-grid">

--- a/components/o3-form/stories/whitelabel/checkbox-group.stories.tsx
+++ b/components/o3-form/stories/whitelabel/checkbox-group.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBoxGroup as CheckBoxGroupTsx} from '../../src/tsx/index';
 import '../../src/css/brands/whitelabel.css';
 import {CheckBoxGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxGroupStory} from '../story-template';
 export default {
 	title: 'Whitelabel/o3-form',
 	component: CheckBoxGroupTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box-group"].figma
-		}
+			url: links['whitelabel-o3-form--check-box-group'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/whitelabel/checkbox.stories.tsx
+++ b/components/o3-form/stories/whitelabel/checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {CheckBox as CheckBoxTsx} from '../../src/tsx/index';
 import '../../src/css/brands/whitelabel.css';
 import {CheckBoxStory} from '../story-template';
@@ -7,6 +7,7 @@ import {CheckBoxStory} from '../story-template';
 export default {
 	title: 'Whitelabel/o3-form',
 	component: CheckBoxTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--check-box"].figma
-		}
+			url: links['whitelabel-o3-form--check-box'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/whitelabel/error-summary.stories.tsx
+++ b/components/o3-form/stories/whitelabel/error-summary.stories.tsx
@@ -7,6 +7,7 @@ import {ErrorSummaryStory} from '../story-template';
 export default {
 	title: 'Whitelabel/o3-form',
 	component: ErrorSummaryTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel">

--- a/components/o3-form/stories/whitelabel/passwordInput.stories.tsx
+++ b/components/o3-form/stories/whitelabel/passwordInput.stories.tsx
@@ -8,6 +8,7 @@ import {Form} from '../../src/tsx';
 const meta: Meta<typeof PasswordInputTsx> = {
 	title: 'Whitelabel/o3-form',
 	component: PasswordInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel" className="o3-grid">

--- a/components/o3-form/stories/whitelabel/radio-button.stories.tsx
+++ b/components/o3-form/stories/whitelabel/radio-button.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta} from '@storybook/react';
-import links from "@financial-times/o3-figma-sb-links"
+import links from '@financial-times/o3-figma-sb-links';
 import {RadioButtonGroup as RadioButtonTsx} from '../../src/tsx/index';
 import '../../src/css/brands/whitelabel.css';
 import {RadioButtonGroupStory} from '../story-template';
@@ -7,6 +7,7 @@ import {RadioButtonGroupStory} from '../story-template';
 export default {
 	title: 'Whitelabel/o3-form',
 	component: RadioButtonTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel">
@@ -18,8 +19,8 @@ export default {
 		backgrounds: {disable: true},
 		design: {
 			type: 'figma',
-			url: links["whitelabel-o3-form--radio-button"].figma
-		}
+			url: links['whitelabel-o3-form--radio-button'].figma,
+		},
 	},
 } as Meta;
 

--- a/components/o3-form/stories/whitelabel/textInput.stories.tsx
+++ b/components/o3-form/stories/whitelabel/textInput.stories.tsx
@@ -7,6 +7,7 @@ import '../../src/css/brands/whitelabel.css';
 const meta: Meta<typeof TextInputTsx> = {
 	title: 'Whitelabel/o3-form',
 	component: TextInputTsx,
+	tags: ['experimental'],
 	decorators: [
 		Story => (
 			<div data-o3-brand="whitelabel" className="o3-grid">

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"storybook": "^8.1.2",
+				"storybook-addon-tag-badges": "^1.4.0",
 				"style-loader": "^3.3.3",
 				"typescript": "^5.2.2"
 			},
@@ -573,7 +574,7 @@
 				"@financial-times/o3-button": "^3.12.0",
 				"@financial-times/o3-editorial-typography": "^3.0.2",
 				"@financial-times/o3-figma-sb-links": "^0.0.0",
-				"@financial-times/o3-form": "^0.5.0",
+				"@financial-times/o3-form": "^0.6.0",
 				"@financial-times/o3-foundation": "^3.0.1",
 				"@financial-times/o3-social-sign-in": "^2.0.0",
 				"@financial-times/o3-tooling-token": "^0.0.0",
@@ -619,19 +620,6 @@
 				"@types/react-dom": "^17.0.17 || ^18.0.6",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0-beta",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0-beta"
-			}
-		},
-		"apps/website/node_modules/@financial-times/o3-form": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@financial-times/o3-form/-/o3-form-0.5.4.tgz",
-			"integrity": "sha512-nUukoqgabKz7m7Hn6KVBT76i3H5dUoqvUIIN8CwIRoy9ERaYORS/a5ZuZZwwYcOYraa7hOlWdJx1wKzw2s93Bw==",
-			"engines": {
-				"npm": ">7"
-			},
-			"peerDependencies": {
-				"@financial-times/o-utils": "^2.2.1",
-				"@financial-times/o3-figma-sb-links": "^0.0.0",
-				"@financial-times/o3-foundation": "^3.0.0"
 			}
 		},
 		"apps/website/node_modules/@types/node": {
@@ -48934,6 +48922,21 @@
 			"dev": true,
 			"dependencies": {
 				"@figspec/react": "^1.0.0"
+			}
+		},
+		"node_modules/storybook-addon-tag-badges": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/storybook-addon-tag-badges/-/storybook-addon-tag-badges-1.4.0.tgz",
+			"integrity": "sha512-ecVwNVT4zIpnB14ltXCTHsWqykW2lgiHrDJW1VeblI3+aU9uMaSZG0zuey+r3vehMeODADnRNrcdk6sN9MAmBA==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/icons": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"storybook": "^8.4.0"
 			}
 		},
 		"node_modules/stream": {


### PR DESCRIPTION
## Describe your changes
* introduces tag-addon plugin to storybook
* aligns website and storybook to use "experimental" tag to signal a component/guide is not ready for production
## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1543](https://financialtimes.atlassian.net/browse/OR-1543?atlOrigin=eyJpIjoiNzY0NTM0NTliYWE0NGE3Zjg1OTY3YzI1MmRhN2IyYTAiLCJwIjoiaiJ9) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1543]: https://financialtimes.atlassian.net/browse/OR-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ