### PR TITLE
fix: remove tabindex on footer headings when transitioning to large breakpoint

### DIFF
--- a/components/o-footer/src/js/footer.js
+++ b/components/o-footer/src/js/footer.js
@@ -45,7 +45,10 @@ class Footer {
 	}
 
 	destroy () {
-		this._toggles.forEach(toggle => toggle.destroy());
+		this._toggles.forEach(toggle => {
+			toggle.toggleEl.removeAttribute('tabindex');
+			toggle.destroy();
+		});
 		this._toggles = null;
 	}
 

--- a/components/o-footer/test/oFooter.test.js
+++ b/components/o-footer/test/oFooter.test.js
@@ -87,7 +87,7 @@ describe("oFooter", () => {
 		describe("destroy()", () => {
 			it("calls destroy on things found in _toggles and then sets _toggles to null", () => {
 				const footer = oFooter.init();
-				const toggle = new Toggle();
+				const toggle = new Toggle(document.createElement('h3'), { target: document.createElement('ul') });
 				const toggleSpy = sinon.stub(toggle, "destroy").returns(true);
 
 				footer._toggles = [toggle];

--- a/components/o-footer/test/oFooter.test.js
+++ b/components/o-footer/test/oFooter.test.js
@@ -83,6 +83,19 @@ describe("oFooter", () => {
 				proclaim.equal(typeof footer._toggles, 'object');
 				proclaim.equal(footer._toggles.length, 5);
 			});
+
+			it("sets tabindex=0 for every toggle target on the page", () => {
+				const footer = oFooter.init();
+
+				footer.setup();
+
+				const toggleEls = footer.footerEl.querySelectorAll('[aria-controls]');
+
+				proclaim.deepEqual(
+					Array.from(toggleEls, el => el.getAttribute('tabindex')),
+					['0', '0', '0', '0', '0']
+				)
+			})
 		});
 		describe("destroy()", () => {
 			it("calls destroy on things found in _toggles and then sets _toggles to null", () => {
@@ -97,6 +110,20 @@ describe("oFooter", () => {
 				proclaim.equal(toggleSpy.called, true);
 				proclaim.equal(footer._toggles, null);
 
+			});
+
+			it('removes tabindex on every toggle target on the page', () => {
+				const footer = oFooter.init();
+
+				footer.setup();
+				footer.destroy()
+
+				const toggleEls = footer.footerEl.querySelectorAll('[aria-controls]');
+
+				proclaim.deepEqual(
+					Array.from(toggleEls, el => el.getAttribute('tabindex')),
+					[null, null, null, null, null]
+				);
 			});
 		});
 


### PR DESCRIPTION
since the heading is no longer interactive, it shouldn't have a `tabindex`. this was reported by DAC in [CPP-2630](https://financialtimes.atlassian.net/browse/CPP-2630).

[CPP-2630]: https://financialtimes.atlassian.net/browse/CPP-2630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ