### PR TITLE
fix: use -webkit-inline-block for meter inner element

### DIFF
--- a/components/o-meter/main.scss
+++ b/components/o-meter/main.scss
@@ -72,7 +72,7 @@
 
 	meter::-webkit-meter-inner-element {
 		// Chrome 83 added a display grid which we want to override
-		display: inline-block;
+		display: -webkit-inline-block;
 	}
 
 	/* for Firefox */


### PR DESCRIPTION
## Describe your changes

Makes a minor change to the `display` element to make it display correctly when using a meter element in an internal app.

## Additional context

This was raised by @conor-mullen for the usage of meter in https://lantern.ft.com/dashboard. This minor fix is all Conor's credit! 😅 

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1789](https://financialtimes.atlassian.net/browse/OR-1789) | N/A |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.


[OR-1789]: https://financialtimes.atlassian.net/browse/OR-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ