### PR TITLE
feat: introduce method to update position of tooltip

### DIFF
--- a/components/o3-tooltip/src/ts/tooltip.ts
+++ b/components/o3-tooltip/src/ts/tooltip.ts
@@ -57,6 +57,10 @@ export class ToolTip extends HTMLElement implements TooltipProps {
 		this._popperInstance?.destroy();
 	}
 
+	async update() {
+		await this._popperInstance?.update();
+	}
+
 	protected render(name?: string) {
 		this._popperInstance?.setOptions({
 			placement: this.placement,


### PR DESCRIPTION
## Describe your changes

There may be some race conditions that cause a tooltip to be disconnected from the target element. In these cases, we can offer users finer control to recalculate position after a particular race condition occurs.

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-xxxx](https://financialtimes.atlassian.net/browse/OR-xxxx) | [Figma: Name](https://www.figma.com/design/path/to/your/figma/sharing/link) |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.
