### PR TITLE
fix: use forceUpdate for aligning to target element

### DIFF
--- a/components/o3-tooltip/src/ts/tooltip.ts
+++ b/components/o3-tooltip/src/ts/tooltip.ts
@@ -1,4 +1,4 @@
-import {createPopper, Instance} from '@popperjs/core';
+import {createPopper, type Instance} from '@popperjs/core';
 import type {TooltipProps} from '../types';
 
 export class ToolTip extends HTMLElement implements TooltipProps {
@@ -50,6 +50,9 @@ export class ToolTip extends HTMLElement implements TooltipProps {
 		}
 		this.contentId = this.getAttribute('content-id') as string;
 
+		this._mutationObserver?.disconnect();
+		this._resizeObserver?.disconnect();
+
 		const contentRoot = (this.shadowRoot?.querySelector('[part="content"]') as HTMLElement) ?? this;
 		this._mutationObserver = new MutationObserver(() => this.update());
 		this._mutationObserver.observe(contentRoot, { childList: true, subtree: true, characterData: true });
@@ -73,14 +76,10 @@ export class ToolTip extends HTMLElement implements TooltipProps {
 	}
 
 	forceUpdate() {
-		this._popperInstance?.forceUpdate();
+		this._popperInstance?.forceUpdate?.();
 	}
 
 	protected render(name?: string) {
-		// this._popperInstance?.setOptions({
-		// 	placement: this.placement,
-		// });
-
 		if (this._popperInstance) {
 			this._popperInstance.setOptions((opts) => ({
 				...opts,
@@ -116,36 +115,6 @@ export class ToolTip extends HTMLElement implements TooltipProps {
 		targetNode: HTMLElement,
 		popperElement: HTMLElement
 	) {
-		// return createPopper(targetNode, popperElement, {
-		// 	placement: this.placement || 'top',
-		// 	modifiers: [
-		// 		{
-		// 			name: 'preventOverflow',
-		// 			options: {
-		// 				rootBoundary: document.body,
-		// 			},
-		// 		},
-		// 		{
-		// 			name: 'eventListeners',
-		// 			options: {
-		// 				scroll: false,
-		// 			},
-		// 		},
-		// 		{
-		// 			name: 'flip',
-		// 			options: {
-		// 				fallbackPlacements: ['top', 'bottom', 'left', 'right'],
-		// 				rootBoundary: document.body,
-		// 			},
-		// 		},
-		// 		{
-		// 			name: 'offset',
-		// 			options: {
-		// 				offset: [0, 16],
-		// 			},
-		// 		},
-		// 	],
-		// });
 		this._popperInstance = createPopper(targetNode, popperElement, {
 			placement: this.placement || 'top',
 			modifiers: [


### PR DESCRIPTION
## Describe your changes

* Added a `MutationObserver` to watch for changes in the tooltip's content and a `ResizeObserver` to monitor size changes, both triggering updates to the tooltip positioning. [[1]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR11-R12) [[2]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR52-R58)
* Ensured observers are disconnected in `disconnectedCallback` to prevent memory leaks when the tooltip is removed from the DOM.
* Refactored Popper.js options setting in the `render` method to use a callback for merging options, allowing dynamic updates of the tooltip's placement.
* Added a `forceUpdate` method to explicitly trigger Popper.js updates, and ensured it is called when title/content changes for more accurate positioning. [[1]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR67-R89) [[2]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR107-R149)
* Updated `initialisePopper` to store and return the Popper instance, with commented-out legacy code for reference. [[1]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR107-R149) [[2]](diffhunk://#diff-2bb3586e3c072c60c941ea7e44518ccf3dd1a076c1a7d95a9ae9b484930e607bR179)

## Additional context

| JIRA ticket                                                    | Figma design                                                                |
| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [OR-1876](https://financialtimes.atlassian.net/browse/OR-1876) | N/A |

## Checklist before requesting a review

- [ ] I have applied `percy` label for o-[COMPONENT] or `chromatic` label for o3-[COMPONENT] on my PR before merging and after review. Find more details in [CONTRIBUTING.md](https://github.com/Financial-Times/origami/blob/main/CONTRIBUTING.md#pull-requests-and-visual-regression-tests)
- [ ] If it is a new feature, I have added thorough tests.
- [ ] I have updated relevant docs.
- [ ] I have updated relevant env variables in Doppler.