### PR TITLE
LIF-677: Expose tracking.getSession() for Spoor session access

### DIFF
--- a/libraries/o-tracking/src/javascript/tracking.js
+++ b/libraries/o-tracking/src/javascript/tracking.js
@@ -126,7 +126,14 @@ function init(config = {}) {
 	updateConfig(config);
 
 	// Session
-	initSession(config.session);
+	const session = initSession(config.session); // returns the session
+	// Expose the session props through accessor function
+	tracking.getSession = () => ({
+		sessionId: session?.id,
+		sessionIsNew: session?.isNew,
+		sessionTimestamp:session?.timestamp
+	});
+
 
 	// Initialize the sending queue.
 	initSend();


### PR DESCRIPTION
## Describe your changes
This PR adds a new public accessor to o-tracking’s tracking object:
```
tracking.getSession = () => ({
  session: session?.id,
  sessionIsNew: session?.isNew,
  sessionTimestamp: session?.timestamp
});

- By exposing only the fields we need today (id, isNew, timestamp), we keep the API minimal and stable, while leaving flexibility to expand later if more session props are needed.

```
**Why**: Consumer apps (e.g. For Amplitude Session Replay integration) need a reliable way to get the current Spoor session identifier.

**Other Approaches tried:**
- `(get('session') from settings`- generates issues with module scoping
- Reading from localStorage is fragile and can have timing issues.

Ticket: https://financialtimes.atlassian.net/browse/LIF-677

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
