### PR TITLE
fix: use correct label tokens for live label

### DIFF
--- a/components/o-labels/main.scss
+++ b/components/o-labels/main.scss
@@ -129,7 +129,6 @@
 		.o-labels-indicator.o-labels-indicator--badge.o-labels-indicator--inverse {
 
 			&.o-labels-indicator--live,
-			// 👆 should this be red bg instead?
 			&.o-labels-indicator--closed {
 				background: transparent;
 			}


### PR DESCRIPTION
## Describe your changes

1. Ignore the linting changes
2. Apply the correct o3 tokens for labels for Live label

## Additional context

The current labels are not set up correctly to use the tokens that are in the Design System. As a short term fix, this is what I've suggested to do.

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1818](https://financialtimes.atlassian.net/browse/OR-1818) | [Figma: FT Experience library](https://www.figma.com/design/GzU2AFej1vbEphodgvyvH8/%F0%9F%9A%A7-FT-Experience-library?node-id=799-16320&t=ts4lmNuOMJM9gKWk-1) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1818]: https://financialtimes.atlassian.net/browse/OR-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ