### PR TITLE
fix: move figma-sb-links to dev deps

### DIFF
--- a/components/o3-form/package.json
+++ b/components/o3-form/package.json
@@ -35,8 +35,10 @@
 	},
 	"peerDependencies": {
 		"@financial-times/o-utils": "^2.2.1",
-		"@financial-times/o3-figma-sb-links": "^0.0.0",
 		"@financial-times/o3-foundation": "^3.0.0"
+	},
+	"devDependencies": {
+		"@financial-times/o3-figma-sb-links": "^0.0.0"
 	},
 	"engines": {
 		"npm": ">7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1316,7 +1316,7 @@
 		},
 		"components/o-meter": {
 			"name": "@financial-times/o-meter",
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@financial-times/o-fonts": "^5.3.5",
@@ -1775,12 +1775,14 @@
 			"name": "@financial-times/o3-form",
 			"version": "0.6.0",
 			"license": "MIT",
+			"devDependencies": {
+				"@financial-times/o3-figma-sb-links": "^0.0.0"
+			},
 			"engines": {
 				"npm": ">7"
 			},
 			"peerDependencies": {
 				"@financial-times/o-utils": "^2.2.1",
-				"@financial-times/o3-figma-sb-links": "^0.0.0",
 				"@financial-times/o3-foundation": "^3.0.0"
 			}
 		},


### PR DESCRIPTION
## Describe your changes

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
