### PR TITLE
feat: allow refs on o3-button

### DIFF
--- a/components/o3-button/src/tsx/button.tsx
+++ b/components/o3-button/src/tsx/button.tsx
@@ -58,6 +58,7 @@ export function Button({
 	visuallyHideDisabled = false,
 	attributes = {},
 	onClick,
+	ref,
 }: ButtonProps) {
 	// Combine custom classes with first party o3-button classes,
 	// rather than override them.
@@ -71,6 +72,7 @@ export function Button({
 	}
 	return (
 		<button
+			ref={ref}
 			onClick={onClick ? event => onClick(event) : undefined}
 			className={makeClassNames({
 				customClasses,

--- a/components/o3-button/src/types/index.ts
+++ b/components/o3-button/src/types/index.ts
@@ -5,6 +5,9 @@ export interface ButtonProps {
 	size?: 'small' | '';
 	fluid?: boolean;
 	theme?: 'inverse' | 'mono' | 'neutral';
+	ref?:
+		| LegacyRef<HTMLButtonElement | null>
+		| MutableRef<HTMLButtonElement | null>;
 	icon?:
 		| 'chevron-left'
 		| 'chevron-right'
@@ -75,3 +78,17 @@ export type Ellipsis = Pick<ButtonProps, 'theme'> & {
 export interface ButtonGroupProps {
 	children: React.JSX.Element[];
 }
+
+export interface MutableRef<T> {
+	current: T;
+}
+
+export type RefObject<T> = {
+	readonly current: T | null;
+};
+
+export type RefCallback<T> = (instance: T | null) => void;
+
+export type Ref<T> = RefCallback<T> | RefObject<T> | null;
+
+export type LegacyRef<T> = string | Ref<T>;


### PR DESCRIPTION
## Describe your changes

Allows a ref to be passed in props of o3-button. Allowing references found in frameworks like React and Preact to be passed in.

**Why have we defined our own Ref types?**

Origami remains platform agnostic. We could use React/Preact's types for References, but this puts a dependency on those for consumer that use neither. By defining, we keep the ref dependency optional, without importing any react code.

It should be noted that by using this approach, we now need to ensure our types remain compatible with React's. And that we may need to introduce other types for other frameworks should they need them.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
