### PR TITLE
feat: allow event handlers on o3 button attributes

### DIFF
--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -34,7 +34,7 @@ export interface ButtonProps {
 	iconOnly?: boolean;
 	visuallyHideDisabled?: boolean;
 	attributes?: {
-		[attribute: string]: string | boolean;
+		[attribute: string]: string | boolean | Function;
 	};
 	onClick?: Function;
 }


### PR DESCRIPTION
## Describe your changes

Allows the passing of `Function` type to `attributes` to allow HTML event handlers to be attached to button.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
