### PR TITLE
[OR-1770] o-meter not displaying <meter> correctly

### DIFF
--- a/components/o-meter/main.scss
+++ b/components/o-meter/main.scss
@@ -16,18 +16,17 @@
 		display: block;
 		width: var(--o-meter-width);
 		height: var(--o-meter-height);
+
 		--o-meter-background-color: #{oPrivateFoundationGet('o3-color-palette-slate-white-15')};
 		--o-meter-optimum-color: #{oPrivateFoundationGet('o3-color-palette-jade')};
 		--o-meter-sub-optimum-color: #{oPrivateFoundationGet('o3-color-palette-mandarin')};
 		--o-meter-less-than-sub-optimum-color: #{oPrivateFoundationGet('o3-color-palette-crimson')};
-
-		/* Background in Firefox */
-		background: var(--o-meter-background-color);
 	}
 
 	.o-meter-container {
 		width: var(--o-meter-width);
 		position: relative;
+
 		.o-meter {
 			width: 100%;
 		}
@@ -122,7 +121,7 @@
 	// sass-lint:enable no-vendor-prefixes
 }
 
-@if ($o-meter-is-silent == false) {
+@if ($o-meter-is-silent ==false) {
 	@include oMeter();
 
 	// Set to silent again to avoid being output twice


### PR DESCRIPTION
## Describe your changes

As raised on Slack in the `#origami-support` channel that the component `o-meter` is not displaying correctly and whenever to fix it themselves or look at how it is in the component.

It is a one-liner change, so I've taken the liberty to provide a CodePen so that this can be viewed in tandem. The regressed one is at the top, and the fix is at the bottom.

## o-meter bugs

<img width="288" height="66" alt="image" src="https://github.com/user-attachments/assets/f68da72a-200a-4a4c-a29f-8fc950a67323" />

<img width="691" height="235" alt="image" src="https://github.com/user-attachments/assets/18faa81c-0341-4002-9e1a-d9db84e0e73d" />

### Reproduction in CodePen

Top: The live bug
Bottom: The fix

<img width="1132" height="568" alt="Screenshot 2025-07-30 at 11 53 23" src="https://github.com/user-attachments/assets/b5d00987-08cc-4651-895b-4bfa753566b2" />

## Additional context

<table>
<thead>
<th>JIRA ticket</th>
<th>Figma design</th>
<th>CodePen</th>
</thead>
<tbody>
<tr>
<td><a href="https://financialtimes.atlassian.net/browse/OR-1770">OR-1770</a></td>
<td>N/A</td>
<td><a href="https://codepen.io/j-mes/pen/xbwRWEP">CodePen demo</a></td>
</tr>
</tbody>
</table>

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
